### PR TITLE
feat: workflow engine, pi extension, and live terminal viewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check (format, lint, typecheck, build, coverage)
+        run: npm run check
+
+      - name: Slophammer
+        run: |
+          npx slophammer-ts@latest rules --format text
+          npx slophammer-ts@latest dry .
+          npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+
+  e2e:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: End-to-end tests (mock provider, real pi runtime)
+        run: npm run test:e2e

--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "sortImports": {
+    "newlinesBetween": false,
+  },
+  "sortPackageJson": {
+    "sortScripts": true,
+  },
+  "tabWidth": 2,
+  "useTabs": false,
+  "ignorePatterns": ["dist/", "node_modules/", "coverage/", "package-lock.json"],
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Before finishing any change, run:
+
+```bash
+npm run check      # oxfmt check, oxlint, tsc, build, vitest with coverage (85% thresholds)
+npm run test:e2e   # non-destructive end-to-end test against the real pi runtime
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+```
+
+Repository rules:
+
+- Use Conventional Commits for commit messages and PR titles.
+- Respect the dependency boundaries in `slophammer.yml`: `src/workflows` never
+  imports pi or the other layers; `src/extension` and `src/viewer` may import
+  `src/workflows` and never each other.
+- Persisted JSON is camelCase with versioned `schema` identifiers. Breaking a
+  persisted shape means bumping the schema version string
+  (see `docs/run-bundles.md`).
+- Tests must not write outside temp directories, call real models, or perform
+  destructive actions.
+- New engine features need unit tests and a section in `docs/workflows.md`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+# pi-workflows
+
+pi-workflows is a workflow extension for the [pi coding agent](https://pi.dev).
+It lets you define multi-step agent workflows as TypeScript graphs, trigger
+them at any point in a pi conversation with `/workflow`, and watch them run
+live in a standalone terminal viewer.
+
+The workflow model is a port of [openclaw/acpx](https://github.com/openclaw/acpx)
+flows into pi itself. Agent steps run inside your current pi conversation, so
+the model keeps everything it already knows from the discussion. The model
+completes each step by calling a JSON `workflow` tool, which gives the engine
+structured, validated output to route on.
+
+## Install
+
+```bash
+pi install git:github.com/osolmaz/pi-workflows
+```
+
+Or try it without installing:
+
+```bash
+pi -e git:github.com/osolmaz/pi-workflows
+```
+
+The `pi-workflows` viewer binary is part of the same package. To get it on
+your PATH, clone the repo and run `npm install && npm run build && npm link`,
+or run it in place with `npx tsx src/viewer/cli.ts`.
+
+## Quick start
+
+Put a workflow file in `.pi/workflows/` (project) or `~/.pi/agent/workflows/`
+(global):
+
+```typescript
+// .pi/workflows/echo.workflow.ts
+import { agent, defineWorkflow } from "pi-workflows";
+
+export default defineWorkflow({
+  name: "echo",
+  startAt: "reply",
+  nodes: {
+    reply: agent({
+      prompt: ({ input }) => `Answer concisely: ${(input as { task?: string }).task}`,
+      expectedOutput: `{ "reply": "your concise answer" }`,
+    }),
+  },
+  edges: [],
+});
+```
+
+Then, from any pi conversation:
+
+```
+/workflow echo summarize this repository
+```
+
+`/workflow` with no arguments lists discovered workflows. `/workflow cancel`
+stops the active run. Trailing text becomes `{ task: "..." }`; pass arbitrary
+input with `--input-json {"key": "value"}`.
+
+Because the workflow runs in your current conversation, you can have a long
+discussion first and then trigger a workflow that builds on it. The
+`elegant-solution` example does exactly that. It asks the model for the most
+elegant long-term production-ready solution to the problem you discussed, then
+for the holy grail, then whether the two are the same (y/n). On `y` it routes
+straight into implementation, and on `n` it asks the model to reconcile the
+gap and pauses at a checkpoint for you to decide.
+
+## Watching a run
+
+Runs persist to `~/.pi/agent/workflows/runs/` as they execute. The viewer
+tails that directory and re-renders on every state change:
+
+```bash
+pi-workflows view          # interactive picker, live updates
+pi-workflows view <runId>  # jump straight to one run
+pi-workflows runs          # plain list of recent runs
+pi-workflows view --once   # print a snapshot and exit (good for scripts)
+```
+
+Inside pi, a compact widget above the editor shows the same progress while a
+workflow is running.
+
+## Node types
+
+A workflow is a graph of named nodes with exactly one entry point. Each node
+finishes with a JSON output, and edges decide what runs next.
+
+An `agent` node sends a prompt into the pi conversation and waits for the
+model to submit its output through the `workflow` tool. A `compute` node runs
+a pure TypeScript function. An `action` node performs a side effect, either a
+TypeScript function (`action({ run })`) or a runtime-owned shell command
+(`shell({ exec, parse })`). A `checkpoint` node ends the run in a `waiting`
+state so a human can pick it up. On top of `agent`, the `decision` helper asks
+the model to pick from a fixed set of choices and validates the answer, and
+`decisionEdge` routes on the result with compile-time case checking.
+
+See [docs/workflows.md](docs/workflows.md) for the full authoring reference
+and [docs/run-bundles.md](docs/run-bundles.md) for the on-disk run format.
+
+## Examples
+
+The [examples/workflows/](examples/workflows/) directory mirrors the acpx
+example set. Copy any of them into `.pi/workflows/` to use them:
+
+- `echo` is the smallest possible workflow, one agent step.
+- `branch` classifies a task with a `decision` and routes to either a
+  continue lane or a clarification checkpoint.
+- `shell` runs a runtime-owned shell command and parses its output, with no
+  agent step at all.
+- `two-turn` chains three agent steps that build on each other's outputs in
+  the same conversation.
+- `elegant-solution` is the mid-conversation trigger described above.
+- `autoimplement` runs an implement, verify, review loop where the review
+  decision routes `issues_found` back to a fix step until it comes back
+  `clean`, bounded by `maxSteps`.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,76 @@
+# Development guide
+
+This document covers the standards for working on pi-workflows itself. For
+authoring workflows, see [workflows.md](workflows.md).
+
+## Layout and boundaries
+
+```
+src/workflows/   engine core: definitions, graph, engine, store, loader
+src/extension/   pi integration: /workflow command, workflow tool, widget
+src/viewer/      standalone TUI viewer over run bundles
+```
+
+The dependency direction is enforced by `slophammer.yml`. `src/workflows`
+imports nothing outside itself and never imports pi. `src/extension` and
+`src/viewer` may import `src/workflows` and never each other. The viewer
+observes runs purely through the bundle files, so it works from any process.
+
+Inside the engine, the pi-facing seam is the `AgentStepExecutor` interface.
+The extension implements it on top of the live conversation
+(`src/extension/executor.ts`), and tests implement it with a scripted fake
+(`test/helpers.ts`). Anything that would couple the engine to pi belongs on
+the extension side of that seam.
+
+## Toolchain
+
+Node 22+, ESM, TypeScript strict (including `exactOptionalPropertyTypes`).
+Formatting is oxfmt, linting is oxlint with warnings denied, tests are vitest
+with istanbul coverage. The single gate is:
+
+```bash
+npm run check   # format:check + lint + typecheck + build + test:coverage
+```
+
+Coverage thresholds are 85% lines/functions/branches/statements, configured
+in `vitest.config.ts`. The istanbul provider is deliberate. Workflow files are
+loaded through jiti at runtime, and the v8 provider mismapped those modules;
+istanbul instruments through the vitest transform pipeline only.
+
+Slophammer runs in CI (coverage, complexity max 8, DRY max 0 findings,
+dependency boundaries). Run it locally with:
+
+```bash
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+```
+
+## End-to-end tests
+
+```bash
+npm run test:e2e
+```
+
+The E2E suite (`test/e2e/`) is non-destructive and fully local. It starts a
+mock OpenAI-compatible server (`test/e2e/mock-openai.ts`) whose scripted
+"model" answers each step contract with a `workflow` tool call, then spawns
+the real pi CLI from `devDependencies` in RPC mode with:
+
+- `PI_CODING_AGENT_DIR` pointed at a temp agent dir containing a `models.json`
+  for the mock provider,
+- `PI_WORKFLOWS_RUNS_DIR` pointed at a temp runs dir,
+- the extension loaded from source with `-e src/extension/index.ts`.
+
+It drives `/workflow` over the RPC protocol and asserts on the resulting run
+bundle, then renders the finished run through the viewer CLI. Nothing outside
+the temp directories is touched, and no real model is called.
+
+## Conventions
+
+- Conventional Commits for commit messages and PR titles.
+- Persisted JSON uses camelCase keys and versioned `schema` identifiers; see
+  [run-bundles.md](run-bundles.md). Breaking a persisted shape means bumping
+  the schema version string.
+- Every exported API of the engine (`src/workflows/index.ts`) is covered by
+  unit tests; new node types or edge semantics need tests in `test/` and a
+  section in [workflows.md](workflows.md).

--- a/docs/run-bundles.md
+++ b/docs/run-bundles.md
@@ -1,0 +1,112 @@
+# Run bundle format
+
+Every workflow run persists to its own directory, called a run bundle. The
+bundle is the contract between the engine and anything that observes runs,
+including the bundled terminal viewer. This document specifies the format so
+other tools can consume it.
+
+## Location and layout
+
+Bundles live under `~/.pi/agent/workflows/runs/` by default. The
+`PI_WORKFLOWS_RUNS_DIR` environment variable overrides the location for both
+the engine and the viewer, which is how the test suite keeps runs inside
+temporary directories.
+
+```
+~/.pi/agent/workflows/runs/
+  20260719T023912Z-autoimplement-3f2a9c1b/
+    manifest.json     # pi-workflows.run-bundle.v1
+    workflow.json     # pi-workflows.definition-snapshot.v1
+    state.json        # full run projection
+    trace.ndjson      # pi-workflows.trace-event.v1, append-only
+```
+
+Run ids are `<UTC timestamp>-<workflow slug>-<8 hex chars>`, so lexical order
+is chronological order.
+
+## Write discipline
+
+Every JSON file in the bundle is written atomically (write to a temp file in
+the same directory, then rename), so a reader never sees a partial document. `trace.ndjson` is append-only, one JSON object
+per line, with writes serialized per file. After a run reaches a terminal
+status (`completed`, `failed`, `timed_out`, `cancelled`, or `waiting`), the
+bundle no longer changes.
+
+A live viewer needs only two behaviors. Treat `state.json` as the current
+projection and re-read it on any file change, and treat `trace.ndjson` as the
+event timeline when history matters.
+
+## manifest.json
+
+Identity and pointers, kept in sync with the state on every snapshot:
+
+```json
+{
+  "schema": "pi-workflows.run-bundle.v1",
+  "runId": "20260719T023912Z-autoimplement-3f2a9c1b",
+  "workflowName": "autoimplement",
+  "runTitle": "autoimplement: fix the flaky test",
+  "workflowPath": "/repo/.pi/workflows/autoimplement.workflow.ts",
+  "startedAt": "2026-07-19T02:39:12.412Z",
+  "finishedAt": "2026-07-19T02:41:03.977Z",
+  "status": "completed",
+  "traceSchema": "pi-workflows.trace-event.v1",
+  "paths": { "workflow": "workflow.json", "state": "state.json", "trace": "trace.ndjson" }
+}
+```
+
+## workflow.json
+
+A serializable snapshot of the graph taken at run start. Functions such as
+prompts and validators are not serialized. Each node keeps only its metadata
+(`nodeType`, `timeoutMs`, `statusDetail`, `expectedOutput`, `summary`,
+`actionExecution`), and edges are copied verbatim. The snapshot is what lets
+the viewer draw all nodes, including ones that have not run yet.
+
+## state.json
+
+The full run projection (`WorkflowRunState` in
+[`src/workflows/types.ts`](../src/workflows/types.ts)). The `status` field is
+one of `running`, `waiting`, `completed`, `failed`, `timed_out`, or
+`cancelled`. While a node is executing, `currentNode`, `currentNodeType`,
+`currentNodeStartedAt`, and `statusDetail` describe it, and they disappear
+when the node finishes.
+
+Per-node data lives in `outputs` (the accepted output of each finished node,
+where the latest attempt wins on loops) and in `results` (the full result
+record including the outcome and timing). The ordered history is `steps`,
+with one record per node execution that includes the prompt text for agent
+steps and an action receipt with the command, exit code, and duration for
+action steps. When a run pauses at a checkpoint, `waitingOn` names the
+checkpoint node. Terminal runs carry `finalOutput` on success and `error` on
+failure.
+
+## trace.ndjson
+
+One event per line, monotonically sequenced per run:
+
+```json
+{
+  "seq": 3,
+  "at": "2026-07-19T02:39:14.101Z",
+  "scope": "agent",
+  "type": "agent_prompt_sent",
+  "runId": "...",
+  "nodeId": "implement",
+  "attemptId": "...",
+  "payload": { "prompt": "..." }
+}
+```
+
+Event types: `run_started`, `node_started`, `agent_prompt_sent`,
+`node_finished`, `node_failed`, and a terminal `run_<status>`. The `scope`
+field (`run`, `node`, `agent`, `action`) groups them. Consumers should ignore
+unknown event types so new ones can be added within the same schema version.
+
+## Versioning
+
+Each file carries a versioned schema identifier such as
+`pi-workflows.run-bundle.v1`, and the identifier changes only on breaking
+shape changes. Readers should check `manifest.json`'s `schema` field and skip
+bundles they do not understand, which is exactly what the bundled viewer does
+with unreadable directories.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -147,6 +147,8 @@ command fails.
 
 Ends the run in a `waiting` state for human review. Runs after a checkpoint do
 not resume automatically; the checkpoint output is the run's final output.
+Because nothing resumes past a checkpoint, graph validation rejects outgoing
+edges from checkpoint nodes.
 
 ```typescript
 checkpoint({

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -64,11 +64,18 @@ type WorkflowNodeContext = {
   outputs: Record<string, unknown>; // accepted output per finished node id
   results: Record<string, WorkflowNodeResult>; // full result records, including failures
   state: WorkflowRunState; // the live run state (read-only by convention)
+  signal: AbortSignal; // aborted on node timeout or run cancellation
 };
 ```
 
 `outputs` only contains nodes that finished with outcome `ok`. When a node runs
-more than once (a loop), the latest result wins.
+more than once (a loop), the latest result wins. A failed retry removes the
+node's earlier output from `outputs`.
+
+Long-running compute, action, and checkpoint callbacks should observe
+`context.signal` (pass it to `fetch`/`spawn`, or check `signal.aborted` between
+steps). When the node times out or the run is cancelled, the engine stops
+waiting immediately, but only cooperative callbacks stop doing work.
 
 ## Node types
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -203,23 +203,25 @@ node with no outgoing edge (or no matching failure route) ends the run:
 ## The step contract
 
 Every `agent` prompt ends with a step contract block naming the workflow, the
-step id, and the expected output shape:
+step id, the attempt id, and the expected output shape:
 
 ```
 ---
-Workflow step contract (workflow: autoimplement, step: review)
+Workflow step contract (workflow: autoimplement, step: review, attempt: 6f9d…)
 
 Complete this step by calling the `workflow` tool exactly once with:
-{"step": "review", "output": <your result>}
+{"step": "review", "attempt": "6f9d…", "output": <your result>}
 Expected output: { "route": "clean" | "issues_found", "reason": "short justification" }
 The step is complete only after the workflow tool accepts the output.
 If the tool reports a validation error, correct the output and call it again.
 ```
 
-The `workflow` tool takes `{ step, output }`. Submissions are rejected (with a
-reason the model sees) when no step is pending, the step id is wrong, or
-`validate` throws. Acceptance resolves the step and the engine advances; the
-next agent prompt arrives as a new user message in the same conversation.
+The `workflow` tool takes `{ step, attempt, output }`. Submissions are
+rejected (with a reason the model sees) when no step is pending, the step id
+is wrong, the attempt id belongs to an earlier attempt of the same node (loops
+revisit node ids, so each attempt gets a fresh id), or `validate` throws.
+Acceptance resolves the step and the engine advances; the next agent prompt
+arrives as a new user message in the same conversation.
 
 ## Runtime behavior
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -41,14 +41,14 @@ export default defineWorkflow({
 
 Top-level fields:
 
-| Field      | Type                   | Notes                                                                      |
-| ---------- | ---------------------- | -------------------------------------------------------------------------- |
-| `name`     | `string`               | Required. Used in run ids and the step contract.                           |
-| `title`    | `string` or function   | Optional run title, resolved once at start from `{ input, workflowName }`. |
-| `startAt`  | `string`               | Required. Id of the first node.                                            |
-| `nodes`    | `Record<string, node>` | Required, non-empty. Node ids must match `[A-Za-z_][A-Za-z0-9_-]*`.        |
-| `edges`    | `WorkflowEdge[]`       | Required. See routing below.                                               |
-| `maxSteps` | `number`               | Optional loop bound, default 100. The run fails when exceeded.             |
+| Field      | Type                   | Notes                                                                                                                         |
+| ---------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | `string`               | Required. Used in run ids and the step contract.                                                                              |
+| `title`    | `string` or function   | Optional run title, resolved once at start from `{ input, workflowName }`. Async resolution is bounded (30s) and cancellable. |
+| `startAt`  | `string`               | Required. Id of the first node.                                                                                               |
+| `nodes`    | `Record<string, node>` | Required, non-empty. Node ids must match `[A-Za-z_][A-Za-z0-9_-]*`.                                                           |
+| `edges`    | `WorkflowEdge[]`       | Required. See routing below.                                                                                                  |
+| `maxSteps` | `number`               | Optional loop bound, default 100. The run fails when exceeded.                                                                |
 
 `defineWorkflow` validates the shape eagerly (node ids, edge shapes, function
 fields) and validates the graph (unknown targets, duplicate outgoing edges,
@@ -137,8 +137,11 @@ shell({
 
 Without `parse`, the node output is the full `ShellActionResult` (`stdout`,
 `stderr`, `exitCode`, `signal`, `durationMs`). A non-zero exit fails the node
-unless `allowNonZeroExit` is set. Both action forms record a receipt (command,
-exit code, duration) in the step record for auditability.
+unless `allowNonZeroExit` is set. Captured stdout and stderr are each capped
+(default 1,000,000 characters, configurable with `maxOutputChars`) so verbose
+commands cannot exhaust memory. Both action forms record a receipt (command,
+exit code, duration) in the step record for auditability, including when the
+command fails.
 
 ### checkpoint
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,250 @@
+# Workflow authoring reference
+
+This document is the authoring reference for pi-workflows definitions. It
+covers the file format, every node type, edge routing, the step contract the
+model sees, and how runs behave at runtime. For the on-disk run format, see
+[run-bundles.md](run-bundles.md).
+
+## Workflow files
+
+A workflow is a TypeScript module whose default export is `defineWorkflow(...)`.
+Files are discovered by suffix (`.workflow.ts`, `.workflow.js`, `.workflow.mts`,
+`.workflow.mjs`) from two directories, in precedence order:
+
+1. `.pi/workflows/` in the project (highest precedence on name collisions)
+2. `~/.pi/agent/workflows/` globally
+
+The workflow's command name is the file stem, so `.pi/workflows/triage.workflow.ts`
+runs as `/workflow triage`. A direct path also works: `/workflow ./somewhere/x.workflow.ts`.
+Files are loaded with [jiti](https://github.com/unjs/jiti), so plain TypeScript
+works without a build step, and `import ... from "pi-workflows"` resolves to
+the engine that loaded the file.
+
+```typescript
+import { agent, compute, defineWorkflow } from "pi-workflows";
+
+export default defineWorkflow({
+  name: "example",
+  title: ({ input }) => `example: ${(input as { task?: string }).task}`,
+  startAt: "ask",
+  maxSteps: 50,
+  nodes: {
+    ask: agent({
+      prompt: ({ input }) => `Answer: ${(input as { task?: string }).task}`,
+      expectedOutput: `{ "answer": "text" }`,
+    }),
+    finish: compute({ run: ({ outputs }) => outputs.ask }),
+  },
+  edges: [{ from: "ask", to: "finish" }],
+});
+```
+
+Top-level fields:
+
+| Field      | Type                   | Notes                                                                      |
+| ---------- | ---------------------- | -------------------------------------------------------------------------- |
+| `name`     | `string`               | Required. Used in run ids and the step contract.                           |
+| `title`    | `string` or function   | Optional run title, resolved once at start from `{ input, workflowName }`. |
+| `startAt`  | `string`               | Required. Id of the first node.                                            |
+| `nodes`    | `Record<string, node>` | Required, non-empty. Node ids must match `[A-Za-z_][A-Za-z0-9_-]*`.        |
+| `edges`    | `WorkflowEdge[]`       | Required. See routing below.                                               |
+| `maxSteps` | `number`               | Optional loop bound, default 100. The run fails when exceeded.             |
+
+`defineWorkflow` validates the shape eagerly (node ids, edge shapes, function
+fields) and validates the graph (unknown targets, duplicate outgoing edges,
+unreachable nodes) when a run starts.
+
+## Node context
+
+Every node callback receives the same context object:
+
+```typescript
+type WorkflowNodeContext = {
+  input: unknown; // the run input
+  outputs: Record<string, unknown>; // accepted output per finished node id
+  results: Record<string, WorkflowNodeResult>; // full result records, including failures
+  state: WorkflowRunState; // the live run state (read-only by convention)
+};
+```
+
+`outputs` only contains nodes that finished with outcome `ok`. When a node runs
+more than once (a loop), the latest result wins.
+
+## Node types
+
+### agent
+
+Sends a prompt into the current pi conversation and waits for the model to
+submit output through the `workflow` tool.
+
+```typescript
+agent({
+  prompt: ({ outputs }) => `Review this: ${JSON.stringify(outputs.implement)}`,
+  expectedOutput: `{ "verdict": "clean" | "issues_found" }`,
+  validate: (output) => output, // optional; throw to reject the submission
+  timeoutMs: 30 * 60_000, // optional; default 15 minutes
+  statusDetail: "reviewing", // optional; shown in widget and viewer
+});
+```
+
+The engine appends a step contract to the prompt (see below). When the model
+calls the tool, the output passes through normalization (a JSON string is
+parsed tolerantly) and then `validate`. If `validate` throws, the tool call
+returns an error and the model can retry within the same step. If the agent
+ends its turn without submitting, the extension nudges it, twice by default,
+then fails the step.
+
+### compute
+
+Runs a TypeScript function inline. Use it for pure data shaping.
+
+```typescript
+compute({ run: ({ outputs }) => ({ merged: { ...outputs } }) });
+```
+
+### action
+
+Performs a side effect. Two forms exist. The function form runs arbitrary
+TypeScript:
+
+```typescript
+action({ run: async ({ input }) => await deployPreview(input) });
+```
+
+The shell form (`shell` is a synonym that requires `exec`) runs a command owned
+by the runtime, so the workflow author decides exactly what executes, with a
+timeout and captured output:
+
+```typescript
+shell({
+  exec: ({ input }) => ({
+    command: "git",
+    args: ["status", "--porcelain"],
+    cwd: "/path/to/repo",
+    timeoutMs: 10_000,
+    allowNonZeroExit: false,
+  }),
+  parse: (result) => ({ dirty: result.stdout.trim().length > 0 }),
+});
+```
+
+Without `parse`, the node output is the full `ShellActionResult` (`stdout`,
+`stderr`, `exitCode`, `signal`, `durationMs`). A non-zero exit fails the node
+unless `allowNonZeroExit` is set. Both action forms record a receipt (command,
+exit code, duration) in the step record for auditability.
+
+### checkpoint
+
+Ends the run in a `waiting` state for human review. Runs after a checkpoint do
+not resume automatically; the checkpoint output is the run's final output.
+
+```typescript
+checkpoint({
+  summary: "human decides how to proceed",
+  run: ({ outputs }) => outputs.reconcile, // optional; default output is { summary }
+});
+```
+
+### decision
+
+`decision` is sugar over `agent` for constrained choices. It builds the prompt
+suffix listing the choices, sets `expectedOutput`, and validates that the
+submitted object carries one of the allowed values in the decision field
+(default `route`).
+
+```typescript
+const choices = ["y", "n"] as const;
+
+decision({
+  choices,
+  question: ({ outputs }) => `Same as proposed? ${JSON.stringify(outputs.propose)}`,
+});
+```
+
+Pair it with `decisionEdge`, which builds the matching `switch` edge and makes
+a missing case a compile-time error:
+
+```typescript
+decisionEdge({ from: "compare", choices, cases: { y: "implement", n: "reconcile" } });
+```
+
+## Edges and routing
+
+Each node has at most one outgoing edge. A plain edge is unconditional:
+
+```typescript
+{ from: "a", to: "b" }
+```
+
+A `switch` edge routes on a JSON path evaluated against the node's result:
+
+```typescript
+{ from: "review", switch: { on: "$.route", cases: { clean: "done", issues_found: "fix" } } }
+```
+
+Path roots:
+
+- `$.field` and `$output.field` read from the node's accepted output.
+- `$result.field` reads from the result record. `$result.outcome` is the main
+  use, with values `ok`, `failed`, `timed_out`, or `cancelled`, which lets a
+  workflow route failures to a recovery node instead of failing the run.
+
+A missing case for the resolved value fails the run with a routing error. A
+node with no outgoing edge (or no matching failure route) ends the run:
+`completed` on success, `failed`/`timed_out`/`cancelled` otherwise.
+
+## The step contract
+
+Every `agent` prompt ends with a step contract block naming the workflow, the
+step id, and the expected output shape:
+
+```
+---
+Workflow step contract (workflow: autoimplement, step: review)
+
+Complete this step by calling the `workflow` tool exactly once with:
+{"step": "review", "output": <your result>}
+Expected output: { "route": "clean" | "issues_found", "reason": "short justification" }
+The step is complete only after the workflow tool accepts the output.
+If the tool reports a validation error, correct the output and call it again.
+```
+
+The `workflow` tool takes `{ step, output }`. Submissions are rejected (with a
+reason the model sees) when no step is pending, the step id is wrong, or
+`validate` throws. Acceptance resolves the step and the engine advances; the
+next agent prompt arrives as a new user message in the same conversation.
+
+## Runtime behavior
+
+Runs execute one node at a time. Every transition is persisted to the run
+bundle before the engine moves on, which is what makes the live viewer
+possible. Defaults worth knowing:
+
+- Node timeout is 15 minutes unless the node sets `timeoutMs`. A timed-out
+  node has outcome `timed_out` and can be routed with `$result.outcome`.
+- `maxSteps` (workflow-level, default 100) bounds loops built from cycles in
+  the graph.
+- `/workflow cancel` aborts the current node and marks the run `cancelled`.
+- One workflow runs per session at a time.
+- Agent nudges: if the model ends its turn without submitting the pending
+  step, it gets a reminder, twice by default, then the step fails.
+
+## Using the engine outside pi
+
+The engine is pi-agnostic. `WorkflowEngine` takes any `AgentStepExecutor`, so
+tests (and other hosts) can script agent steps:
+
+```typescript
+import { WorkflowEngine, type AgentStepExecutor } from "pi-workflows";
+
+const executor: AgentStepExecutor = {
+  async runAgentStep(request) {
+    const accepted = await request.accept({ answer: "42" });
+    if (!accepted.ok) throw new Error(accepted.error);
+    return { output: accepted.value };
+  },
+};
+
+const engine = new WorkflowEngine({ executor, outputRoot: "/tmp/runs" });
+const { state } = await engine.run(workflow, { task: "..." });
+```

--- a/examples/workflows/autoimplement.workflow.ts
+++ b/examples/workflows/autoimplement.workflow.ts
@@ -1,0 +1,90 @@
+import { agent, compute, decision, decisionEdge, defineWorkflow } from "pi-workflows";
+
+type AutoimplementInput = {
+  task?: string;
+};
+
+const reviewChoices = ["clean", "issues_found"] as const;
+
+/**
+ * Implement, verify, then loop a self-review until it comes back clean. The
+ * decision edge routes `issues_found` back to the fix step, and the engine's
+ * maxSteps guard bounds the loop.
+ */
+export default defineWorkflow({
+  name: "autoimplement",
+  title: ({ input }) => {
+    const task = (input as AutoimplementInput).task;
+    return task ? `autoimplement: ${task.slice(0, 60)}` : undefined;
+  },
+  maxSteps: 20,
+  startAt: "implement",
+  nodes: {
+    implement: agent({
+      timeoutMs: 60 * 60_000,
+      statusDetail: "implementing",
+      prompt: ({ input }) => {
+        const task =
+          (input as AutoimplementInput).task ?? "the plan discussed so far in this conversation";
+        return [
+          `Implement ${task} end-to-end.`,
+          "Aim for the most elegant, long-term production-ready solution without gold-plating.",
+        ].join("\n");
+      },
+      expectedOutput: `{ "summary": "what was implemented", "files": ["changed file", "changed file"] }`,
+    }),
+    verify: agent({
+      timeoutMs: 30 * 60_000,
+      statusDetail: "verifying",
+      prompt: () =>
+        [
+          "Verify the implementation.",
+          "Run the test suite plus any relevant builds, linters, or local smoke tests.",
+          "Do not run destructive commands.",
+        ].join("\n"),
+      expectedOutput: `{ "passed": true | false, "details": "what was run and what happened" }`,
+    }),
+    review: decision({
+      choices: reviewChoices,
+      question: ({ outputs }) =>
+        [
+          "Critically review your implementation as a strict reviewer.",
+          "Look for correctness bugs, missed requirements, and failing checks.",
+          "Pick `issues_found` if anything must be fixed, otherwise `clean`.",
+          "",
+          `Verification: ${JSON.stringify(outputs.verify)}`,
+        ].join("\n"),
+    }),
+    fix: agent({
+      timeoutMs: 30 * 60_000,
+      statusDetail: "fixing",
+      prompt: ({ outputs }) =>
+        [
+          "Fix the issues you found in review, then stop.",
+          "",
+          `Review: ${JSON.stringify(outputs.review)}`,
+        ].join("\n"),
+      expectedOutput: `{ "fixed": "what was changed" }`,
+    }),
+    finalize: compute({
+      run: ({ outputs }) => ({
+        implementation: outputs.implement,
+        verification: outputs.verify,
+        review: outputs.review,
+      }),
+    }),
+  },
+  edges: [
+    { from: "implement", to: "verify" },
+    { from: "verify", to: "review" },
+    decisionEdge({
+      from: "review",
+      choices: reviewChoices,
+      cases: {
+        clean: "finalize",
+        issues_found: "fix",
+      },
+    }),
+    { from: "fix", to: "verify" },
+  ],
+});

--- a/examples/workflows/branch.workflow.ts
+++ b/examples/workflows/branch.workflow.ts
@@ -1,0 +1,59 @@
+import { agent, checkpoint, decision, decisionEdge, defineWorkflow } from "pi-workflows";
+
+type BranchInput = {
+  task?: string;
+};
+
+const classifyChoices = ["continue", "checkpoint"] as const;
+
+/**
+ * decision() + decisionEdge() constrained-choice classification, then a
+ * deterministic branch. Analogous to the acpx branch example.
+ */
+export default defineWorkflow({
+  name: "branch",
+  startAt: "classify",
+  nodes: {
+    classify: decision({
+      choices: classifyChoices,
+      question: ({ input }) => {
+        const task =
+          (input as BranchInput).task ??
+          "Investigate a flaky test and decide whether the request is clear enough to continue.";
+        return [
+          "Read the task below.",
+          "Pick `continue` if it is concrete and scoped.",
+          "Pick `checkpoint` if it is ambiguous or needs clarification.",
+          "",
+          `Task: ${task}`,
+        ].join("\n");
+      },
+    }),
+    continue_lane: agent({
+      prompt: ({ outputs }) =>
+        [
+          "We are on the continue path.",
+          `Decision: ${JSON.stringify(outputs.classify)}`,
+          "Summarize in one sentence how you would proceed.",
+        ].join("\n"),
+      expectedOutput: `{ "summary": "short explanation" }`,
+    }),
+    checkpoint_lane: checkpoint({
+      summary: "needs clarification",
+      run: ({ outputs }) => ({
+        route: "checkpoint",
+        summary: (outputs.classify as { reason?: string }).reason ?? "Needs clarification.",
+      }),
+    }),
+  },
+  edges: [
+    decisionEdge({
+      from: "classify",
+      choices: classifyChoices,
+      cases: {
+        continue: "continue_lane",
+        checkpoint: "checkpoint_lane",
+      },
+    }),
+  ],
+});

--- a/examples/workflows/echo.workflow.ts
+++ b/examples/workflows/echo.workflow.ts
@@ -1,7 +1,7 @@
 import { agent, defineWorkflow } from "pi-workflows";
 
 type EchoInput = {
-  request?: string;
+  task?: string;
 };
 
 /** Smallest possible workflow: one agent step that submits a JSON reply. */
@@ -11,8 +11,7 @@ export default defineWorkflow({
   nodes: {
     reply: agent({
       prompt: ({ input }) => {
-        const request =
-          (input as EchoInput).request ?? "Summarize this repository in one sentence.";
+        const request = (input as EchoInput).task ?? "Summarize this repository in one sentence.";
         return `Answer the following request concisely.\n\nRequest: ${request}`;
       },
       expectedOutput: `{ "reply": "your concise answer" }`,

--- a/examples/workflows/echo.workflow.ts
+++ b/examples/workflows/echo.workflow.ts
@@ -1,0 +1,22 @@
+import { agent, defineWorkflow } from "pi-workflows";
+
+type EchoInput = {
+  request?: string;
+};
+
+/** Smallest possible workflow: one agent step that submits a JSON reply. */
+export default defineWorkflow({
+  name: "echo",
+  startAt: "reply",
+  nodes: {
+    reply: agent({
+      prompt: ({ input }) => {
+        const request =
+          (input as EchoInput).request ?? "Summarize this repository in one sentence.";
+        return `Answer the following request concisely.\n\nRequest: ${request}`;
+      },
+      expectedOutput: `{ "reply": "your concise answer" }`,
+    }),
+  },
+  edges: [],
+});

--- a/examples/workflows/elegant-solution.workflow.ts
+++ b/examples/workflows/elegant-solution.workflow.ts
@@ -1,0 +1,86 @@
+import { agent, checkpoint, decision, decisionEdge, defineWorkflow } from "pi-workflows";
+
+const sameChoices = ["y", "n"] as const;
+
+/**
+ * Trigger this mid-conversation with /workflow elegant-solution once a
+ * problem has been discussed. It makes the model commit to the most elegant
+ * long-term production-ready solution, articulate the holy grail, and check
+ * whether the two match before implementing.
+ */
+export default defineWorkflow({
+  name: "elegant-solution",
+  title: "Elegant production-ready solution",
+  startAt: "propose",
+  nodes: {
+    propose: agent({
+      prompt: () =>
+        [
+          "Consider the problem discussed so far in this conversation.",
+          "What is the most elegant and long-term production-ready solution?",
+          "Think it through and commit to one concrete proposal.",
+        ].join("\n"),
+      expectedOutput: `{ "solution": "the proposed solution", "rationale": "why it is the most elegant long-term choice" }`,
+    }),
+    holy_grail: agent({
+      prompt: () =>
+        [
+          "Now set your previous proposal aside for a moment.",
+          "What is the holy grail for this problem?",
+          "Describe the ideal end state with no constraints on effort.",
+        ].join("\n"),
+      expectedOutput: `{ "holyGrail": "the ideal end state" }`,
+    }),
+    compare: decision({
+      choices: sameChoices,
+      question: ({ outputs }) =>
+        [
+          "Is the holy grail the same as what you proposed? Answer y or n.",
+          "",
+          `Proposal: ${JSON.stringify(outputs.propose)}`,
+          `Holy grail: ${JSON.stringify(outputs.holy_grail)}`,
+        ].join("\n"),
+    }),
+    implement: agent({
+      timeoutMs: 60 * 60_000,
+      statusDetail: "implementing",
+      prompt: ({ outputs }) =>
+        [
+          "The proposal matches the holy grail, so implement it now.",
+          "Implement the most elegant and long-term production-ready solution end-to-end.",
+          "Test as much as possible without destructive actions, and state what could not be verified locally.",
+          "",
+          `Proposal: ${JSON.stringify(outputs.propose)}`,
+        ].join("\n"),
+      expectedOutput: `{ "implemented": true, "summary": "what was built", "tested": "what was verified", "untested": "what still needs verification" }`,
+    }),
+    reconcile: agent({
+      prompt: ({ outputs }) =>
+        [
+          "The proposal and the holy grail differ.",
+          "Explain the gap and propose the pragmatic path: what to build now and how it evolves toward the holy grail.",
+          "",
+          `Proposal: ${JSON.stringify(outputs.propose)}`,
+          `Holy grail: ${JSON.stringify(outputs.holy_grail)}`,
+        ].join("\n"),
+      expectedOutput: `{ "gap": "how they differ", "path": "what to build now and how it evolves" }`,
+    }),
+    review: checkpoint({
+      summary: "human decides between proposal and holy grail path",
+      run: ({ outputs }) => outputs.reconcile,
+    }),
+  },
+  edges: [
+    { from: "propose", to: "holy_grail" },
+    { from: "holy_grail", to: "compare" },
+    decisionEdge({
+      from: "compare",
+      choices: sameChoices,
+      cases: {
+        y: "implement",
+        n: "reconcile",
+      },
+    }),
+    { from: "reconcile", to: "review" },
+  ],
+});

--- a/examples/workflows/shell.workflow.ts
+++ b/examples/workflows/shell.workflow.ts
@@ -1,0 +1,31 @@
+import { compute, defineWorkflow, shell } from "pi-workflows";
+
+type ShellInput = {
+  text?: string;
+};
+
+/** One runtime-owned shell action returning structured JSON, no agent step. */
+export default defineWorkflow({
+  name: "shell",
+  startAt: "echo_text",
+  nodes: {
+    echo_text: shell({
+      exec: ({ input }) => ({
+        command: "printf",
+        args: ["%s", (input as ShellInput).text ?? "hello from pi-workflows"],
+        timeoutMs: 10_000,
+      }),
+      parse: (result) => ({
+        stdout: result.stdout,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+      }),
+    }),
+    finalize: compute({
+      run: ({ outputs }) => ({
+        echoed: (outputs.echo_text as { stdout: string }).stdout,
+      }),
+    }),
+  },
+  edges: [{ from: "echo_text", to: "finalize" }],
+});

--- a/examples/workflows/two-turn.workflow.ts
+++ b/examples/workflows/two-turn.workflow.ts
@@ -1,0 +1,62 @@
+import { agent, compute, defineWorkflow } from "pi-workflows";
+
+type TwoTurnInput = {
+  topic?: string;
+};
+
+/**
+ * Multi-step agent work in the same pi conversation. Each step builds on the
+ * previous step's accepted output, and the model keeps its full session
+ * context (files it read, tools it ran) across steps.
+ */
+export default defineWorkflow({
+  name: "two-turn",
+  startAt: "inspect",
+  nodes: {
+    inspect: agent({
+      prompt: ({ input }) => {
+        const topic =
+          (input as TwoTurnInput).topic ??
+          "How should we validate a new extension before shipping it?";
+        return [
+          "Inspect the current workspace before answering.",
+          "Read at least two files relevant to the topic (for example the package manifest and a source file).",
+          "",
+          `Topic: ${topic}`,
+        ].join("\n");
+      },
+      expectedOutput: `{ "findings": ["short finding", "short finding"], "repoSummary": "short paragraph" }`,
+    }),
+    draft: agent({
+      prompt: ({ outputs }) =>
+        [
+          "Build on your earlier inspection in this same conversation.",
+          "Write a short draft answer about the topic.",
+          "",
+          `Inspection: ${JSON.stringify(outputs.inspect)}`,
+        ].join("\n"),
+      expectedOutput: `{ "draft": "short paragraph" }`,
+    }),
+    checklist: agent({
+      prompt: ({ outputs }) =>
+        [
+          "Turn the draft into a concise validation checklist with concrete references.",
+          "",
+          `Draft: ${JSON.stringify(outputs.draft)}`,
+        ].join("\n"),
+      expectedOutput: `{ "checklist": ["item", "item"], "references": ["path", "path"] }`,
+    }),
+    finalize: compute({
+      run: ({ outputs }) => ({
+        inspection: outputs.inspect,
+        draft: outputs.draft,
+        checklist: outputs.checklist,
+      }),
+    }),
+  },
+  edges: [
+    { from: "inspect", to: "draft" },
+    { from: "draft", to: "checklist" },
+    { from: "checklist", to: "finalize" },
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5634 @@
+{
+  "name": "pi-workflows",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-workflows",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "^2.7.0",
+        "typebox": "^1.3.6"
+      },
+      "bin": {
+        "pi-workflows": "dist/viewer/cli.js"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@types/node": "^26.1.1",
+        "@vitest/coverage-istanbul": "^4.1.10",
+        "oxfmt": "^0.59.0",
+        "oxlint": "^1.74.0",
+        "tsx": "^4.23.1",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
+      "dev": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.1.38",
+        "undici": "8.5.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.80.10",
+        "ignore": "7.0.5",
+        "typebox": "1.1.38",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.59.0.tgz",
+      "integrity": "sha512-bNTnfbuG7sAwb2PakMNaDukx5kXeW9duXOBeWtTOiLz3fXz3q2DlWguufPZ+c2IHEVrRXHD+M4aUgEWm841LDA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.59.0.tgz",
+      "integrity": "sha512-R/Sn7z52QtdAKNqQLLY0EK7hVMjXiz3XUlvoCFCm/60jgIzAnQtiqLKBCFaBkimCQL5rs2ezPMcicpjCsrl54Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.59.0.tgz",
+      "integrity": "sha512-vm/ynUqE4HjC0ZIEjmXv1UJu1/GngccQ+T+TJudTMxUxm6r+GQTg1TO3E5jJfI71pBaXxSzs1+vWHIwuilGHhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.59.0.tgz",
+      "integrity": "sha512-uTtYDpLN/obfKVWGpgEc8BqYlLZBQTPz2uYEvLRy3HPZxjZ34wiFzukUBU2bf64JuCYZI//GTV1EOMmWlPjf/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.59.0.tgz",
+      "integrity": "sha512-e2UnxL/ifStSPy8ffBCDbdy595SYsGy+U1pur4G65TuMmWxAMBzYGG7atZo/3mp515p8rZdsflxVD/E1FAdPLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.59.0.tgz",
+      "integrity": "sha512-LtdeZ1l0urxte3VNi3g8cocZwv1xGM1NKHSgF/fJEEVhyQmlgGh7WFWKFd/pNuO7djfvPNtNO1+MS+FEWkgVSA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.59.0.tgz",
+      "integrity": "sha512-dBTciSsj9GTMl7p+h2gMSI0hoPn2ijfc/dUsbnWsP0RbwgPl2r0C/5zkMb3Pb+gGj17LH7f1o4qLo9aes/pAvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.59.0.tgz",
+      "integrity": "sha512-tXVdJ/JINsNWdponPHN0OuKHtC+HdpyoS9sd6IDPNiiEYsRki8b7tefRZ1iMnRkdbyT4SEbguWsr6o+5awvbPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.59.0.tgz",
+      "integrity": "sha512-RRTq38i2zT5fnw6XGHjvT6w2mh6x/G3m6AZcAZ56OTDTT/lsOeYnG3SVjwmH40z5kPqF+lf+o35e6m6PpKy9Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.59.0.tgz",
+      "integrity": "sha512-lD3k7glAJSaXW0D6xzu8VOZbYbosvy+0ktOVkfLEoQF5HJlMSxTQ2KNW0JO+08ccP/1ElOKktVEMI0fqRbVB4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.59.0.tgz",
+      "integrity": "sha512-WH5ZP1RbuHKBO/yfPRQKpNO/ijHcEDNbnmC4VPf/Bcd3+mbMAZpRiJWRa1PL5bREdIZZHo343mk3sqlc9x7Usw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.59.0.tgz",
+      "integrity": "sha512-743wOiaI9RZY4QVGkWkfGRavD5ZJUJ6gscFjVrVu1dP8AZh9jM+a6v3NhlR+OIzHdS6DhLM96w+gcVskskz7rw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.59.0.tgz",
+      "integrity": "sha512-xjRXQsRnrRZCcCkIEnbd2lmsQNobtwwkJxdy2bWXhZ1lIN0ouZwsBXRsoovW3yATuziAYwr9HMiQuR/Cc75NIw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.59.0.tgz",
+      "integrity": "sha512-4hNjqq/Rbr9B+StY9zMMAfm72+mtM4v80xYL5Qkb59Qd72g2vJMI0iFlPj3kf6miMsie/yJ7rt4urJT292HBgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.59.0.tgz",
+      "integrity": "sha512-NH579iN8EVQYsWowUB8B5vFchcylJtwPVJ7NmUAqEQHNLfhPbDT3K56KrECNAkUN4QpF4qiMgN2vsfZwVvjm7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.59.0.tgz",
+      "integrity": "sha512-mzZy3Z5Aj1D75Aq9FVlmoRQH5ei8Ga4o/NZmlXkKyeZ5EmPrUXRR7c6BMBteV1ZuZ/356UYDuLRLjAMxTDTiBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.59.0.tgz",
+      "integrity": "sha512-0CpDJ1gE3jN1Gk6xms1Ie6LPfPcOtY4FAtoOmVLHQoAf8DvO2wd0DW2dIX2f7YTp5dxrr0ND8JeUEjm3DP3k5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.59.0.tgz",
+      "integrity": "sha512-zwdKBu3pt87uW0bRcywZb0oGMS7C6n87qogwRYFUgmk44T90ZzYlPjtlFYXs/DnBFrgNCvlHwCuWKfVWLeE7kw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.59.0.tgz",
+      "integrity": "sha512-dUUbZkKgWrmAeI/puzv4bxN8lzcYaFnQVwFTFtwO2Gp8M7lZGSE2qJjC58g518+1bltJ8mizjYwD0BGHym0l/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.74.0.tgz",
+      "integrity": "sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.74.0.tgz",
+      "integrity": "sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.74.0.tgz",
+      "integrity": "sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.74.0.tgz",
+      "integrity": "sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.74.0.tgz",
+      "integrity": "sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.74.0.tgz",
+      "integrity": "sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.74.0.tgz",
+      "integrity": "sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.74.0.tgz",
+      "integrity": "sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.74.0.tgz",
+      "integrity": "sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.74.0.tgz",
+      "integrity": "sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.74.0.tgz",
+      "integrity": "sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.74.0.tgz",
+      "integrity": "sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.74.0.tgz",
+      "integrity": "sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.74.0.tgz",
+      "integrity": "sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.74.0.tgz",
+      "integrity": "sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.74.0.tgz",
+      "integrity": "sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.74.0.tgz",
+      "integrity": "sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.74.0.tgz",
+      "integrity": "sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.74.0.tgz",
+      "integrity": "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.10.tgz",
+      "integrity": "sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "@jridgewell/gen-mapping": "^0.3.13",
+        "@jridgewell/trace-mapping": "0.3.31",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/oxfmt": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.59.0.tgz",
+      "integrity": "sha512-Xqk6cPZS1yMvVa7OAuenaDZUsgMDutvvbZ9/L5gSvAfW64+WN4HVhgipLj5rVERbYQt8fLs9TopyZ1rU1XEG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.59.0",
+        "@oxfmt/binding-android-arm64": "0.59.0",
+        "@oxfmt/binding-darwin-arm64": "0.59.0",
+        "@oxfmt/binding-darwin-x64": "0.59.0",
+        "@oxfmt/binding-freebsd-x64": "0.59.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.59.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.59.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.59.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.59.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.59.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.59.0",
+        "@oxfmt/binding-linux-x64-musl": "0.59.0",
+        "@oxfmt/binding-openharmony-arm64": "0.59.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.59.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.59.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.59.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.74.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.74.0.tgz",
+      "integrity": "sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.74.0",
+        "@oxlint/binding-android-arm64": "1.74.0",
+        "@oxlint/binding-darwin-arm64": "1.74.0",
+        "@oxlint/binding-darwin-x64": "1.74.0",
+        "@oxlint/binding-freebsd-x64": "1.74.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.74.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.74.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.74.0",
+        "@oxlint/binding-linux-arm64-musl": "1.74.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.74.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.74.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.74.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.74.0",
+        "@oxlint/binding-linux-x64-gnu": "1.74.0",
+        "@oxlint/binding-linux-x64-musl": "1.74.0",
+        "@oxlint/binding-openharmony-arm64": "1.74.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.74.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.74.0",
+        "@oxlint/binding-win32-x64-msvc": "1.74.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.24.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
+      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "format": "oxfmt --write",
     "format:check": "oxfmt --check",
     "lint": "oxlint --deny-warnings src test examples",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "pi-workflows",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Workflow engine, JSON control-flow tool, and live terminal viewer for the pi coding agent",
+  "keywords": [
+    "pi-package"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/osolmaz/pi-workflows.git"
+  },
+  "bin": {
+    "pi-workflows": "dist/viewer/cli.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "examples",
+    "docs",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/workflows/index.d.ts",
+      "default": "./dist/workflows/index.js"
+    },
+    "./extension": {
+      "types": "./dist/extension/index.d.ts",
+      "default": "./dist/extension/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run build && npm run test:coverage",
+    "format": "oxfmt --write",
+    "format:check": "oxfmt --check",
+    "lint": "oxlint --deny-warnings src test examples",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "jiti": "^2.7.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@types/node": "^26.1.1",
+    "@vitest/coverage-istanbul": "^4.1.10",
+    "oxfmt": "^0.59.0",
+    "oxlint": "^1.74.0",
+    "tsx": "^4.23.1",
+    "typebox": "^1.3.6",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  },
+  "peerDependencies": {
+    "typebox": "*"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "pi": {
+    "extensions": [
+      "./src/extension/index.ts"
+    ]
+  }
+}

--- a/slophammer.yml
+++ b/slophammer.yml
@@ -1,0 +1,28 @@
+typescript:
+  coverage:
+    threshold: 85
+  complexity:
+    max: 8
+  dry:
+    max_findings: 0
+    paths:
+      - src
+    exclude:
+      - "**/*.test.ts"
+      - "dist/**"
+      - "node_modules/**"
+    copied_blocks:
+      enabled: true
+      min_tokens: 100
+  dependency_boundaries:
+    # workflows is the core engine; it must stay pi-agnostic and standalone.
+    - from: src/workflows
+      allow: []
+    # The extension embeds the engine in pi.
+    - from: src/extension
+      allow:
+        - src/workflows
+    # The viewer only reads run bundles; it must never import the extension.
+    - from: src/viewer
+      allow:
+        - src/workflows

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -1,0 +1,160 @@
+import type {
+  AgentStepExecutor,
+  AgentStepRequest,
+  AgentStepSubmission,
+} from "../workflows/types.js";
+
+export type SubmissionResult =
+  | { accepted: true; message: string }
+  | { accepted: false; message: string };
+
+export type PromptDelivery = {
+  prompt: string;
+  /** True when the agent is known to be mid-run, so delivery must be queued. */
+  streaming: boolean;
+};
+
+export type ConversationStepExecutorOptions = {
+  /** Deliver a prompt into the pi conversation. */
+  sendPrompt: (delivery: PromptDelivery) => void;
+  /** Reminders sent when the agent settles without submitting. Default 2. */
+  maxNudges?: number;
+};
+
+type PendingStep = {
+  request: AgentStepRequest;
+  resolve: (submission: AgentStepSubmission) => void;
+  reject: (error: unknown) => void;
+  nudgesSent: number;
+  cleanup: () => void;
+};
+
+const DEFAULT_MAX_NUDGES = 2;
+
+/**
+ * AgentStepExecutor that runs steps inside the current pi conversation. The
+ * engine hands it a prompt; it delivers the prompt as a user message and
+ * resolves once the model submits an accepted output through the `workflow`
+ * tool. If the agent settles without submitting, it nudges the model a
+ * bounded number of times before failing the step.
+ */
+export class ConversationStepExecutor implements AgentStepExecutor {
+  private readonly sendPrompt: (delivery: PromptDelivery) => void;
+  private readonly maxNudges: number;
+  private pending: PendingStep | null = null;
+  private streaming = false;
+
+  constructor(options: ConversationStepExecutorOptions) {
+    this.sendPrompt = options.sendPrompt;
+    this.maxNudges = options.maxNudges ?? DEFAULT_MAX_NUDGES;
+  }
+
+  /** Track agent streaming state (wire to agent_start / agent_settled). */
+  setStreaming(streaming: boolean): void {
+    this.streaming = streaming;
+  }
+
+  get pendingStepId(): string | null {
+    return this.pending?.request.contract.nodeId ?? null;
+  }
+
+  async runAgentStep(request: AgentStepRequest, signal: AbortSignal): Promise<AgentStepSubmission> {
+    if (this.pending) {
+      throw new Error("Another workflow step is already awaiting output");
+    }
+    return await new Promise<AgentStepSubmission>((resolve, reject) => {
+      const onAbort = () => {
+        const reason: unknown = signal.reason ?? new Error("Workflow step aborted");
+        this.clearPending();
+        reject(reason);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      this.pending = {
+        request,
+        resolve,
+        reject,
+        nudgesSent: 0,
+        cleanup: () => signal.removeEventListener("abort", onAbort),
+      };
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      this.sendPrompt({ prompt: request.prompt, streaming: this.streaming });
+    });
+  }
+
+  /** Called by the `workflow` tool when the model submits a step output. */
+  async submit(stepId: string, output: unknown): Promise<SubmissionResult> {
+    const pending = this.pending;
+    if (!pending) {
+      return {
+        accepted: false,
+        message:
+          "No workflow step is awaiting output. Do not call the workflow tool outside an active workflow step.",
+      };
+    }
+    const expected = pending.request.contract.nodeId;
+    if (stepId !== expected) {
+      return {
+        accepted: false,
+        message: `Wrong step id ${JSON.stringify(stepId)}; the pending step is ${JSON.stringify(expected)}.`,
+      };
+    }
+    const result = await pending.request.accept(output);
+    if (!result.ok) {
+      return {
+        accepted: false,
+        message: `Output rejected for step ${JSON.stringify(stepId)}: ${result.error}`,
+      };
+    }
+    this.clearPending();
+    pending.resolve({ output: result.value });
+    return {
+      accepted: true,
+      message: [
+        `Output accepted for step ${JSON.stringify(stepId)}.`,
+        "If the workflow continues, the next step arrives as a new user message. End your turn now.",
+      ].join(" "),
+    };
+  }
+
+  /**
+   * Called when the agent settles. Returns true when a nudge was sent, false
+   * when there was nothing to do. Fails the pending step once the nudge
+   * budget is exhausted.
+   */
+  handleAgentSettled(): boolean {
+    const pending = this.pending;
+    if (!pending) {
+      return false;
+    }
+    if (pending.nudgesSent >= this.maxNudges) {
+      this.clearPending();
+      pending.reject(
+        new Error(
+          `Agent settled ${pending.nudgesSent + 1} times without submitting step ${JSON.stringify(
+            pending.request.contract.nodeId,
+          )} via the workflow tool`,
+        ),
+      );
+      return false;
+    }
+    pending.nudgesSent += 1;
+    this.sendPrompt({
+      prompt: [
+        `Reminder: workflow step ${JSON.stringify(pending.request.contract.nodeId)} is still awaiting your output.`,
+        "Complete it by calling the `workflow` tool with:",
+        `{"step": ${JSON.stringify(pending.request.contract.nodeId)}, "output": <your result>}`,
+        `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
+      ].join("\n"),
+      streaming: this.streaming,
+    });
+    return true;
+  }
+
+  private clearPending(): void {
+    this.pending?.cleanup();
+    this.pending = null;
+  }
+}

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -102,6 +102,15 @@ export class ConversationStepExecutor implements AgentStepExecutor {
       };
     }
     const result = await pending.request.accept(output);
+    // The step may have timed out or been cancelled (and a newer step
+    // installed) while validation was awaited; a stale submission must not
+    // clear or resolve the newer pending step.
+    if (this.pending !== pending) {
+      return {
+        accepted: false,
+        message: `Step ${JSON.stringify(stepId)} is no longer awaiting output.`,
+      };
+    }
     if (!result.ok) {
       return {
         accepted: false,

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -184,15 +184,23 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     }
     pending.nudgesSent += 1;
     const { nodeId, attemptId } = pending.request.contract;
-    this.sendPrompt({
-      prompt: [
-        `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
-        "Complete it by calling the `workflow` tool with:",
-        `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
-        `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
-      ].join("\n"),
-      streaming: this.streaming,
-    });
+    try {
+      this.sendPrompt({
+        prompt: [
+          `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
+          "Complete it by calling the `workflow` tool with:",
+          `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
+          `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
+        ].join("\n"),
+        streaming: this.streaming,
+      });
+    } catch (error) {
+      // No reminder turn was started, so nothing would settle the step; fail
+      // it promptly instead of waiting out the node timeout.
+      this.clearPending();
+      pending.reject(error);
+      return false;
+    }
     return true;
   }
 

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -80,7 +80,14 @@ export class ConversationStepExecutor implements AgentStepExecutor {
         onAbort();
         return;
       }
-      this.sendPrompt({ prompt: request.prompt, streaming: this.streaming });
+      try {
+        this.sendPrompt({ prompt: request.prompt, streaming: this.streaming });
+      } catch (error) {
+        // A failed delivery must not leave the step installed, or every
+        // subsequent agent node would fail with "already awaiting output".
+        this.clearPending();
+        reject(error);
+      }
     });
   }
 

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -27,6 +27,9 @@ type PendingStep = {
   reject: (error: unknown) => void;
   nudgesSent: number;
   cleanup: () => void;
+  /** Resolves when this step stops being the pending step. */
+  cleared: Promise<void>;
+  markCleared: () => void;
 };
 
 const DEFAULT_MAX_NUDGES = 2;
@@ -69,12 +72,18 @@ export class ConversationStepExecutor implements AgentStepExecutor {
         reject(reason);
       };
       signal.addEventListener("abort", onAbort, { once: true });
+      let markCleared!: () => void;
+      const cleared = new Promise<void>((resolveCleared) => {
+        markCleared = resolveCleared;
+      });
       this.pending = {
         request,
         resolve,
         reject,
         nudgesSent: 0,
         cleanup: () => signal.removeEventListener("abort", onAbort),
+        cleared,
+        markCleared,
       };
       if (signal.aborted) {
         onAbort();
@@ -119,11 +128,17 @@ export class ConversationStepExecutor implements AgentStepExecutor {
         )}; the pending attempt is ${JSON.stringify(expectedAttempt)}. Use the attempt id from the latest step contract.`,
       };
     }
-    const result = await pending.request.accept(output);
+    // Race validation against the step being cleared: a hung `validate`
+    // callback must not leave this tool call (and therefore pi) blocked after
+    // a timeout or cancel already resolved the run.
+    const result = await Promise.race([
+      pending.request.accept(output),
+      pending.cleared.then(() => null),
+    ]);
     // The step may have timed out or been cancelled (and a newer step
     // installed) while validation was awaited; a stale submission must not
     // clear or resolve the newer pending step.
-    if (this.pending !== pending) {
+    if (result === null || this.pending !== pending) {
       return {
         accepted: false,
         message: `Step ${JSON.stringify(stepId)} is no longer awaiting output.`,
@@ -183,6 +198,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
 
   private clearPending(): void {
     this.pending?.cleanup();
+    this.pending?.markCleared();
     this.pending = null;
   }
 }

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -92,7 +92,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
   }
 
   /** Called by the `workflow` tool when the model submits a step output. */
-  async submit(stepId: string, output: unknown): Promise<SubmissionResult> {
+  async submit(stepId: string, attemptId: string, output: unknown): Promise<SubmissionResult> {
     const pending = this.pending;
     if (!pending) {
       return {
@@ -106,6 +106,17 @@ export class ConversationStepExecutor implements AgentStepExecutor {
       return {
         accepted: false,
         message: `Wrong step id ${JSON.stringify(stepId)}; the pending step is ${JSON.stringify(expected)}.`,
+      };
+    }
+    // Loops revisit the same node id, so a delayed duplicate submission from
+    // an earlier attempt would otherwise be accepted as this attempt's output.
+    const expectedAttempt = pending.request.contract.attemptId;
+    if (attemptId !== expectedAttempt) {
+      return {
+        accepted: false,
+        message: `Stale attempt id ${JSON.stringify(attemptId)} for step ${JSON.stringify(
+          stepId,
+        )}; the pending attempt is ${JSON.stringify(expectedAttempt)}. Use the attempt id from the latest step contract.`,
       };
     }
     const result = await pending.request.accept(output);
@@ -157,11 +168,12 @@ export class ConversationStepExecutor implements AgentStepExecutor {
       return false;
     }
     pending.nudgesSent += 1;
+    const { nodeId, attemptId } = pending.request.contract;
     this.sendPrompt({
       prompt: [
-        `Reminder: workflow step ${JSON.stringify(pending.request.contract.nodeId)} is still awaiting your output.`,
+        `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
         "Complete it by calling the `workflow` tool with:",
-        `{"step": ${JSON.stringify(pending.request.contract.nodeId)}, "output": <your result>}`,
+        `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
         `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
       ].join("\n"),
       streaming: this.streaming,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -44,8 +44,11 @@ export function parseWorkflowArgs(args: string): ParsedWorkflowArgs {
   const spaceIndex = trimmed.search(/\s/);
   const ref = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
   const rest = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex).trim();
-  if (rest.startsWith("--input-json")) {
-    const json = rest.slice("--input-json".length).trim();
+  // Match the option as a complete token so task text such as
+  // "--input-jsonschema help" is not misparsed as the JSON option.
+  const inputJsonMatch = rest.match(/^--input-json(?:\s+|$)([\s\S]*)$/);
+  if (inputJsonMatch) {
+    const json = (inputJsonMatch[1] as string).trim();
     if (!json) {
       throw new Error("--input-json requires a JSON value");
     }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,0 +1,237 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { WorkflowEngine } from "../workflows/engine.js";
+import { errorMessage } from "../workflows/errors.js";
+import { discoverWorkflows, loadWorkflowFile, resolveWorkflowRef } from "../workflows/loader.js";
+import { createDefinitionSnapshot } from "../workflows/store.js";
+import type {
+  WorkflowDefinitionSnapshot,
+  WorkflowRunResult,
+  WorkflowRunState,
+} from "../workflows/types.js";
+import { ConversationStepExecutor } from "./executor.js";
+import { buildWidgetLines } from "./widget.js";
+
+const WIDGET_KEY = "pi-workflows";
+const FINAL_WIDGET_TTL_MS = 60_000;
+
+type ActiveRun = {
+  runId: string | null;
+  workflowName: string;
+  engine: WorkflowEngine;
+  executor: ConversationStepExecutor;
+  snapshot: WorkflowDefinitionSnapshot;
+};
+
+export type ParsedWorkflowArgs =
+  | { kind: "list" }
+  | { kind: "cancel" }
+  | { kind: "run"; ref: string; input: unknown };
+
+/** Parse `/workflow` arguments. Exported for tests. */
+export function parseWorkflowArgs(args: string): ParsedWorkflowArgs {
+  const trimmed = args.trim();
+  if (trimmed.length === 0) {
+    return { kind: "list" };
+  }
+  if (trimmed === "cancel") {
+    return { kind: "cancel" };
+  }
+  const spaceIndex = trimmed.search(/\s/);
+  const ref = spaceIndex === -1 ? trimmed : trimmed.slice(0, spaceIndex);
+  const rest = spaceIndex === -1 ? "" : trimmed.slice(spaceIndex).trim();
+  if (rest.startsWith("--input-json")) {
+    const json = rest.slice("--input-json".length).trim();
+    if (!json) {
+      throw new Error("--input-json requires a JSON value");
+    }
+    return { kind: "run", ref, input: JSON.parse(json) as unknown };
+  }
+  return { kind: "run", ref, input: rest.length > 0 ? { task: rest } : {} };
+}
+
+export default function piWorkflows(pi: ExtensionAPI) {
+  let activeRun: ActiveRun | null = null;
+  let widgetTimer: NodeJS.Timeout | null = null;
+
+  const notify = (ctx: ExtensionContext, message: string, type?: "info" | "warning" | "error") => {
+    if (ctx.hasUI) {
+      ctx.ui.notify(message, type);
+    }
+  };
+
+  const setWidget = (ctx: ExtensionContext, lines: string[] | undefined) => {
+    if (ctx.hasUI) {
+      ctx.ui.setWidget(WIDGET_KEY, lines);
+    }
+  };
+
+  const clearWidgetTimer = () => {
+    if (widgetTimer) {
+      clearTimeout(widgetTimer);
+      widgetTimer = null;
+    }
+  };
+
+  const finishRun = (ctx: ExtensionContext, run: ActiveRun, result: WorkflowRunResult) => {
+    if (activeRun === run) {
+      activeRun = null;
+    }
+    const { state } = result;
+    setWidget(ctx, buildWidgetLines(state, run.snapshot));
+    clearWidgetTimer();
+    widgetTimer = setTimeout(() => setWidget(ctx, undefined), FINAL_WIDGET_TTL_MS);
+    widgetTimer.unref?.();
+    const summary = `Workflow ${state.workflowName} ${state.status} (run ${state.runId})`;
+    notify(ctx, summary, state.status === "completed" ? "info" : "warning");
+  };
+
+  const startRun = async (ctx: ExtensionCommandContext, ref: string, input: unknown) => {
+    if (activeRun) {
+      notify(
+        ctx,
+        `A workflow is already running: ${activeRun.workflowName}. Use /workflow cancel first.`,
+        "error",
+      );
+      return;
+    }
+    const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd });
+    const workflow = await loadWorkflowFile(resolved.path);
+    const snapshot = createDefinitionSnapshot(workflow);
+
+    const executor = new ConversationStepExecutor({
+      sendPrompt: ({ prompt, streaming }) => {
+        pi.sendUserMessage(prompt, streaming ? { deliverAs: "steer" } : undefined);
+      },
+    });
+    const engine = new WorkflowEngine({
+      executor,
+      onEvent: (_event, state: WorkflowRunState) => {
+        if (run.runId === null) {
+          run.runId = state.runId;
+        }
+        setWidget(ctx, buildWidgetLines(state, snapshot));
+      },
+    });
+    const run: ActiveRun = { runId: null, workflowName: workflow.name, engine, executor, snapshot };
+    activeRun = run;
+    clearWidgetTimer();
+    notify(ctx, `Workflow ${workflow.name} started. Follow it live with: pi-workflows view`);
+
+    engine
+      .run(workflow, input, { workflowPath: resolved.path })
+      .then((result) => finishRun(ctx, run, result))
+      .catch((error: unknown) => {
+        if (activeRun === run) {
+          activeRun = null;
+        }
+        setWidget(ctx, undefined);
+        notify(ctx, `Workflow ${workflow.name} crashed: ${errorMessage(error)}`, "error");
+      });
+  };
+
+  const listWorkflows = async (ctx: ExtensionCommandContext) => {
+    const discovered = await discoverWorkflows({ cwd: ctx.cwd });
+    if (discovered.length === 0) {
+      notify(
+        ctx,
+        "No workflows found. Put *.workflow.ts files in .pi/workflows/ or ~/.pi/agent/workflows/, or pass a path.",
+        "warning",
+      );
+      return;
+    }
+    const names = discovered.map((workflow) => `${workflow.name} (${workflow.source})`).join(", ");
+    notify(ctx, `Workflows: ${names}. Run one with /workflow <name> [task].`);
+  };
+
+  pi.registerCommand("workflow", {
+    description:
+      "Run a workflow: /workflow <name-or-path> [task | --input-json {…}], /workflow cancel",
+    getArgumentCompletions: async (prefix: string) => {
+      const discovered = await discoverWorkflows({ cwd: process.cwd() });
+      const items = [
+        ...discovered.map((workflow) => ({ value: workflow.name, label: workflow.name })),
+        { value: "cancel", label: "cancel" },
+      ].filter((item) => item.value.startsWith(prefix));
+      return items.length > 0 ? items : null;
+    },
+    handler: async (args, ctx) => {
+      let parsed: ParsedWorkflowArgs;
+      try {
+        parsed = parseWorkflowArgs(args);
+      } catch (error) {
+        notify(ctx, errorMessage(error), "error");
+        return;
+      }
+      if (parsed.kind === "list") {
+        await listWorkflows(ctx);
+        return;
+      }
+      if (parsed.kind === "cancel") {
+        if (!activeRun) {
+          notify(ctx, "No workflow is running.", "warning");
+          return;
+        }
+        activeRun.engine.cancel();
+        notify(ctx, `Cancelling workflow ${activeRun.workflowName}…`);
+        return;
+      }
+      try {
+        await startRun(ctx, parsed.ref, parsed.input);
+      } catch (error) {
+        notify(ctx, `Could not start workflow: ${errorMessage(error)}`, "error");
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "workflow",
+    label: "Workflow",
+    description: [
+      "Submit the output for the pending workflow step.",
+      "Only call this tool when a workflow step contract in the conversation asks you to.",
+      "Pass the exact step id from the contract and your result as the output.",
+    ].join(" "),
+    parameters: Type.Object({
+      step: Type.String({ description: "The step id from the workflow step contract" }),
+      output: Type.Unknown({ description: "The step output, matching the expected output shape" }),
+    }),
+    async execute(_toolCallId, params) {
+      if (!activeRun) {
+        throw new Error(
+          "No workflow is running. Do not call the workflow tool outside a workflow.",
+        );
+      }
+      const result = await activeRun.executor.submit(params.step, params.output);
+      if (!result.accepted) {
+        throw new Error(result.message);
+      }
+      return {
+        content: [{ type: "text", text: result.message }],
+        details: { step: params.step, accepted: true },
+      };
+    },
+  });
+
+  pi.on("agent_start", () => {
+    activeRun?.executor.setStreaming(true);
+  });
+
+  pi.on("agent_settled", () => {
+    if (!activeRun) {
+      return;
+    }
+    activeRun.executor.setStreaming(false);
+    activeRun.executor.handleAgentSettled();
+  });
+
+  pi.on("session_shutdown", () => {
+    activeRun?.engine.cancel();
+    activeRun = null;
+    clearWidgetTimer();
+  });
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -198,6 +198,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     ].join(" "),
     parameters: Type.Object({
       step: Type.String({ description: "The step id from the workflow step contract" }),
+      attempt: Type.String({ description: "The attempt id from the workflow step contract" }),
       output: Type.Unknown({ description: "The step output, matching the expected output shape" }),
     }),
     async execute(_toolCallId, params) {
@@ -206,7 +207,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           "No workflow is running. Do not call the workflow tool outside a workflow.",
         );
       }
-      const result = await activeRun.executor.submit(params.step, params.output);
+      const result = await activeRun.executor.submit(params.step, params.attempt, params.output);
       if (!result.accepted) {
         throw new Error(result.message);
       }

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -1,3 +1,4 @@
+import { sanitizeText } from "../workflows/text.js";
 import type {
   WorkflowDefinitionSnapshot,
   WorkflowRunState,
@@ -41,19 +42,23 @@ export function buildWidgetLines(
   snapshot: WorkflowDefinitionSnapshot,
 ): string[] {
   const glyph = STATUS_GLYPHS[state.status];
-  const title = state.runTitle ? ` — ${state.runTitle}` : "";
-  const header = `${glyph} workflow ${state.workflowName}${title} [${state.status}]`;
+  // Titles, status details, and errors can carry model- or shell-controlled
+  // text; never let escape sequences or newlines reach the terminal.
+  const title = state.runTitle ? ` — ${sanitizeText(state.runTitle)}` : "";
+  const header = `${glyph} workflow ${sanitizeText(state.workflowName)}${title} [${state.status}]`;
 
   const nodes = displayNodeIds(snapshot).map((nodeId) => {
     const marker = nodeGlyph(state, nodeId);
     const detail =
-      state.currentNode === nodeId && state.statusDetail ? ` (${state.statusDetail})` : "";
+      state.currentNode === nodeId && state.statusDetail
+        ? ` (${sanitizeText(state.statusDetail)})`
+        : "";
     return `${marker} ${nodeId}${detail}`;
   });
 
   const lines = [header, `  ${nodes.join("  ")}`];
   if (state.error) {
-    lines.push(`  error: ${truncate(state.error, 120)}`);
+    lines.push(`  error: ${truncate(sanitizeText(state.error), 120)}`);
   }
   if (state.status === "waiting" && state.waitingOn) {
     lines.push(`  waiting on checkpoint: ${state.waitingOn}`);

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -1,0 +1,66 @@
+import type {
+  WorkflowDefinitionSnapshot,
+  WorkflowRunState,
+  WorkflowRunStatus,
+} from "../workflows/types.js";
+
+const STATUS_GLYPHS: Record<WorkflowRunStatus, string> = {
+  running: "◐",
+  waiting: "⏸",
+  completed: "✓",
+  failed: "✗",
+  timed_out: "✗",
+  cancelled: "✗",
+};
+
+export function nodeGlyph(state: WorkflowRunState, nodeId: string): string {
+  if (state.currentNode === nodeId) {
+    return "◐";
+  }
+  const result = state.results[nodeId];
+  if (!result) {
+    return "·";
+  }
+  if (state.waitingOn === nodeId) {
+    return "⏸";
+  }
+  return result.outcome === "ok" ? "✓" : "✗";
+}
+
+/** Node ids in a stable display order: definition order from the snapshot. */
+export function displayNodeIds(snapshot: WorkflowDefinitionSnapshot): string[] {
+  return Object.keys(snapshot.nodes);
+}
+
+/**
+ * Compact live-progress lines for the in-pi widget. Pure so it can be tested
+ * without a TUI.
+ */
+export function buildWidgetLines(
+  state: WorkflowRunState,
+  snapshot: WorkflowDefinitionSnapshot,
+): string[] {
+  const glyph = STATUS_GLYPHS[state.status];
+  const title = state.runTitle ? ` — ${state.runTitle}` : "";
+  const header = `${glyph} workflow ${state.workflowName}${title} [${state.status}]`;
+
+  const nodes = displayNodeIds(snapshot).map((nodeId) => {
+    const marker = nodeGlyph(state, nodeId);
+    const detail =
+      state.currentNode === nodeId && state.statusDetail ? ` (${state.statusDetail})` : "";
+    return `${marker} ${nodeId}${detail}`;
+  });
+
+  const lines = [header, `  ${nodes.join("  ")}`];
+  if (state.error) {
+    lines.push(`  error: ${truncate(state.error, 120)}`);
+  }
+  if (state.status === "waiting" && state.waitingOn) {
+    lines.push(`  waiting on checkpoint: ${state.waitingOn}`);
+  }
+  return lines;
+}
+
+function truncate(text: string, maxLength: number): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
+}

--- a/src/viewer/ansi.ts
+++ b/src/viewer/ansi.ts
@@ -1,0 +1,49 @@
+const COLOR_ENABLED =
+  process.env.NO_COLOR === undefined && process.env.PI_WORKFLOWS_NO_COLOR === undefined;
+
+function wrap(code: string, text: string): string {
+  return COLOR_ENABLED ? `\u001b[${code}m${text}\u001b[0m` : text;
+}
+
+export const ansi = {
+  bold: (text: string) => wrap("1", text),
+  dim: (text: string) => wrap("2", text),
+  red: (text: string) => wrap("31", text),
+  green: (text: string) => wrap("32", text),
+  yellow: (text: string) => wrap("33", text),
+  blue: (text: string) => wrap("34", text),
+  magenta: (text: string) => wrap("35", text),
+  cyan: (text: string) => wrap("36", text),
+};
+
+/** Visible length of a string, ignoring ANSI escape sequences. */
+export function visibleLength(text: string): number {
+  return stripAnsi(text).length;
+}
+
+export function stripAnsi(text: string): string {
+  let result = "";
+  let index = 0;
+  while (index < text.length) {
+    if (text[index] === "\u001b" && text[index + 1] === "[") {
+      index += 2;
+      while (index < text.length && !/[A-Za-z]/.test(text[index] as string)) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += text[index];
+    index += 1;
+  }
+  return result;
+}
+
+/** Truncate to a visible width, keeping ANSI sequences intact by stripping them first when needed. */
+export function fitWidth(text: string, width: number): string {
+  if (visibleLength(text) <= width) {
+    return text;
+  }
+  const plain = stripAnsi(text);
+  return width <= 1 ? plain.slice(0, width) : `${plain.slice(0, width - 1)}…`;
+}

--- a/src/viewer/ansi.ts
+++ b/src/viewer/ansi.ts
@@ -39,6 +39,15 @@ export function stripAnsi(text: string): string {
   return result;
 }
 
+/**
+ * Remove ANSI escapes and control characters from untrusted text (model
+ * outputs, errors) so rendering it cannot alter terminal state.
+ */
+export function sanitizeText(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return stripAnsi(text).replaceAll(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "");
+}
+
 /** Truncate to a visible width, keeping ANSI sequences intact by stripping them first when needed. */
 export function fitWidth(text: string, width: number): string {
   if (visibleLength(text) <= width) {

--- a/src/viewer/ansi.ts
+++ b/src/viewer/ansi.ts
@@ -53,11 +53,18 @@ export function stripAnsi(text: string): string {
 
 /**
  * Remove ANSI escapes and control characters from untrusted text (model
- * outputs, errors) so rendering it cannot alter terminal state.
+ * outputs, errors) so rendering it cannot alter terminal state. Line breaks
+ * and tabs collapse to single spaces because callers interpolate the result
+ * into single terminal lines, where a stray newline would break viewport
+ * math and allow fake rows.
  */
 export function sanitizeText(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return stripAnsi(text).replaceAll(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "");
+  return (
+    stripAnsi(text)
+      .replaceAll(/[\t\n\r]+/g, " ")
+      // eslint-disable-next-line no-control-regex
+      .replaceAll(/[\u0000-\u001f\u007f]/g, "")
+  );
 }
 
 /** Truncate to a visible width, keeping ANSI sequences intact by stripping them first when needed. */

--- a/src/viewer/ansi.ts
+++ b/src/viewer/ansi.ts
@@ -1,8 +1,20 @@
-const COLOR_ENABLED =
-  process.env.NO_COLOR === undefined && process.env.PI_WORKFLOWS_NO_COLOR === undefined;
+/**
+ * Colors are on for interactive terminals only, so piped output stays clean.
+ * `NO_COLOR`/`PI_WORKFLOWS_NO_COLOR` force them off; `FORCE_COLOR` forces
+ * them on. Evaluated per call so env changes (tests) take effect.
+ */
+function colorEnabled(): boolean {
+  if (process.env.NO_COLOR !== undefined || process.env.PI_WORKFLOWS_NO_COLOR !== undefined) {
+    return false;
+  }
+  if (process.env.FORCE_COLOR !== undefined) {
+    return true;
+  }
+  return process.stdout.isTTY === true;
+}
 
 function wrap(code: string, text: string): string {
-  return COLOR_ENABLED ? `\u001b[${code}m${text}\u001b[0m` : text;
+  return colorEnabled() ? `\u001b[${code}m${text}\u001b[0m` : text;
 }
 
 export const ansi = {

--- a/src/viewer/ansi.ts
+++ b/src/viewer/ansi.ts
@@ -1,3 +1,7 @@
+import { sanitizeText, stripAnsi } from "../workflows/text.js";
+
+export { sanitizeText, stripAnsi };
+
 /**
  * Colors are on for interactive terminals only, so piped output stays clean.
  * `NO_COLOR`/`PI_WORKFLOWS_NO_COLOR` force them off; `FORCE_COLOR` forces
@@ -31,40 +35,6 @@ export const ansi = {
 /** Visible length of a string, ignoring ANSI escape sequences. */
 export function visibleLength(text: string): number {
   return stripAnsi(text).length;
-}
-
-export function stripAnsi(text: string): string {
-  let result = "";
-  let index = 0;
-  while (index < text.length) {
-    if (text[index] === "\u001b" && text[index + 1] === "[") {
-      index += 2;
-      while (index < text.length && !/[A-Za-z]/.test(text[index] as string)) {
-        index += 1;
-      }
-      index += 1;
-      continue;
-    }
-    result += text[index];
-    index += 1;
-  }
-  return result;
-}
-
-/**
- * Remove ANSI escapes and control characters from untrusted text (model
- * outputs, errors) so rendering it cannot alter terminal state. Line breaks
- * and tabs collapse to single spaces because callers interpolate the result
- * into single terminal lines, where a stray newline would break viewport
- * math and allow fake rows.
- */
-export function sanitizeText(text: string): string {
-  return (
-    stripAnsi(text)
-      .replaceAll(/[\t\n\r]+/g, " ")
-      // eslint-disable-next-line no-control-regex
-      .replaceAll(/[\u0000-\u001f\u007f]/g, "")
-  );
 }
 
 /** Truncate to a visible width, keeping ANSI sequences intact by stripping them first when needed. */

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
 import { listRunBundles, readRunBundle, workflowRunsBaseDir } from "../workflows/store.js";
+import { sanitizeText } from "./ansi.js";
 import {
   formatDuration,
   renderRunDetailLines,
@@ -68,9 +69,10 @@ async function printRuns(dir: string): Promise<void> {
   }
   for (const bundle of bundles) {
     const state = bundle.state;
-    const title = state.runTitle ? ` — ${state.runTitle}` : "";
+    // Titles can interpolate untrusted run input; strip control sequences.
+    const title = state.runTitle ? ` — ${sanitizeText(state.runTitle)}` : "";
     process.stdout.write(
-      `${statusLabel(state.status)}  ${state.workflowName}${title}  ${state.runId}  ${formatDuration(
+      `${statusLabel(state.status)}  ${sanitizeText(state.workflowName)}${title}  ${state.runId}  ${formatDuration(
         runElapsedMs(state),
       )}\n`,
     );

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+import { listRunBundles, readRunBundle, workflowRunsBaseDir } from "../workflows/store.js";
+import {
+  formatDuration,
+  renderRunDetailLines,
+  renderRunListLines,
+  runElapsedMs,
+  statusLabel,
+} from "./render.js";
+import { runViewer } from "./tui.js";
+
+const USAGE = `pi-workflows — live terminal viewer for pi workflow runs
+
+Usage:
+  pi-workflows view [runId] [--dir <runsDir>] [--once]
+  pi-workflows runs [--dir <runsDir>]
+
+Commands:
+  view   Open the live TUI viewer. With --once, print a snapshot and exit.
+  runs   List recent workflow runs.
+
+Options:
+  --dir <runsDir>   Runs directory (default: ~/.pi/agent/workflows/runs)
+  --once            Render once to stdout without the interactive TUI
+`;
+
+type CliArgs = {
+  command: string;
+  runId?: string | undefined;
+  dir: string;
+  once: boolean;
+};
+
+export function parseCliArgs(argv: string[]): CliArgs {
+  const args = [...argv];
+  const command = args[0] && !args[0].startsWith("-") ? (args.shift() as string) : "view";
+  let dir = workflowRunsBaseDir();
+  let once = false;
+  let runId: string | undefined;
+
+  while (args.length > 0) {
+    const arg = args.shift() as string;
+    if (arg === "--dir") {
+      const value = args.shift();
+      if (!value) {
+        throw new Error("--dir requires a path");
+      }
+      dir = value;
+    } else if (arg === "--once") {
+      once = true;
+    } else if (arg === "--help" || arg === "-h") {
+      return { command: "help", dir, once };
+    } else if (!arg.startsWith("-") && runId === undefined) {
+      runId = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { command, runId, dir, once };
+}
+
+async function printRuns(dir: string): Promise<void> {
+  const bundles = await listRunBundles(dir);
+  if (bundles.length === 0) {
+    process.stdout.write(`No workflow runs found in ${dir}\n`);
+    return;
+  }
+  for (const bundle of bundles) {
+    const state = bundle.state;
+    const title = state.runTitle ? ` — ${state.runTitle}` : "";
+    process.stdout.write(
+      `${statusLabel(state.status)}  ${state.workflowName}${title}  ${state.runId}  ${formatDuration(
+        runElapsedMs(state),
+      )}\n`,
+    );
+  }
+}
+
+async function printOnce(dir: string, runId: string | undefined): Promise<void> {
+  const bundles = await listRunBundles(dir);
+  const size = { width: process.stdout.columns ?? 100, height: 1_000 };
+  if (runId === undefined) {
+    process.stdout.write(`${renderRunListLines(bundles, 0, size).join("\n")}\n`);
+    return;
+  }
+  const match = bundles.find((bundle) => bundle.state.runId === runId);
+  if (!match) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+  const bundle = await readRunBundle(match.runDir);
+  if (!bundle) {
+    throw new Error(`Run bundle unreadable: ${match.runDir}`);
+  }
+  process.stdout.write(`${renderRunDetailLines(bundle, size).join("\n")}\n`);
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  let args: CliArgs;
+  try {
+    args = parseCliArgs(argv);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n\n${USAGE}`);
+    return 2;
+  }
+
+  try {
+    if (args.command === "help") {
+      process.stdout.write(USAGE);
+      return 0;
+    }
+    if (args.command === "runs") {
+      await printRuns(args.dir);
+      return 0;
+    }
+    if (args.command === "view") {
+      if (args.once || !process.stdout.isTTY) {
+        await printOnce(args.dir, args.runId);
+        return 0;
+      }
+      await runViewer({ runsDir: args.dir, runId: args.runId });
+      return 0;
+    }
+    process.stderr.write(`Unknown command: ${args.command}\n\n${USAGE}`);
+    return 2;
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+const entryPath = process.argv[1];
+if (entryPath !== undefined && import.meta.url === pathToFileURL(entryPath).href) {
+  main().then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/src/viewer/render.ts
+++ b/src/viewer/render.ts
@@ -4,7 +4,7 @@ import type {
   WorkflowRunStatus,
   WorkflowStepRecord,
 } from "../workflows/types.js";
-import { ansi, fitWidth } from "./ansi.js";
+import { ansi, fitWidth, sanitizeText } from "./ansi.js";
 
 export type ViewportSize = {
   width: number;
@@ -47,7 +47,10 @@ function previewValue(value: unknown, maxLength: number): string {
     return "";
   }
   const text = typeof value === "string" ? value : JSON.stringify(value);
-  const singleLine = (text ?? "").replaceAll(/\s+/g, " ").trim();
+  // Model-controlled values must not carry escape sequences into the terminal.
+  const singleLine = sanitizeText(text ?? "")
+    .replaceAll(/\s+/g, " ")
+    .trim();
   return singleLine.length <= maxLength ? singleLine : `${singleLine.slice(0, maxLength - 1)}…`;
 }
 
@@ -76,7 +79,7 @@ export function renderRunListLines(
     const state = bundle.state;
     const marker = index === selectedIndex ? ansi.cyan("›") : " ";
     const elapsed = formatDuration(runElapsedMs(state, now));
-    const title = state.runTitle ? ` — ${state.runTitle}` : "";
+    const title = state.runTitle ? ` — ${sanitizeText(state.runTitle)}` : "";
     lines.push(
       fitWidth(
         `${marker} ${statusLabel(state.status)}  ${ansi.bold(state.workflowName)}${title}  ${ansi.dim(
@@ -132,7 +135,7 @@ export function renderRunDetailLines(
 ): string[] {
   const state = bundle.state;
   const lines: string[] = [];
-  const title = state.runTitle ? ` — ${state.runTitle}` : "";
+  const title = state.runTitle ? ` — ${sanitizeText(state.runTitle)}` : "";
   lines.push(fitWidth(`${ansi.bold(`workflow ${state.workflowName}`)}${title}`, size.width));
   lines.push(
     fitWidth(
@@ -159,7 +162,7 @@ export function renderRunDetailLines(
 
   if (state.error) {
     lines.push("");
-    lines.push(fitWidth(ansi.red(`error: ${state.error}`), size.width));
+    lines.push(fitWidth(ansi.red(`error: ${sanitizeText(state.error)}`), size.width));
   }
   if (state.status === "completed" && state.finalOutput !== undefined) {
     lines.push("");

--- a/src/viewer/render.ts
+++ b/src/viewer/render.ts
@@ -1,0 +1,174 @@
+import type { LoadedRunBundle } from "../workflows/store.js";
+import type {
+  WorkflowRunState,
+  WorkflowRunStatus,
+  WorkflowStepRecord,
+} from "../workflows/types.js";
+import { ansi, fitWidth } from "./ansi.js";
+
+export type ViewportSize = {
+  width: number;
+  height: number;
+};
+
+const STATUS_COLORS: Record<WorkflowRunStatus, (text: string) => string> = {
+  running: ansi.cyan,
+  waiting: ansi.yellow,
+  completed: ansi.green,
+  failed: ansi.red,
+  timed_out: ansi.red,
+  cancelled: ansi.yellow,
+};
+
+export function statusLabel(status: WorkflowRunStatus): string {
+  return STATUS_COLORS[status](status);
+}
+
+export function formatDuration(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return `${Math.max(durationMs, 0)}ms`;
+  }
+  const seconds = durationMs / 1_000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return `${minutes}m${rest.toString().padStart(2, "0")}s`;
+}
+
+export function runElapsedMs(state: WorkflowRunState, now: Date = new Date()): number {
+  const end = state.finishedAt ? Date.parse(state.finishedAt) : now.getTime();
+  return Math.max(0, end - Date.parse(state.startedAt));
+}
+
+function previewValue(value: unknown, maxLength: number): string {
+  if (value === undefined) {
+    return "";
+  }
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  const singleLine = (text ?? "").replaceAll(/\s+/g, " ").trim();
+  return singleLine.length <= maxLength ? singleLine : `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+/** One line per run for the run picker. */
+export function renderRunListLines(
+  bundles: LoadedRunBundle[],
+  selectedIndex: number,
+  size: ViewportSize,
+  now: Date = new Date(),
+): string[] {
+  const lines: string[] = [];
+  lines.push(ansi.bold("pi-workflows — runs"));
+  lines.push(ansi.dim("↑/↓ select · enter open · q quit"));
+  lines.push("");
+  if (bundles.length === 0) {
+    lines.push(ansi.dim("No workflow runs found."));
+    return lines.map((line) => fitWidth(line, size.width));
+  }
+  const visible = Math.max(1, size.height - lines.length - 1);
+  const start = Math.min(
+    Math.max(0, selectedIndex - Math.floor(visible / 2)),
+    Math.max(0, bundles.length - visible),
+  );
+  for (const [offset, bundle] of bundles.slice(start, start + visible).entries()) {
+    const index = start + offset;
+    const state = bundle.state;
+    const marker = index === selectedIndex ? ansi.cyan("›") : " ";
+    const elapsed = formatDuration(runElapsedMs(state, now));
+    const title = state.runTitle ? ` — ${state.runTitle}` : "";
+    lines.push(
+      fitWidth(
+        `${marker} ${statusLabel(state.status)}  ${ansi.bold(state.workflowName)}${title}  ${ansi.dim(
+          `${state.runId} · ${elapsed}`,
+        )}`,
+        size.width,
+      ),
+    );
+  }
+  return lines;
+}
+
+function stepLine(step: WorkflowStepRecord, width: number): string {
+  const durationMs = Date.parse(step.finishedAt) - Date.parse(step.startedAt);
+  const glyph = step.outcome === "ok" ? ansi.green("✓") : ansi.red("✗");
+  const preview =
+    step.error !== undefined
+      ? ansi.red(previewValue(step.error, 60))
+      : ansi.dim(previewValue(step.output, 60));
+  return fitWidth(
+    `  ${glyph} ${step.nodeId} ${ansi.dim(`(${step.nodeType}, ${formatDuration(durationMs)})`)} ${preview}`,
+    width,
+  );
+}
+
+function nodeStatusLine(bundle: LoadedRunBundle, nodeId: string, width: number, now: Date): string {
+  const state = bundle.state;
+  const nodeType = bundle.snapshot?.nodes[nodeId]?.nodeType ?? "?";
+  const result = state.results[nodeId];
+  let glyph = ansi.dim("·");
+  let suffix = "";
+  if (state.currentNode === nodeId) {
+    glyph = ansi.cyan("◐");
+    const startedAt = state.currentNodeStartedAt
+      ? Date.parse(state.currentNodeStartedAt)
+      : now.getTime();
+    suffix = ansi.cyan(` running ${formatDuration(now.getTime() - startedAt)}`);
+  } else if (state.waitingOn === nodeId) {
+    glyph = ansi.yellow("⏸");
+    suffix = ansi.yellow(" waiting");
+  } else if (result) {
+    glyph = result.outcome === "ok" ? ansi.green("✓") : ansi.red("✗");
+    suffix = ansi.dim(` ${formatDuration(result.durationMs)}`);
+  }
+  return fitWidth(`  ${glyph} ${nodeId} ${ansi.dim(`[${nodeType}]`)}${suffix}`, width);
+}
+
+/** Full-run detail view. */
+export function renderRunDetailLines(
+  bundle: LoadedRunBundle,
+  size: ViewportSize,
+  now: Date = new Date(),
+): string[] {
+  const state = bundle.state;
+  const lines: string[] = [];
+  const title = state.runTitle ? ` — ${state.runTitle}` : "";
+  lines.push(fitWidth(`${ansi.bold(`workflow ${state.workflowName}`)}${title}`, size.width));
+  lines.push(
+    fitWidth(
+      `${statusLabel(state.status)} · run ${state.runId} · elapsed ${formatDuration(runElapsedMs(state, now))}`,
+      size.width,
+    ),
+  );
+  lines.push(ansi.dim("q back · r refresh"));
+  lines.push("");
+
+  lines.push(ansi.bold("nodes"));
+  const nodeIds = bundle.snapshot ? Object.keys(bundle.snapshot.nodes) : Object.keys(state.results);
+  for (const nodeId of nodeIds) {
+    lines.push(nodeStatusLine(bundle, nodeId, size.width, now));
+  }
+
+  if (state.steps.length > 0) {
+    lines.push("");
+    lines.push(ansi.bold("steps"));
+    for (const step of state.steps) {
+      lines.push(stepLine(step, size.width));
+    }
+  }
+
+  if (state.error) {
+    lines.push("");
+    lines.push(fitWidth(ansi.red(`error: ${state.error}`), size.width));
+  }
+  if (state.status === "completed" && state.finalOutput !== undefined) {
+    lines.push("");
+    lines.push(
+      fitWidth(
+        `${ansi.bold("output")} ${previewValue(state.finalOutput, size.width - 8)}`,
+        size.width,
+      ),
+    );
+  }
+  return lines.slice(0, size.height);
+}

--- a/src/viewer/render.ts
+++ b/src/viewer/render.ts
@@ -116,7 +116,8 @@ function nodeStatusLine(bundle: LoadedRunBundle, nodeId: string, width: number, 
     const startedAt = state.currentNodeStartedAt
       ? Date.parse(state.currentNodeStartedAt)
       : now.getTime();
-    suffix = ansi.cyan(` running ${formatDuration(now.getTime() - startedAt)}`);
+    const detail = state.statusDetail ? ` · ${sanitizeText(state.statusDetail)}` : "";
+    suffix = ansi.cyan(` running ${formatDuration(now.getTime() - startedAt)}${detail}`);
   } else if (state.waitingOn === nodeId) {
     glyph = ansi.yellow("⏸");
     suffix = ansi.yellow(" waiting");
@@ -127,11 +128,15 @@ function nodeStatusLine(bundle: LoadedRunBundle, nodeId: string, width: number, 
   return fitWidth(`  ${glyph} ${nodeId} ${ansi.dim(`[${nodeType}]`)}${suffix}`, width);
 }
 
-/** Full-run detail view. */
+/**
+ * Full-run detail view. `scroll` shifts the viewport down over the full body
+ * so long runs stay explorable; it is clamped to the content height.
+ */
 export function renderRunDetailLines(
   bundle: LoadedRunBundle,
   size: ViewportSize,
   now: Date = new Date(),
+  scroll = 0,
 ): string[] {
   const state = bundle.state;
   const lines: string[] = [];
@@ -143,7 +148,7 @@ export function renderRunDetailLines(
       size.width,
     ),
   );
-  lines.push(ansi.dim("q back · r refresh"));
+  lines.push(ansi.dim("q back · r refresh · ↑/↓ scroll"));
   lines.push("");
 
   lines.push(ansi.bold("nodes"));
@@ -173,5 +178,15 @@ export function renderRunDetailLines(
       ),
     );
   }
-  return lines.slice(0, size.height);
+  const start = Math.max(0, Math.min(scroll, lines.length - size.height));
+  return lines.slice(start, start + size.height);
+}
+
+/** Highest useful `scroll` value for the detail view of `bundle`. */
+export function maxDetailScroll(bundle: LoadedRunBundle, size: ViewportSize): number {
+  const total = renderRunDetailLines(bundle, {
+    width: size.width,
+    height: Number.MAX_SAFE_INTEGER,
+  }).length;
+  return Math.max(0, total - size.height);
 }

--- a/src/viewer/tui.ts
+++ b/src/viewer/tui.ts
@@ -1,0 +1,127 @@
+import { listRunBundles, readRunBundle } from "../workflows/store.js";
+import type { LoadedRunBundle } from "../workflows/store.js";
+import { renderRunDetailLines, renderRunListLines, type ViewportSize } from "./render.js";
+import { watchRunsDir } from "./watch.js";
+
+const ALT_SCREEN_ON = "\u001b[?1049h\u001b[?25l";
+const ALT_SCREEN_OFF = "\u001b[?25h\u001b[?1049l";
+const CLEAR = "\u001b[2J\u001b[H";
+
+type ViewerMode = { view: "list" } | { view: "detail"; runDir: string };
+
+export type ViewerOptions = {
+  runsDir: string;
+  runId?: string | undefined;
+  /** Redraw interval for elapsed timers while a run is active. */
+  tickMs?: number;
+};
+
+function viewportSize(): ViewportSize {
+  return {
+    width: process.stdout.columns ?? 80,
+    height: process.stdout.rows ?? 24,
+  };
+}
+
+/**
+ * Interactive live viewer. Watches the runs directory and re-renders as run
+ * bundles change on disk. Returns when the user quits.
+ */
+export async function runViewer(options: ViewerOptions): Promise<void> {
+  let mode: ViewerMode = { view: "list" };
+  let bundles: LoadedRunBundle[] = [];
+  let selectedIndex = 0;
+
+  if (options.runId) {
+    bundles = await listRunBundles(options.runsDir);
+    const match = bundles.find((bundle) => bundle.state.runId === options.runId);
+    if (!match) {
+      throw new Error(`Run not found: ${options.runId}`);
+    }
+    mode = { view: "detail", runDir: match.runDir };
+  }
+
+  const draw = async () => {
+    bundles = await listRunBundles(options.runsDir);
+    selectedIndex = Math.min(selectedIndex, Math.max(0, bundles.length - 1));
+    const size = viewportSize();
+    const lines =
+      mode.view === "list"
+        ? renderRunListLines(bundles, selectedIndex, size)
+        : await renderDetail(mode.runDir, size);
+    process.stdout.write(CLEAR + lines.join("\n"));
+  };
+
+  const renderDetail = async (runDir: string, size: ViewportSize): Promise<string[]> => {
+    const bundle = await readRunBundle(runDir);
+    if (!bundle) {
+      return ["Run bundle disappeared. Press q to go back."];
+    }
+    return renderRunDetailLines(bundle, size);
+  };
+
+  process.stdout.write(ALT_SCREEN_ON);
+  const stopWatching = watchRunsDir(options.runsDir, () => {
+    void draw();
+  });
+  const ticker = setInterval(() => {
+    void draw();
+  }, options.tickMs ?? 1_000);
+
+  const rawModeSupported = process.stdin.isTTY === true;
+  if (rawModeSupported) {
+    process.stdin.setRawMode(true);
+  }
+  process.stdin.resume();
+
+  try {
+    await new Promise<void>((resolve) => {
+      const onKey = (data: Buffer) => {
+        const key = data.toString("utf8");
+        if (key === "q" || key === "\u0003" || key === "\u001b") {
+          if (mode.view === "detail" && key === "q") {
+            mode = { view: "list" };
+            void draw();
+            return;
+          }
+          resolve();
+          return;
+        }
+        handleNavigationKey(key);
+      };
+
+      const handleNavigationKey = (key: string) => {
+        if (mode.view !== "list") {
+          if (key === "r") {
+            void draw();
+          }
+          return;
+        }
+        if (key === "\u001b[A" || key === "k") {
+          selectedIndex = Math.max(0, selectedIndex - 1);
+          void draw();
+        } else if (key === "\u001b[B" || key === "j") {
+          selectedIndex = Math.min(Math.max(0, bundles.length - 1), selectedIndex + 1);
+          void draw();
+        } else if (key === "\r" || key === "\n") {
+          const selected = bundles[selectedIndex];
+          if (selected) {
+            mode = { view: "detail", runDir: selected.runDir };
+            void draw();
+          }
+        }
+      };
+
+      process.stdin.on("data", onKey);
+      void draw();
+    });
+  } finally {
+    clearInterval(ticker);
+    stopWatching();
+    if (rawModeSupported) {
+      process.stdin.setRawMode(false);
+    }
+    process.stdin.pause();
+    process.stdout.write(ALT_SCREEN_OFF);
+  }
+}

--- a/src/viewer/tui.ts
+++ b/src/viewer/tui.ts
@@ -1,6 +1,11 @@
 import { listRunBundles, readRunBundle } from "../workflows/store.js";
 import type { LoadedRunBundle } from "../workflows/store.js";
-import { renderRunDetailLines, renderRunListLines, type ViewportSize } from "./render.js";
+import {
+  maxDetailScroll,
+  renderRunDetailLines,
+  renderRunListLines,
+  type ViewportSize,
+} from "./render.js";
 import { watchRunsDir } from "./watch.js";
 
 const ALT_SCREEN_ON = "\u001b[?1049h\u001b[?25l";
@@ -31,6 +36,7 @@ export async function runViewer(options: ViewerOptions): Promise<void> {
   let mode: ViewerMode = { view: "list" };
   let bundles: LoadedRunBundle[] = [];
   let selectedIndex = 0;
+  let detailScroll = 0;
 
   if (options.runId) {
     bundles = await listRunBundles(options.runsDir);
@@ -57,7 +63,8 @@ export async function runViewer(options: ViewerOptions): Promise<void> {
     if (!bundle) {
       return ["Run bundle disappeared. Press q to go back."];
     }
-    return renderRunDetailLines(bundle, size);
+    detailScroll = Math.min(detailScroll, maxDetailScroll(bundle, size));
+    return renderRunDetailLines(bundle, size, new Date(), detailScroll);
   };
 
   process.stdout.write(ALT_SCREEN_ON);
@@ -94,6 +101,13 @@ export async function runViewer(options: ViewerOptions): Promise<void> {
         if (mode.view !== "list") {
           if (key === "r") {
             void draw();
+          } else if (key === "\u001b[A" || key === "k") {
+            detailScroll = Math.max(0, detailScroll - 1);
+            void draw();
+          } else if (key === "\u001b[B" || key === "j") {
+            // Clamped against the content height in renderDetail.
+            detailScroll += 1;
+            void draw();
           }
           return;
         }
@@ -107,6 +121,7 @@ export async function runViewer(options: ViewerOptions): Promise<void> {
           const selected = bundles[selectedIndex];
           if (selected) {
             mode = { view: "detail", runDir: selected.runDir };
+            detailScroll = 0;
             void draw();
           }
         }

--- a/src/viewer/watch.ts
+++ b/src/viewer/watch.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+
+export type Unsubscribe = () => void;
+
+/**
+ * Watch a directory tree for changes with a polling fallback. `onChange` is
+ * debounced so bursts of writes trigger one refresh.
+ */
+export function watchRunsDir(
+  dir: string,
+  onChange: () => void,
+  options: { pollMs?: number; debounceMs?: number } = {},
+): Unsubscribe {
+  const pollMs = options.pollMs ?? 1_000;
+  const debounceMs = options.debounceMs ?? 80;
+  let debounceTimer: NodeJS.Timeout | null = null;
+  let closed = false;
+
+  const fire = () => {
+    if (closed) {
+      return;
+    }
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      onChange();
+    }, debounceMs);
+  };
+
+  let watcher: fs.FSWatcher | null = null;
+  try {
+    watcher = fs.watch(dir, { recursive: true }, fire);
+    watcher.on("error", () => {
+      watcher?.close();
+      watcher = null;
+    });
+  } catch {
+    watcher = null;
+  }
+
+  // Polling fallback covers platforms without recursive fs.watch and missed events.
+  const poller = setInterval(fire, pollMs);
+  poller.unref?.();
+
+  return () => {
+    closed = true;
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    clearInterval(poller);
+    watcher?.close();
+  };
+}

--- a/src/workflows/decision.ts
+++ b/src/workflows/decision.ts
@@ -1,0 +1,127 @@
+import { agent } from "./definition.js";
+import { extractJsonValue } from "./json.js";
+import type { AgentNodeDefinition, WorkflowEdge, WorkflowNodeContext } from "./types.js";
+
+const DEFAULT_FIELD = "route";
+const SIMPLE_FIELD_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// All `agent` node fields except the ones the decision helper owns.
+type DecisionAgentOptions = Omit<
+  AgentNodeDefinition,
+  "nodeType" | "prompt" | "expectedOutput" | "validate"
+>;
+
+export type DecisionDefinition<TChoice extends string> = DecisionAgentOptions & {
+  question: string | ((context: WorkflowNodeContext) => string | Promise<string>);
+  choices: readonly TChoice[];
+  field?: string;
+};
+
+/**
+ * Build an `agent` node that asks the model to pick one of `choices` and
+ * submit a JSON object whose chosen field is validated. Pair with
+ * `decisionEdge` (or any `switch` edge keyed on `$.<field>`) to route on the
+ * result.
+ */
+export function decision<TChoice extends string>(
+  definition: DecisionDefinition<TChoice>,
+): AgentNodeDefinition {
+  const { question, choices, field: fieldOverride, ...agentOptions } = definition;
+  const field = normalizeField(fieldOverride);
+  assertValidChoices(choices);
+  const allowed = new Set<string>(choices);
+  const allowedLabels = choices.map((choice) => JSON.stringify(choice)).join(" | ");
+
+  return agent({
+    ...agentOptions,
+    async prompt(context) {
+      const text = typeof question === "function" ? await question(context) : question;
+      return [
+        text,
+        "",
+        `Answer by picking exactly one of: ${allowedLabels}.`,
+        `Include a short "reason" alongside your choice.`,
+      ].join("\n");
+    },
+    expectedOutput: `{ ${JSON.stringify(field)}: ${allowedLabels}, "reason": "short justification" }`,
+    validate(output) {
+      const raw = normalizeDecisionOutput(output);
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+        throw new Error(`Decision output must be a JSON object, got ${describeValue(raw)}`);
+      }
+      const value = (raw as Record<string, unknown>)[field];
+      if (typeof value !== "string" || !allowed.has(value)) {
+        throw new Error(
+          `Decision returned invalid ${field}=${JSON.stringify(value)}; expected one of ${allowedLabels}`,
+        );
+      }
+      return raw;
+    },
+  });
+}
+
+/**
+ * Build the matching `switch` edge for a `decision` node. Typing `cases` as
+ * `Record<TChoice, string>` makes a missing case a compile error.
+ */
+export function decisionEdge<TChoice extends string>(args: {
+  from: string;
+  choices: readonly TChoice[];
+  field?: string;
+  cases: Record<TChoice, string>;
+}): WorkflowEdge {
+  const field = normalizeField(args.field);
+  assertValidChoices(args.choices);
+  for (const choice of args.choices) {
+    if (!Object.hasOwn(args.cases, choice)) {
+      throw new Error(`Decision edge is missing case for choice ${JSON.stringify(choice)}`);
+    }
+  }
+  return {
+    from: args.from,
+    switch: {
+      on: `$.${field}`,
+      cases: args.cases,
+    },
+  };
+}
+
+function normalizeDecisionOutput(output: unknown): unknown {
+  if (typeof output === "string") {
+    return extractJsonValue(output);
+  }
+  return output;
+}
+
+function describeValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  return Array.isArray(value) ? "array" : typeof value;
+}
+
+function assertValidChoices(choices: readonly string[]): void {
+  if (choices.length === 0) {
+    throw new Error("Decision choices must include at least one value");
+  }
+  const seen = new Set<string>();
+  for (const choice of choices) {
+    if (typeof choice !== "string" || choice.length === 0) {
+      throw new Error("Decision choices must be non-empty strings");
+    }
+    if (seen.has(choice)) {
+      throw new Error(`Decision choices must be unique; duplicate ${JSON.stringify(choice)}`);
+    }
+    seen.add(choice);
+  }
+}
+
+function normalizeField(fieldOverride: string | undefined): string {
+  const field = fieldOverride ?? DEFAULT_FIELD;
+  if (!SIMPLE_FIELD_PATTERN.test(field)) {
+    throw new Error(
+      `Decision field must be a simple JSON key matching ${SIMPLE_FIELD_PATTERN.source}`,
+    );
+  }
+  return field;
+}

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -1,0 +1,104 @@
+import {
+  assertValidAgentNode,
+  assertValidActionNode,
+  assertValidCheckpointNode,
+  assertValidComputeNode,
+  assertValidShellActionNode,
+  assertValidWorkflowDefinitionShape,
+} from "./schema.js";
+import type {
+  AgentNodeDefinition,
+  ActionNodeDefinition,
+  CheckpointNodeDefinition,
+  ComputeNodeDefinition,
+  FunctionActionNodeDefinition,
+  ShellActionNodeDefinition,
+  WorkflowDefinition,
+} from "./types.js";
+
+const WORKFLOW_DEFINITION_BRAND = Symbol.for("pi-workflows.definition");
+
+export function defineWorkflow<TWorkflow extends WorkflowDefinition>(
+  definition: TWorkflow,
+): TWorkflow {
+  assertValidWorkflowDefinitionShape(definition);
+  if (isWorkflowDefinition(definition)) {
+    return definition;
+  }
+  Object.defineProperty(definition, WORKFLOW_DEFINITION_BRAND, {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return definition;
+}
+
+export function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as Record<PropertyKey, unknown>)[WORKFLOW_DEFINITION_BRAND] === true
+  );
+}
+
+export function agent(definition: Omit<AgentNodeDefinition, "nodeType">): AgentNodeDefinition {
+  const node: AgentNodeDefinition = {
+    nodeType: "agent",
+    ...definition,
+  };
+  assertValidAgentNode(node);
+  return node;
+}
+
+export function compute(
+  definition: Omit<ComputeNodeDefinition, "nodeType">,
+): ComputeNodeDefinition {
+  const node: ComputeNodeDefinition = {
+    nodeType: "compute",
+    ...definition,
+  };
+  assertValidComputeNode(node);
+  return node;
+}
+
+export function action(
+  definition: Omit<FunctionActionNodeDefinition, "nodeType">,
+): FunctionActionNodeDefinition;
+export function action(
+  definition: Omit<ShellActionNodeDefinition, "nodeType">,
+): ShellActionNodeDefinition;
+export function action(
+  definition:
+    | Omit<FunctionActionNodeDefinition, "nodeType">
+    | Omit<ShellActionNodeDefinition, "nodeType">,
+): ActionNodeDefinition {
+  const node: ActionNodeDefinition = {
+    nodeType: "action",
+    ...definition,
+  };
+  assertValidActionNode(node);
+  return node;
+}
+
+export function shell(
+  definition: Omit<ShellActionNodeDefinition, "nodeType">,
+): ShellActionNodeDefinition {
+  const node: ShellActionNodeDefinition = {
+    nodeType: "action",
+    ...definition,
+  };
+  assertValidShellActionNode(node);
+  return node;
+}
+
+export function checkpoint(
+  definition: Omit<CheckpointNodeDefinition, "nodeType"> = {},
+): CheckpointNodeDefinition {
+  const node: CheckpointNodeDefinition = {
+    nodeType: "checkpoint",
+    ...definition,
+  };
+  assertValidCheckpointNode(node);
+  return node;
+}

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -483,6 +483,12 @@ export class WorkflowEngine {
     meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
     const basePrompt = await node.prompt(context);
+    if (signal.aborted) {
+      // The node timed out or the run was cancelled while the async prompt
+      // builder ran; a late continuation must not write into a bundle that
+      // may already be terminal.
+      throw abortError(signal);
+    }
     const prompt = appendStepContract(
       basePrompt,
       workflow.name,
@@ -636,11 +642,16 @@ async function runShellActionNode(
 }
 
 /** Rejects with the abort reason once the signal fires; never resolves. */
+/** The error carried by an aborted signal, normalized to an Error. */
+function abortError(signal: AbortSignal): Error {
+  const reason: unknown = signal.reason ?? new CancelledError();
+  return reason instanceof Error ? reason : new CancelledError(String(reason));
+}
+
 function abortRejection(signal: AbortSignal): Promise<never> {
   return new Promise<never>((_resolve, reject) => {
     const onAbort = () => {
-      const reason: unknown = signal.reason ?? new CancelledError();
-      reject(reason instanceof Error ? reason : new CancelledError(String(reason)));
+      reject(abortError(signal));
     };
     if (signal.aborted) {
       onAbort();

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -340,6 +340,11 @@ export class WorkflowEngine {
         this.dispatchNode(workflow, state, runDir, nodeId, attemptId, node, abort.signal),
         abortRejection(abort.signal),
       ]);
+      if (execution.output === undefined) {
+        // JSON cannot represent undefined; normalize so the in-memory state
+        // matches what the persisted bundle round-trips to.
+        execution.output = null;
+      }
       assertJsonSerializable(execution.output, nodeId);
       return execution;
     } catch (error) {
@@ -360,7 +365,7 @@ export class WorkflowEngine {
     node: WorkflowNodeDefinition,
     signal: AbortSignal,
   ): Promise<NodeExecution> {
-    const context = this.createNodeContext(state);
+    const context = this.createNodeContext(state, signal);
     switch (node.nodeType) {
       case "agent":
         return await this.runAgentNode(
@@ -382,12 +387,13 @@ export class WorkflowEngine {
     }
   }
 
-  private createNodeContext(state: WorkflowRunState): WorkflowNodeContext {
+  private createNodeContext(state: WorkflowRunState, signal: AbortSignal): WorkflowNodeContext {
     return {
       input: state.input,
       outputs: state.outputs,
       results: state.results,
       state,
+      signal,
     };
   }
 
@@ -551,9 +557,6 @@ function abortRejection(signal: AbortSignal): Promise<never> {
  * instead of corrupting the run state.
  */
 function assertJsonSerializable(output: unknown, nodeId: string): void {
-  if (output === undefined) {
-    return;
-  }
   let encoded: string | undefined;
   try {
     encoded = JSON.stringify(output);

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { CancelledError, TimeoutError, errorMessage, isAbortLikeError } from "./errors.js";
+import { isDeepStrictEqual } from "node:util";
+import { CancelledError, errorMessage, isAbortLikeError, TimeoutError } from "./errors.js";
 import { resolveNext, resolveNextForOutcome, validateWorkflowDefinition } from "./graph.js";
 import { extractJsonValue } from "./json.js";
 import { runShellAction } from "./shell.js";
@@ -208,6 +209,10 @@ export class WorkflowEngine {
     state.results[attempt.result.nodeId] = attempt.result;
     if (attempt.result.outcome === "ok") {
       state.outputs[attempt.result.nodeId] = attempt.result.output;
+    } else {
+      // A failed repeat attempt supersedes an earlier success; stale output
+      // must not survive next to a non-ok latest result.
+      delete state.outputs[attempt.result.nodeId];
     }
     const step: WorkflowStepRecord = {
       attemptId: attempt.result.attemptId,
@@ -549,11 +554,18 @@ function assertJsonSerializable(output: unknown, nodeId: string): void {
   if (output === undefined) {
     return;
   }
+  let encoded: string | undefined;
   try {
-    JSON.stringify(output);
+    encoded = JSON.stringify(output);
   } catch (error) {
     throw new Error(
       `Node ${nodeId} returned a non-JSON-serializable output: ${errorMessage(error)}`,
+    );
+  }
+  if (encoded === undefined || !isDeepStrictEqual(JSON.parse(encoded), output)) {
+    throw new Error(
+      `Node ${nodeId} returned an output that does not survive a JSON round-trip. ` +
+        `Outputs must be plain JSON values (no functions, dates, NaN, or undefined properties).`,
     );
   }
 }

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -78,9 +78,13 @@ export class WorkflowEngine {
     options: { workflowPath?: string } = {},
   ): Promise<WorkflowRunResult> {
     validateWorkflowDefinition(workflow);
+    // Fail before any bundle exists so bad input cannot leave a partial run
+    // on disk or silently change shape when state.json round-trips.
+    const normalizedInput = input === undefined ? null : input;
+    assertJsonSerializable(normalizedInput, "Workflow run input");
     this.cancelled = false;
 
-    const state = await this.createRunState(workflow, input, options.workflowPath);
+    const state = await this.createRunState(workflow, normalizedInput, options.workflowPath);
     const runDir = await this.store.initializeRunBundle(workflow, state);
     await this.persist(runDir, state, {
       scope: "run",
@@ -345,7 +349,7 @@ export class WorkflowEngine {
         // matches what the persisted bundle round-trips to.
         execution.output = null;
       }
-      assertJsonSerializable(execution.output, nodeId);
+      assertJsonSerializable(execution.output, `Node ${nodeId} output`);
       return execution;
     } catch (error) {
       const reason: unknown = abort.signal.aborted ? abort.signal.reason : undefined;
@@ -408,7 +412,13 @@ export class WorkflowEngine {
     signal: AbortSignal,
   ): Promise<NodeExecution> {
     const basePrompt = await node.prompt(context);
-    const prompt = appendStepContract(basePrompt, workflow.name, nodeId, node.expectedOutput);
+    const prompt = appendStepContract(
+      basePrompt,
+      workflow.name,
+      nodeId,
+      attemptId,
+      node.expectedOutput,
+    );
     await this.persist(runDir, state, {
       scope: "agent",
       type: "agent_prompt_sent",
@@ -556,19 +566,17 @@ function abortRejection(signal: AbortSignal): Promise<never> {
  * Failing here turns a bad callback return value into a normal node failure
  * instead of corrupting the run state.
  */
-function assertJsonSerializable(output: unknown, nodeId: string): void {
+function assertJsonSerializable(value: unknown, what: string): void {
   let encoded: string | undefined;
   try {
-    encoded = JSON.stringify(output);
+    encoded = JSON.stringify(value);
   } catch (error) {
-    throw new Error(
-      `Node ${nodeId} returned a non-JSON-serializable output: ${errorMessage(error)}`,
-    );
+    throw new Error(`${what} is non-JSON-serializable: ${errorMessage(error)}`);
   }
-  if (encoded === undefined || !isDeepStrictEqual(JSON.parse(encoded), output)) {
+  if (encoded === undefined || !isDeepStrictEqual(JSON.parse(encoded), value)) {
     throw new Error(
-      `Node ${nodeId} returned an output that does not survive a JSON round-trip. ` +
-        `Outputs must be plain JSON values (no functions, dates, NaN, or undefined properties).`,
+      `${what} does not survive a JSON round-trip. ` +
+        `Use plain JSON values (no functions, dates, NaN, or undefined properties).`,
     );
   }
 }
@@ -596,16 +604,17 @@ export function appendStepContract(
   prompt: string,
   workflowName: string,
   nodeId: string,
+  attemptId: string,
   expectedOutput: string | undefined,
 ): string {
   return [
     prompt.trimEnd(),
     "",
     "---",
-    `Workflow step contract (workflow: ${workflowName}, step: ${nodeId})`,
+    `Workflow step contract (workflow: ${workflowName}, step: ${nodeId}, attempt: ${attemptId})`,
     "",
     "Complete this step by calling the `workflow` tool exactly once with:",
-    `{"step": ${JSON.stringify(nodeId)}, "output": <your result>}`,
+    `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
     `Expected output: ${expectedOutput ?? "a JSON object with your result"}`,
     "The step is complete only after the workflow tool accepts the output.",
     "If the tool reports a validation error, correct the output and call it again.",

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -93,7 +93,8 @@ export class WorkflowEngine {
     try {
       await this.executeGraph(workflow, state, runDir);
     } catch (error) {
-      await this.finishRun(runDir, state, this.cancelled ? "cancelled" : "failed", {
+      const cancelled = this.cancelled || isAbortLikeError(error);
+      await this.finishRun(runDir, state, cancelled ? "cancelled" : "failed", {
         error: errorMessage(error),
       });
       return { runDir, state };
@@ -328,15 +329,14 @@ export class WorkflowEngine {
       abort.abort(new TimeoutError(timeoutMs));
     }, timeoutMs);
     try {
-      return await this.dispatchNode(
-        workflow,
-        state,
-        runDir,
-        nodeId,
-        attemptId,
-        node,
-        abort.signal,
-      );
+      // Race the dispatch against the abort signal so timeouts and cancel
+      // take effect even for node callbacks that never observe the signal.
+      const execution = await Promise.race([
+        this.dispatchNode(workflow, state, runDir, nodeId, attemptId, node, abort.signal),
+        abortRejection(abort.signal),
+      ]);
+      assertJsonSerializable(execution.output, nodeId);
+      return execution;
     } catch (error) {
       const reason: unknown = abort.signal.aborted ? abort.signal.reason : undefined;
       throw reason instanceof TimeoutError || reason instanceof CancelledError ? reason : error;
@@ -371,7 +371,7 @@ export class WorkflowEngine {
       case "compute":
         return { output: await node.run(context), promptText: null };
       case "action":
-        return await this.runActionNode(node, context);
+        return await this.runActionNode(node, context, signal);
       case "checkpoint":
         return await runCheckpointNode(node, context);
     }
@@ -440,9 +440,10 @@ export class WorkflowEngine {
   private async runActionNode(
     node: ActionNodeDefinition,
     context: WorkflowNodeContext,
+    signal: AbortSignal,
   ): Promise<NodeExecution> {
     if ("exec" in node) {
-      return await runShellActionNode(node, context);
+      return await runShellActionNode(node, context, signal);
     }
     const output = await node.run(context);
     return { output, promptText: null, action: { actionType: "function" } };
@@ -504,9 +505,10 @@ async function runCheckpointNode(
 async function runShellActionNode(
   node: ShellActionNodeDefinition,
   context: WorkflowNodeContext,
+  signal: AbortSignal,
 ): Promise<NodeExecution> {
   const spec = await node.exec(context);
-  const result = await runShellAction(spec);
+  const result = await runShellAction(spec, signal);
   const output = node.parse ? await node.parse(result, context) : result;
   return {
     output,
@@ -521,6 +523,39 @@ async function runShellActionNode(
       durationMs: result.durationMs,
     },
   };
+}
+
+/** Rejects with the abort reason once the signal fires; never resolves. */
+function abortRejection(signal: AbortSignal): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    const onAbort = () => {
+      const reason: unknown = signal.reason ?? new CancelledError();
+      reject(reason instanceof Error ? reason : new CancelledError(String(reason)));
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Outputs are persisted to the run bundle, so they must be JSON-serializable.
+ * Failing here turns a bad callback return value into a normal node failure
+ * instead of corrupting the run state.
+ */
+function assertJsonSerializable(output: unknown, nodeId: string): void {
+  if (output === undefined) {
+    return;
+  }
+  try {
+    JSON.stringify(output);
+  } catch (error) {
+    throw new Error(
+      `Node ${nodeId} returned a non-JSON-serializable output: ${errorMessage(error)}`,
+    );
+  }
 }
 
 /**

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -1,0 +1,577 @@
+import { randomUUID } from "node:crypto";
+import { CancelledError, TimeoutError, errorMessage, isAbortLikeError } from "./errors.js";
+import { resolveNext, resolveNextForOutcome, validateWorkflowDefinition } from "./graph.js";
+import { extractJsonValue } from "./json.js";
+import { runShellAction } from "./shell.js";
+import { WorkflowRunStore, createRunId } from "./store.js";
+import type {
+  AgentNodeDefinition,
+  AgentStepExecutor,
+  ActionNodeDefinition,
+  CheckpointNodeDefinition,
+  ShellActionNodeDefinition,
+  WorkflowActionReceipt,
+  WorkflowDefinition,
+  WorkflowEngineOptions,
+  WorkflowNodeContext,
+  WorkflowNodeDefinition,
+  WorkflowNodeOutcome,
+  WorkflowNodeResult,
+  WorkflowRunResult,
+  WorkflowRunState,
+  WorkflowStepRecord,
+  WorkflowTraceEventDraft,
+} from "./types.js";
+
+const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
+const DEFAULT_MAX_STEPS = 100;
+
+type NodeExecution = {
+  output: unknown;
+  promptText: string | null;
+  action?: WorkflowActionReceipt;
+};
+
+type NodeAttempt = {
+  result: WorkflowNodeResult;
+  execution: NodeExecution | null;
+  error?: unknown;
+};
+
+/**
+ * Executes a workflow graph step by step. Agent steps are delegated to the
+ * configured executor; compute/action/checkpoint nodes run inline. Every
+ * state transition is persisted to the run bundle before the engine moves on,
+ * so a live viewer can follow along by watching the bundle directory.
+ */
+export class WorkflowEngine {
+  private readonly executor: AgentStepExecutor;
+  private readonly store: WorkflowRunStore;
+  private readonly defaultNodeTimeoutMs: number;
+  private readonly maxSteps: number;
+  private readonly onEvent?: WorkflowEngineOptions["onEvent"];
+  private activeAbort: AbortController | null = null;
+  private cancelled = false;
+
+  constructor(options: WorkflowEngineOptions) {
+    this.executor = options.executor;
+    this.store = new WorkflowRunStore(options.outputRoot);
+    this.defaultNodeTimeoutMs = options.defaultNodeTimeoutMs ?? DEFAULT_NODE_TIMEOUT_MS;
+    this.maxSteps = options.maxSteps ?? DEFAULT_MAX_STEPS;
+    this.onEvent = options.onEvent;
+  }
+
+  get outputRoot(): string {
+    return this.store.outputRoot;
+  }
+
+  /** Abort the currently running node and mark the run cancelled. */
+  cancel(): void {
+    this.cancelled = true;
+    this.activeAbort?.abort(new CancelledError());
+  }
+
+  async run(
+    workflow: WorkflowDefinition,
+    input: unknown,
+    options: { workflowPath?: string } = {},
+  ): Promise<WorkflowRunResult> {
+    validateWorkflowDefinition(workflow);
+    this.cancelled = false;
+
+    const state = await this.createRunState(workflow, input, options.workflowPath);
+    const runDir = await this.store.initializeRunBundle(workflow, state);
+    await this.persist(runDir, state, {
+      scope: "run",
+      type: "run_started",
+      payload: {
+        workflowName: workflow.name,
+        ...(state.runTitle ? { runTitle: state.runTitle } : {}),
+      },
+    });
+
+    try {
+      await this.executeGraph(workflow, state, runDir);
+    } catch (error) {
+      await this.finishRun(runDir, state, this.cancelled ? "cancelled" : "failed", {
+        error: errorMessage(error),
+      });
+      return { runDir, state };
+    }
+    return { runDir, state };
+  }
+
+  private async createRunState(
+    workflow: WorkflowDefinition,
+    input: unknown,
+    workflowPath: string | undefined,
+  ): Promise<WorkflowRunState> {
+    const now = new Date().toISOString();
+    return {
+      runId: createRunId(workflow.name),
+      workflowName: workflow.name,
+      ...(await resolveRunTitle(workflow, input)),
+      ...(workflowPath !== undefined ? { workflowPath } : {}),
+      startedAt: now,
+      updatedAt: now,
+      status: "running",
+      input,
+      outputs: {},
+      results: {},
+      steps: [],
+    };
+  }
+
+  private async executeGraph(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    runDir: string,
+  ): Promise<void> {
+    const maxSteps = workflow.maxSteps ?? this.maxSteps;
+    let currentNodeId: string | null = workflow.startAt;
+    let executedSteps = 0;
+    let lastOutput: unknown;
+
+    while (currentNodeId !== null) {
+      executedSteps += 1;
+      if (executedSteps > maxSteps) {
+        throw new Error(
+          `Workflow exceeded maxSteps=${maxSteps}; aborting to avoid an unbounded loop`,
+        );
+      }
+
+      const node = workflow.nodes[currentNodeId];
+      if (!node) {
+        throw new Error(`Workflow node is missing: ${currentNodeId}`);
+      }
+
+      const attempt = await this.executeNode(workflow, state, runDir, currentNodeId, node);
+      this.recordAttempt(state, attempt);
+      await this.persist(runDir, state, {
+        scope: "node",
+        type: attempt.result.outcome === "ok" ? "node_finished" : "node_failed",
+        nodeId: attempt.result.nodeId,
+        attemptId: attempt.result.attemptId,
+        payload: {
+          outcome: attempt.result.outcome,
+          durationMs: attempt.result.durationMs,
+          ...(attempt.result.error !== undefined ? { error: attempt.result.error } : {}),
+        },
+      });
+
+      if (attempt.result.outcome !== "ok") {
+        currentNodeId = this.routeAfterFailure(workflow, state, attempt);
+        continue;
+      }
+
+      lastOutput = attempt.result.output;
+      if (node.nodeType === "checkpoint") {
+        await this.finishRun(runDir, state, "waiting", {
+          waitingOn: attempt.result.nodeId,
+          finalOutput: lastOutput,
+        });
+        return;
+      }
+      currentNodeId = resolveNext(
+        workflow.edges,
+        attempt.result.nodeId,
+        attempt.result.output,
+        attempt.result,
+      );
+    }
+
+    await this.finishRun(runDir, state, "completed", { finalOutput: lastOutput });
+  }
+
+  private routeAfterFailure(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    attempt: NodeAttempt,
+  ): string | null {
+    const next = resolveNextForOutcome(workflow.edges, attempt.result.nodeId, attempt.result);
+    if (next !== null) {
+      return next;
+    }
+    if (attempt.result.outcome === "cancelled" || this.cancelled) {
+      throw new CancelledError();
+    }
+    if (attempt.result.outcome === "timed_out") {
+      state.status = "timed_out";
+    }
+    throw attempt.error instanceof Error
+      ? attempt.error
+      : new Error(attempt.result.error ?? `Workflow node failed: ${attempt.result.nodeId}`);
+  }
+
+  private recordAttempt(state: WorkflowRunState, attempt: NodeAttempt): void {
+    state.results[attempt.result.nodeId] = attempt.result;
+    if (attempt.result.outcome === "ok") {
+      state.outputs[attempt.result.nodeId] = attempt.result.output;
+    }
+    const step: WorkflowStepRecord = {
+      attemptId: attempt.result.attemptId,
+      nodeId: attempt.result.nodeId,
+      nodeType: attempt.result.nodeType,
+      outcome: attempt.result.outcome,
+      startedAt: attempt.result.startedAt,
+      finishedAt: attempt.result.finishedAt,
+      promptText: attempt.execution?.promptText ?? null,
+      output: attempt.result.output,
+      ...(attempt.result.error !== undefined ? { error: attempt.result.error } : {}),
+      ...(attempt.execution?.action !== undefined ? { action: attempt.execution.action } : {}),
+    };
+    state.steps.push(step);
+    delete state.currentNode;
+    delete state.currentAttemptId;
+    delete state.currentNodeType;
+    delete state.currentNodeStartedAt;
+    delete state.statusDetail;
+  }
+
+  private async executeNode(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    runDir: string,
+    nodeId: string,
+    node: WorkflowNodeDefinition,
+  ): Promise<NodeAttempt> {
+    const attemptId = randomUUID();
+    const startedAt = new Date().toISOString();
+    state.currentNode = nodeId;
+    state.currentAttemptId = attemptId;
+    state.currentNodeType = node.nodeType;
+    state.currentNodeStartedAt = startedAt;
+    if (node.statusDetail !== undefined) {
+      state.statusDetail = node.statusDetail;
+    }
+    await this.persist(runDir, state, {
+      scope: "node",
+      type: "node_started",
+      nodeId,
+      attemptId,
+      payload: { nodeType: node.nodeType },
+    });
+
+    try {
+      const execution = await this.runNodeWithTimeout(
+        workflow,
+        state,
+        runDir,
+        nodeId,
+        attemptId,
+        node,
+      );
+      return {
+        result: this.createNodeResult(nodeId, node, attemptId, startedAt, "ok", execution.output),
+        execution,
+      };
+    } catch (error) {
+      const outcome = this.outcomeForError(error);
+      return {
+        result: {
+          ...this.createNodeResult(nodeId, node, attemptId, startedAt, outcome, undefined),
+          error: errorMessage(error),
+        },
+        execution: null,
+        error,
+      };
+    }
+  }
+
+  private outcomeForError(error: unknown): WorkflowNodeOutcome {
+    if (error instanceof TimeoutError) {
+      return "timed_out";
+    }
+    if (this.cancelled || isAbortLikeError(error)) {
+      return "cancelled";
+    }
+    return "failed";
+  }
+
+  private createNodeResult(
+    nodeId: string,
+    node: WorkflowNodeDefinition,
+    attemptId: string,
+    startedAt: string,
+    outcome: WorkflowNodeOutcome,
+    output: unknown,
+  ): WorkflowNodeResult {
+    const finishedAt = new Date().toISOString();
+    return {
+      attemptId,
+      nodeId,
+      nodeType: node.nodeType,
+      outcome,
+      startedAt,
+      finishedAt,
+      durationMs: Date.parse(finishedAt) - Date.parse(startedAt),
+      ...(output !== undefined ? { output } : {}),
+    };
+  }
+
+  private async runNodeWithTimeout(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    runDir: string,
+    nodeId: string,
+    attemptId: string,
+    node: WorkflowNodeDefinition,
+  ): Promise<NodeExecution> {
+    const timeoutMs = node.timeoutMs ?? this.defaultNodeTimeoutMs;
+    const abort = new AbortController();
+    this.activeAbort = abort;
+    if (this.cancelled) {
+      throw new CancelledError();
+    }
+
+    const timer = setTimeout(() => {
+      abort.abort(new TimeoutError(timeoutMs));
+    }, timeoutMs);
+    try {
+      return await this.dispatchNode(
+        workflow,
+        state,
+        runDir,
+        nodeId,
+        attemptId,
+        node,
+        abort.signal,
+      );
+    } catch (error) {
+      const reason: unknown = abort.signal.aborted ? abort.signal.reason : undefined;
+      throw reason instanceof TimeoutError || reason instanceof CancelledError ? reason : error;
+    } finally {
+      clearTimeout(timer);
+      this.activeAbort = null;
+    }
+  }
+
+  private async dispatchNode(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    runDir: string,
+    nodeId: string,
+    attemptId: string,
+    node: WorkflowNodeDefinition,
+    signal: AbortSignal,
+  ): Promise<NodeExecution> {
+    const context = this.createNodeContext(state);
+    switch (node.nodeType) {
+      case "agent":
+        return await this.runAgentNode(
+          workflow,
+          state,
+          runDir,
+          nodeId,
+          attemptId,
+          node,
+          context,
+          signal,
+        );
+      case "compute":
+        return { output: await node.run(context), promptText: null };
+      case "action":
+        return await this.runActionNode(node, context);
+      case "checkpoint":
+        return await runCheckpointNode(node, context);
+    }
+  }
+
+  private createNodeContext(state: WorkflowRunState): WorkflowNodeContext {
+    return {
+      input: state.input,
+      outputs: state.outputs,
+      results: state.results,
+      state,
+    };
+  }
+
+  private async runAgentNode(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+    runDir: string,
+    nodeId: string,
+    attemptId: string,
+    node: AgentNodeDefinition,
+    context: WorkflowNodeContext,
+    signal: AbortSignal,
+  ): Promise<NodeExecution> {
+    const basePrompt = await node.prompt(context);
+    const prompt = appendStepContract(basePrompt, workflow.name, nodeId, node.expectedOutput);
+    await this.persist(runDir, state, {
+      scope: "agent",
+      type: "agent_prompt_sent",
+      nodeId,
+      attemptId,
+      payload: { prompt },
+    });
+
+    const submission = await this.executor.runAgentStep(
+      {
+        contract: {
+          runId: state.runId,
+          workflowName: workflow.name,
+          nodeId,
+          attemptId,
+          ...(node.expectedOutput !== undefined ? { expectedOutput: node.expectedOutput } : {}),
+        },
+        prompt,
+        accept: async (output) => await this.acceptSubmission(node, context, output),
+      },
+      signal,
+    );
+    return { output: submission.output, promptText: prompt };
+  }
+
+  private async acceptSubmission(
+    node: AgentNodeDefinition,
+    context: WorkflowNodeContext,
+    output: unknown,
+  ): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
+    try {
+      const normalized = normalizeAgentOutput(output);
+      const value = node.validate ? await node.validate(normalized, context) : normalized;
+      return { ok: true, value };
+    } catch (error) {
+      return { ok: false, error: errorMessage(error) };
+    }
+  }
+
+  private async runActionNode(
+    node: ActionNodeDefinition,
+    context: WorkflowNodeContext,
+  ): Promise<NodeExecution> {
+    if ("exec" in node) {
+      return await runShellActionNode(node, context);
+    }
+    const output = await node.run(context);
+    return { output, promptText: null, action: { actionType: "function" } };
+  }
+
+  private async persist(
+    runDir: string,
+    state: WorkflowRunState,
+    event: WorkflowTraceEventDraft,
+  ): Promise<void> {
+    const traceEvent = await this.store.writeSnapshot(runDir, state, event);
+    this.onEvent?.(traceEvent, state);
+  }
+
+  private async finishRun(
+    runDir: string,
+    state: WorkflowRunState,
+    status: WorkflowRunState["status"],
+    fields: { error?: string; waitingOn?: string; finalOutput?: unknown },
+  ): Promise<void> {
+    if (status === "failed" && state.status === "timed_out") {
+      status = "timed_out";
+    }
+    state.status = status;
+    state.finishedAt = new Date().toISOString();
+    if (fields.error !== undefined) {
+      state.error = fields.error;
+    }
+    if (fields.waitingOn !== undefined) {
+      state.waitingOn = fields.waitingOn;
+    }
+    if (fields.finalOutput !== undefined) {
+      state.finalOutput = fields.finalOutput;
+    }
+    delete state.currentNode;
+    delete state.currentAttemptId;
+    delete state.currentNodeType;
+    delete state.currentNodeStartedAt;
+    await this.persist(runDir, state, {
+      scope: "run",
+      type: `run_${status}`,
+      payload: {
+        status,
+        ...(fields.error !== undefined ? { error: fields.error } : {}),
+        ...(fields.waitingOn !== undefined ? { waitingOn: fields.waitingOn } : {}),
+      },
+    });
+  }
+}
+
+async function runCheckpointNode(
+  node: CheckpointNodeDefinition,
+  context: WorkflowNodeContext,
+): Promise<NodeExecution> {
+  const output = node.run ? await node.run(context) : { summary: node.summary ?? "checkpoint" };
+  return { output, promptText: null };
+}
+
+async function runShellActionNode(
+  node: ShellActionNodeDefinition,
+  context: WorkflowNodeContext,
+): Promise<NodeExecution> {
+  const spec = await node.exec(context);
+  const result = await runShellAction(spec);
+  const output = node.parse ? await node.parse(result, context) : result;
+  return {
+    output,
+    promptText: null,
+    action: {
+      actionType: "shell",
+      command: result.command,
+      args: result.args,
+      cwd: result.cwd,
+      exitCode: result.exitCode,
+      signal: result.signal,
+      durationMs: result.durationMs,
+    },
+  };
+}
+
+/**
+ * Models occasionally submit the step output as a JSON-encoded string. Accept
+ * that by parsing tolerantly, falling back to the raw string.
+ */
+function normalizeAgentOutput(output: unknown): unknown {
+  if (typeof output !== "string") {
+    return output;
+  }
+  try {
+    return extractJsonValue(output);
+  } catch {
+    return output;
+  }
+}
+
+/**
+ * The step contract appended to every agent-node prompt. This is the
+ * documented standard for how the model completes a workflow step.
+ */
+export function appendStepContract(
+  prompt: string,
+  workflowName: string,
+  nodeId: string,
+  expectedOutput: string | undefined,
+): string {
+  return [
+    prompt.trimEnd(),
+    "",
+    "---",
+    `Workflow step contract (workflow: ${workflowName}, step: ${nodeId})`,
+    "",
+    "Complete this step by calling the `workflow` tool exactly once with:",
+    `{"step": ${JSON.stringify(nodeId)}, "output": <your result>}`,
+    `Expected output: ${expectedOutput ?? "a JSON object with your result"}`,
+    "The step is complete only after the workflow tool accepts the output.",
+    "If the tool reports a validation error, correct the output and call it again.",
+  ].join("\n");
+}
+
+async function resolveRunTitle(
+  workflow: WorkflowDefinition,
+  input: unknown,
+): Promise<{ runTitle?: string }> {
+  if (typeof workflow.title === "string") {
+    return { runTitle: workflow.title };
+  }
+  if (typeof workflow.title === "function") {
+    const title = await workflow.title({ input, workflowName: workflow.name });
+    return title !== undefined ? { runTitle: title } : {};
+  }
+  return {};
+}

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -28,6 +28,8 @@ import type {
 const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_MAX_STEPS = 100;
 const TITLE_TIMEOUT_MS = 30_000;
+// Covers the shell SIGTERM → SIGKILL escalation (1s) plus stdio close.
+const ABORT_CLEANUP_GRACE_MS = 2_000;
 
 type NodeExecution = {
   output: unknown;
@@ -384,13 +386,24 @@ export class WorkflowEngine {
     const timer = setTimeout(() => {
       abort.abort(new TimeoutError(timeoutMs));
     }, timeoutMs);
+    const dispatched = this.dispatchNode(
+      workflow,
+      state,
+      runDir,
+      nodeId,
+      attemptId,
+      node,
+      abort.signal,
+      meta,
+    );
+    const dispatchSettled = dispatched.then(
+      () => undefined,
+      () => undefined,
+    );
     try {
       // Race the dispatch against the abort signal so timeouts and cancel
       // take effect even for node callbacks that never observe the signal.
-      const execution = await Promise.race([
-        this.dispatchNode(workflow, state, runDir, nodeId, attemptId, node, abort.signal, meta),
-        abortRejection(abort.signal),
-      ]);
+      const execution = await Promise.race([dispatched, abortRejection(abort.signal)]);
       if (execution.output === undefined) {
         // JSON cannot represent undefined; normalize so the in-memory state
         // matches what the persisted bundle round-trips to.
@@ -399,6 +412,14 @@ export class WorkflowEngine {
       assertJsonSerializable(execution.output, `Node ${nodeId} output`);
       return execution;
     } catch (error) {
+      if (node.nodeType === "action" && "exec" in node) {
+        // Give the killed shell command a short grace period to close so its
+        // action receipt lands in `meta` before the failed attempt persists.
+        await Promise.race([
+          dispatchSettled,
+          new Promise((resolve) => setTimeout(resolve, ABORT_CLEANUP_GRACE_MS)),
+        ]);
+      }
       const reason: unknown = abort.signal.aborted ? abort.signal.reason : undefined;
       throw reason instanceof TimeoutError || reason instanceof CancelledError ? reason : error;
     } finally {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -560,7 +560,12 @@ export class WorkflowEngine {
     event: WorkflowTraceEventDraft,
   ): Promise<void> {
     const traceEvent = await this.store.writeSnapshot(runDir, state, event);
-    this.onEvent?.(traceEvent, state);
+    try {
+      this.onEvent?.(traceEvent, state);
+    } catch {
+      // Observers (UI updates, loggers) must never determine workflow
+      // correctness; a throwing observer would otherwise fail the run.
+    }
   }
 
   private async finishRun(

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -3,7 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import { CancelledError, errorMessage, isAbortLikeError, TimeoutError } from "./errors.js";
 import { resolveNext, resolveNextForOutcome, validateWorkflowDefinition } from "./graph.js";
 import { extractJsonValue } from "./json.js";
-import { runShellAction } from "./shell.js";
+import { runShellAction, shellResultFromError } from "./shell.js";
 import { WorkflowRunStore, createRunId } from "./store.js";
 import type {
   AgentNodeDefinition,
@@ -11,6 +11,7 @@ import type {
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ShellActionNodeDefinition,
+  ShellActionResult,
   WorkflowActionReceipt,
   WorkflowDefinition,
   WorkflowEngineOptions,
@@ -26,9 +27,19 @@ import type {
 
 const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_MAX_STEPS = 100;
+const TITLE_TIMEOUT_MS = 30_000;
 
 type NodeExecution = {
   output: unknown;
+  promptText: string | null;
+  action?: WorkflowActionReceipt;
+};
+
+/**
+ * Metadata collected while a node runs, so a failing node still persists the
+ * agent prompt it sent and the shell action it executed.
+ */
+type NodeExecutionMeta = {
   promptText: string | null;
   action?: WorkflowActionReceipt;
 };
@@ -107,6 +118,32 @@ export class WorkflowEngine {
     return { runDir, state };
   }
 
+  /**
+   * Resolve the run title inside a cancellation and timeout boundary. This
+   * runs before any node abort controller exists, so without it a hung async
+   * `title` callback would leave the session permanently occupied.
+   */
+  private async resolveTitleBounded(
+    workflow: WorkflowDefinition,
+    input: unknown,
+  ): Promise<{ runTitle?: string }> {
+    if (typeof workflow.title !== "function") {
+      return resolveRunTitle(workflow, input);
+    }
+    const abort = new AbortController();
+    this.activeAbort = abort;
+    const timer = setTimeout(
+      () => abort.abort(new TimeoutError(TITLE_TIMEOUT_MS)),
+      TITLE_TIMEOUT_MS,
+    );
+    try {
+      return await Promise.race([resolveRunTitle(workflow, input), abortRejection(abort.signal)]);
+    } finally {
+      clearTimeout(timer);
+      this.activeAbort = null;
+    }
+  }
+
   private async createRunState(
     workflow: WorkflowDefinition,
     input: unknown,
@@ -116,7 +153,7 @@ export class WorkflowEngine {
     return {
       runId: createRunId(workflow.name),
       workflowName: workflow.name,
-      ...(await resolveRunTitle(workflow, input)),
+      ...(await this.resolveTitleBounded(workflow, input)),
       ...(workflowPath !== undefined ? { workflowPath } : {}),
       startedAt: now,
       updatedAt: now,
@@ -226,7 +263,8 @@ export class WorkflowEngine {
       startedAt: attempt.result.startedAt,
       finishedAt: attempt.result.finishedAt,
       promptText: attempt.execution?.promptText ?? null,
-      output: attempt.result.output,
+      // `undefined` would drop the required field during JSON serialization.
+      output: attempt.result.output ?? null,
       ...(attempt.result.error !== undefined ? { error: attempt.result.error } : {}),
       ...(attempt.execution?.action !== undefined ? { action: attempt.execution.action } : {}),
     };
@@ -262,6 +300,7 @@ export class WorkflowEngine {
       payload: { nodeType: node.nodeType },
     });
 
+    const meta: NodeExecutionMeta = { promptText: null };
     try {
       const execution = await this.runNodeWithTimeout(
         workflow,
@@ -270,6 +309,7 @@ export class WorkflowEngine {
         nodeId,
         attemptId,
         node,
+        meta,
       );
       return {
         result: this.createNodeResult(nodeId, node, attemptId, startedAt, "ok", execution.output),
@@ -282,7 +322,13 @@ export class WorkflowEngine {
           ...this.createNodeResult(nodeId, node, attemptId, startedAt, outcome, undefined),
           error: errorMessage(error),
         },
-        execution: null,
+        // Keep whatever metadata the node produced before failing so the
+        // audit history retains the agent prompt and action receipt.
+        execution: {
+          output: null,
+          promptText: meta.promptText,
+          ...(meta.action !== undefined ? { action: meta.action } : {}),
+        },
         error,
       };
     }
@@ -326,6 +372,7 @@ export class WorkflowEngine {
     nodeId: string,
     attemptId: string,
     node: WorkflowNodeDefinition,
+    meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
     const timeoutMs = node.timeoutMs ?? this.defaultNodeTimeoutMs;
     const abort = new AbortController();
@@ -341,7 +388,7 @@ export class WorkflowEngine {
       // Race the dispatch against the abort signal so timeouts and cancel
       // take effect even for node callbacks that never observe the signal.
       const execution = await Promise.race([
-        this.dispatchNode(workflow, state, runDir, nodeId, attemptId, node, abort.signal),
+        this.dispatchNode(workflow, state, runDir, nodeId, attemptId, node, abort.signal, meta),
         abortRejection(abort.signal),
       ]);
       if (execution.output === undefined) {
@@ -368,6 +415,7 @@ export class WorkflowEngine {
     attemptId: string,
     node: WorkflowNodeDefinition,
     signal: AbortSignal,
+    meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
     const context = this.createNodeContext(state, signal);
     switch (node.nodeType) {
@@ -381,11 +429,12 @@ export class WorkflowEngine {
           node,
           context,
           signal,
+          meta,
         );
       case "compute":
         return { output: await node.run(context), promptText: null };
       case "action":
-        return await this.runActionNode(node, context, signal);
+        return await this.runActionNode(node, context, signal, meta);
       case "checkpoint":
         return await runCheckpointNode(node, context);
     }
@@ -410,6 +459,7 @@ export class WorkflowEngine {
     node: AgentNodeDefinition,
     context: WorkflowNodeContext,
     signal: AbortSignal,
+    meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
     const basePrompt = await node.prompt(context);
     const prompt = appendStepContract(
@@ -419,6 +469,7 @@ export class WorkflowEngine {
       attemptId,
       node.expectedOutput,
     );
+    meta.promptText = prompt;
     await this.persist(runDir, state, {
       scope: "agent",
       type: "agent_prompt_sent",
@@ -451,7 +502,11 @@ export class WorkflowEngine {
   ): Promise<{ ok: true; value: unknown } | { ok: false; error: string }> {
     try {
       const normalized = normalizeAgentOutput(output);
-      const value = node.validate ? await node.validate(normalized, context) : normalized;
+      const validated = node.validate ? await node.validate(normalized, context) : normalized;
+      const value = validated === undefined ? null : validated;
+      // Check here rather than after acceptance so a non-JSON validator
+      // result comes back as a validation error the model can retry.
+      assertJsonSerializable(value, "Step output");
       return { ok: true, value };
     } catch (error) {
       return { ok: false, error: errorMessage(error) };
@@ -462,10 +517,12 @@ export class WorkflowEngine {
     node: ActionNodeDefinition,
     context: WorkflowNodeContext,
     signal: AbortSignal,
+    meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
     if ("exec" in node) {
-      return await runShellActionNode(node, context, signal);
+      return await runShellActionNode(node, context, signal, meta);
     }
+    meta.action = { actionType: "function" };
     const output = await node.run(context);
     return { output, promptText: null, action: { actionType: "function" } };
   }
@@ -523,27 +580,38 @@ async function runCheckpointNode(
   return { output, promptText: null };
 }
 
+function shellReceipt(result: ShellActionResult): WorkflowActionReceipt {
+  return {
+    actionType: "shell",
+    command: result.command,
+    args: result.args,
+    cwd: result.cwd,
+    exitCode: result.exitCode,
+    signal: result.signal,
+    durationMs: result.durationMs,
+  };
+}
+
 async function runShellActionNode(
   node: ShellActionNodeDefinition,
   context: WorkflowNodeContext,
   signal: AbortSignal,
+  meta: NodeExecutionMeta,
 ): Promise<NodeExecution> {
   const spec = await node.exec(context);
-  const result = await runShellAction(spec, signal);
+  let result: ShellActionResult;
+  try {
+    result = await runShellAction(spec, signal);
+  } catch (error) {
+    const failed = shellResultFromError(error);
+    if (failed) {
+      meta.action = shellReceipt(failed);
+    }
+    throw error;
+  }
+  meta.action = shellReceipt(result);
   const output = node.parse ? await node.parse(result, context) : result;
-  return {
-    output,
-    promptText: null,
-    action: {
-      actionType: "shell",
-      command: result.command,
-      args: result.args,
-      cwd: result.cwd,
-      exitCode: result.exitCode,
-      signal: result.signal,
-      durationMs: result.durationMs,
-    },
-  };
+  return { output, promptText: null, action: shellReceipt(result) };
 }
 
 /** Rejects with the abort reason once the signal fires; never resolves. */

--- a/src/workflows/errors.ts
+++ b/src/workflows/errors.ts
@@ -1,0 +1,27 @@
+export class TimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class CancelledError extends Error {
+  constructor(message = "Workflow run was cancelled") {
+    super(message);
+    this.name = "CancelledError";
+  }
+}
+
+export function isAbortLikeError(error: unknown): boolean {
+  return error instanceof CancelledError || (error instanceof Error && error.name === "AbortError");
+}
+
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/workflows/graph.ts
+++ b/src/workflows/graph.ts
@@ -1,0 +1,127 @@
+import { assertValidWorkflowDefinitionShape } from "./schema.js";
+import type { WorkflowDefinition, WorkflowEdge, WorkflowNodeResult } from "./types.js";
+
+/**
+ * Validate the full graph: shape, known start node, known edge targets, and
+ * at most one outgoing edge per node.
+ */
+export function validateWorkflowDefinition(workflow: WorkflowDefinition): void {
+  assertValidWorkflowDefinitionShape(workflow);
+  if (!workflow.nodes[workflow.startAt]) {
+    throw new Error(`Workflow start node is missing: ${workflow.startAt}`);
+  }
+
+  const outgoingEdges = new Set<string>();
+  for (const edge of workflow.edges) {
+    validateWorkflowEdge(workflow, edge, outgoingEdges);
+  }
+}
+
+function assertKnownNode(workflow: WorkflowDefinition, nodeId: string, description: string): void {
+  if (!workflow.nodes[nodeId]) {
+    throw new Error(`${description}: ${nodeId}`);
+  }
+}
+
+function validateWorkflowEdge(
+  workflow: WorkflowDefinition,
+  edge: WorkflowEdge,
+  outgoingEdges: Set<string>,
+): void {
+  assertKnownNode(workflow, edge.from, "Workflow edge references unknown from-node");
+  if (outgoingEdges.has(edge.from)) {
+    throw new Error(`Workflow node must not declare multiple outgoing edges: ${edge.from}`);
+  }
+  outgoingEdges.add(edge.from);
+
+  if ("to" in edge) {
+    assertKnownNode(workflow, edge.to, "Workflow edge references unknown to-node");
+    return;
+  }
+
+  for (const target of Object.values(edge.switch.cases)) {
+    assertKnownNode(workflow, target, "Workflow switch references unknown to-node");
+  }
+}
+
+/**
+ * Resolve the next node after `from` completed with `output`. Switch edges
+ * route on a JSON path into the output (`$.field` or `$output.field`) or the
+ * node result (`$result.outcome`).
+ */
+export function resolveNext(
+  edges: WorkflowEdge[],
+  from: string,
+  output: unknown,
+  result?: WorkflowNodeResult,
+): string | null {
+  const edge = edges.find((candidate) => candidate.from === from);
+  if (!edge) {
+    return null;
+  }
+  if ("to" in edge) {
+    return edge.to;
+  }
+  return resolveSwitchTarget(edge, output, result);
+}
+
+/**
+ * Resolve routing for a failed node. Only `$result.` switch edges apply, so a
+ * workflow can explicitly route on outcomes like `failed` or `timed_out`.
+ */
+export function resolveNextForOutcome(
+  edges: WorkflowEdge[],
+  from: string,
+  result: WorkflowNodeResult,
+): string | null {
+  const edge = edges.find((candidate) => candidate.from === from);
+  if (!edge || "to" in edge || !edge.switch.on.startsWith("$result.")) {
+    return null;
+  }
+  return resolveSwitchTarget(edge, undefined, result);
+}
+
+function resolveSwitchTarget(
+  edge: Extract<WorkflowEdge, { switch: unknown }>,
+  output: unknown,
+  result: WorkflowNodeResult | undefined,
+): string {
+  const value = getBySwitchPath(output, result, edge.switch.on);
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+    throw new Error(`Workflow switch value must be scalar for ${edge.switch.on}`);
+  }
+  const next = edge.switch.cases[String(value)];
+  if (!next) {
+    throw new Error(`No workflow switch case for ${edge.switch.on}=${JSON.stringify(value)}`);
+  }
+  return next;
+}
+
+function getBySwitchPath(
+  output: unknown,
+  result: WorkflowNodeResult | undefined,
+  jsonPath: string,
+): unknown {
+  if (jsonPath.startsWith("$result.")) {
+    return getByPath(result, `$.${jsonPath.slice("$result.".length)}`);
+  }
+  if (jsonPath.startsWith("$output.")) {
+    return getByPath(output, `$.${jsonPath.slice("$output.".length)}`);
+  }
+  return getByPath(output, jsonPath);
+}
+
+function getByPath(value: unknown, jsonPath: string): unknown {
+  if (!jsonPath.startsWith("$.")) {
+    throw new Error(`Unsupported JSON path: ${jsonPath}`);
+  }
+  return jsonPath
+    .slice(2)
+    .split(".")
+    .reduce((current: unknown, key) => {
+      if (current == null || typeof current !== "object") {
+        return undefined;
+      }
+      return (current as Record<string, unknown>)[key];
+    }, value);
+}

--- a/src/workflows/graph.ts
+++ b/src/workflows/graph.ts
@@ -58,6 +58,11 @@ function validateWorkflowEdge(
   outgoingEdges: Set<string>,
 ): void {
   assertKnownNode(workflow, edge.from, "Workflow edge references unknown from-node");
+  if (workflow.nodes[edge.from]?.nodeType === "checkpoint") {
+    // A checkpoint terminates the run as `waiting` and nothing resumes it,
+    // so an outgoing edge would make its targets silently unreachable.
+    throw new Error(`Workflow checkpoint node must not declare an outgoing edge: ${edge.from}`);
+  }
   if (outgoingEdges.has(edge.from)) {
     throw new Error(`Workflow node must not declare multiple outgoing edges: ${edge.from}`);
   }

--- a/src/workflows/graph.ts
+++ b/src/workflows/graph.ts
@@ -15,6 +15,33 @@ export function validateWorkflowDefinition(workflow: WorkflowDefinition): void {
   for (const edge of workflow.edges) {
     validateWorkflowEdge(workflow, edge, outgoingEdges);
   }
+
+  assertAllNodesReachable(workflow);
+}
+
+/** Reject nodes that no path from `startAt` can ever reach. */
+function assertAllNodesReachable(workflow: WorkflowDefinition): void {
+  const reachable = new Set<string>([workflow.startAt]);
+  const queue = [workflow.startAt];
+  while (queue.length > 0) {
+    const nodeId = queue.shift() as string;
+    for (const edge of workflow.edges) {
+      if (edge.from !== nodeId) {
+        continue;
+      }
+      const targets = "to" in edge ? [edge.to] : Object.values(edge.switch.cases);
+      for (const target of targets) {
+        if (!reachable.has(target)) {
+          reachable.add(target);
+          queue.push(target);
+        }
+      }
+    }
+  }
+  const unreachable = Object.keys(workflow.nodes).filter((nodeId) => !reachable.has(nodeId));
+  if (unreachable.length > 0) {
+    throw new Error(`Workflow has unreachable nodes: ${unreachable.join(", ")}`);
+  }
 }
 
 function assertKnownNode(workflow: WorkflowDefinition, nodeId: string, description: string): void {

--- a/src/workflows/graph.ts
+++ b/src/workflows/graph.ts
@@ -7,7 +7,7 @@ import type { WorkflowDefinition, WorkflowEdge, WorkflowNodeResult } from "./typ
  */
 export function validateWorkflowDefinition(workflow: WorkflowDefinition): void {
   assertValidWorkflowDefinitionShape(workflow);
-  if (!workflow.nodes[workflow.startAt]) {
+  if (!Object.hasOwn(workflow.nodes, workflow.startAt)) {
     throw new Error(`Workflow start node is missing: ${workflow.startAt}`);
   }
 
@@ -18,7 +18,9 @@ export function validateWorkflowDefinition(workflow: WorkflowDefinition): void {
 }
 
 function assertKnownNode(workflow: WorkflowDefinition, nodeId: string, description: string): void {
-  if (!workflow.nodes[nodeId]) {
+  // Own-property check so ids like "toString" cannot resolve through the
+  // Object prototype and later dispatch an inherited function as a node.
+  if (!Object.hasOwn(workflow.nodes, nodeId)) {
     throw new Error(`${description}: ${nodeId}`);
   }
 }

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -1,0 +1,74 @@
+export {
+  agent,
+  action,
+  checkpoint,
+  compute,
+  defineWorkflow,
+  isWorkflowDefinition,
+  shell,
+} from "./definition.js";
+export { decision, decisionEdge, type DecisionDefinition } from "./decision.js";
+export { WorkflowEngine, appendStepContract } from "./engine.js";
+export { CancelledError, TimeoutError } from "./errors.js";
+export {
+  extractJsonValue,
+  parseJsonValue,
+  parseStrictJsonValue,
+  type JsonParseMode,
+} from "./json.js";
+export { resolveNext, resolveNextForOutcome, validateWorkflowDefinition } from "./graph.js";
+export {
+  discoverWorkflows,
+  loadWorkflowFile,
+  resolveWorkflowRef,
+  workflowFileStem,
+  workflowSearchDirs,
+  type DiscoveredWorkflow,
+  type WorkflowSearchPaths,
+} from "./loader.js";
+export { renderShellCommand, runShellAction } from "./shell.js";
+export {
+  DEFINITION_SNAPSHOT_SCHEMA,
+  RUN_BUNDLE_SCHEMA,
+  TRACE_EVENT_SCHEMA,
+  WorkflowRunStore,
+  createDefinitionSnapshot,
+  createRunId,
+  listRunBundles,
+  readRunBundle,
+  workflowRunsBaseDir,
+  type LoadedRunBundle,
+} from "./store.js";
+export type {
+  AgentNodeDefinition,
+  AgentStepContract,
+  AgentStepExecutor,
+  AgentStepRequest,
+  AgentStepSubmission,
+  ActionNodeDefinition,
+  CheckpointNodeDefinition,
+  ComputeNodeDefinition,
+  FunctionActionNodeDefinition,
+  MaybePromise,
+  ShellActionExecution,
+  ShellActionNodeDefinition,
+  ShellActionResult,
+  WorkflowActionReceipt,
+  WorkflowDefinition,
+  WorkflowDefinitionSnapshot,
+  WorkflowEdge,
+  WorkflowEngineOptions,
+  WorkflowNodeCommon,
+  WorkflowNodeContext,
+  WorkflowNodeDefinition,
+  WorkflowNodeOutcome,
+  WorkflowNodeResult,
+  WorkflowNodeSnapshot,
+  WorkflowRunManifest,
+  WorkflowRunResult,
+  WorkflowRunState,
+  WorkflowRunStatus,
+  WorkflowStepRecord,
+  WorkflowTraceEvent,
+  WorkflowTraceEventDraft,
+} from "./types.js";

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -27,6 +27,7 @@ export {
   type WorkflowSearchPaths,
 } from "./loader.js";
 export { renderShellCommand, runShellAction } from "./shell.js";
+export { sanitizeText, stripAnsi } from "./text.js";
 export {
   DEFINITION_SNAPSHOT_SCHEMA,
   RUN_BUNDLE_SCHEMA,

--- a/src/workflows/json.ts
+++ b/src/workflows/json.ts
@@ -1,0 +1,148 @@
+export type JsonParseMode = "strict" | "fenced" | "compat";
+
+type ParseAttempt = { ok: true; value: unknown } | { ok: false };
+
+/**
+ * Parse a JSON value out of model text. `strict` requires the whole text to
+ * be JSON. `fenced` additionally accepts a ```json fenced block. `compat`
+ * (the default) also scans for the first balanced JSON object or array
+ * embedded in chatty output.
+ */
+export function parseJsonValue(text: string, options: { mode?: JsonParseMode } = {}): unknown {
+  const trimmed = typeof text === "string" ? text.trim() : "";
+  if (!trimmed) {
+    throw new Error("Expected JSON output, got empty text");
+  }
+  const mode = options.mode ?? "compat";
+
+  const direct = tryParse(trimmed);
+  if (direct.ok) {
+    return direct.value;
+  }
+
+  if (mode === "fenced" || mode === "compat") {
+    const fencedText = extractFencedJsonText(trimmed);
+    if (fencedText !== null) {
+      const fenced = tryParse(fencedText);
+      if (fenced.ok) {
+        return fenced.value;
+      }
+    }
+  }
+
+  if (mode === "compat") {
+    for (const candidate of extractBalancedJsonCandidates(trimmed)) {
+      const parsed = tryParse(candidate);
+      if (parsed.ok) {
+        return parsed.value;
+      }
+    }
+  }
+
+  throw new Error(`Could not parse JSON from text:\n${trimmed}`);
+}
+
+/** Strict parse: the whole text must be a JSON value. */
+export function parseStrictJsonValue(text: string): unknown {
+  return parseJsonValue(text, { mode: "strict" });
+}
+
+/** Default tolerant parser: direct JSON, then fenced, then embedded object. */
+export function extractJsonValue(text: string): unknown {
+  return parseJsonValue(text, { mode: "compat" });
+}
+
+function tryParse(text: string): ParseAttempt {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function extractFencedJsonText(text: string): string | null {
+  const openingFenceIndex = text.indexOf("```");
+  if (openingFenceIndex === -1) {
+    return null;
+  }
+
+  let contentStart = openingFenceIndex + 3;
+  if (
+    text.slice(contentStart, contentStart + 4).toLowerCase() === "json" &&
+    isFenceWhitespace(text[contentStart + 4])
+  ) {
+    contentStart += 4;
+  }
+  while (isFenceWhitespace(text[contentStart])) {
+    contentStart += 1;
+  }
+
+  const closingFenceIndex = text.indexOf("```", contentStart);
+  if (closingFenceIndex === -1) {
+    return null;
+  }
+  return text.slice(contentStart, closingFenceIndex).trim();
+}
+
+function isFenceWhitespace(char: string | undefined): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t";
+}
+
+function extractBalancedJsonCandidates(text: string): string[] {
+  const candidates: string[] = [];
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "{" && text[index] !== "[") {
+      continue;
+    }
+    const candidate = scanBalanced(text, index);
+    if (candidate !== null) {
+      candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function scanBalanced(text: string, startIndex: number): string | null {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index] as string;
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      stack.push(char);
+      continue;
+    }
+    if (char !== "}" && char !== "]") {
+      continue;
+    }
+
+    const open = stack.at(-1);
+    const matches = (open === "{" && char === "}") || (open === "[" && char === "]");
+    if (!matches) {
+      return null;
+    }
+    stack.pop();
+    if (stack.length === 0) {
+      return text.slice(startIndex, index + 1);
+    }
+  }
+
+  return null;
+}

--- a/src/workflows/json.ts
+++ b/src/workflows/json.ts
@@ -88,12 +88,19 @@ function isFenceWhitespace(char: string | undefined): boolean {
   return char === " " || char === "\n" || char === "\r" || char === "\t";
 }
 
+// Bound on balanced-scan attempts. Without it, pathological text such as
+// twenty thousand opening braces makes candidate extraction quadratic and
+// blocks the event loop, which also prevents node timeouts from firing.
+const MAX_CANDIDATE_SCANS = 64;
+
 function extractBalancedJsonCandidates(text: string): string[] {
   const candidates: string[] = [];
-  for (let index = 0; index < text.length; index += 1) {
+  let scans = 0;
+  for (let index = 0; index < text.length && scans < MAX_CANDIDATE_SCANS; index += 1) {
     if (text[index] !== "{" && text[index] !== "[") {
       continue;
     }
+    scans += 1;
     const candidate = scanBalanced(text, index);
     if (candidate !== null) {
       candidates.push(candidate);

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createJiti } from "jiti";
+import { isWorkflowDefinition } from "./definition.js";
+import type { WorkflowDefinition } from "./types.js";
+
+const WORKFLOW_FILE_SUFFIXES = [".workflow.ts", ".workflow.js", ".workflow.mts", ".workflow.mjs"];
+
+export type DiscoveredWorkflow = {
+  name: string;
+  path: string;
+  source: "project" | "global" | "path";
+};
+
+export type WorkflowSearchPaths = {
+  cwd: string;
+  homeDir?: string;
+};
+
+/** Directories scanned for `*.workflow.ts` files, in precedence order. */
+export function workflowSearchDirs(
+  options: WorkflowSearchPaths,
+): { dir: string; source: "project" | "global" }[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  return [
+    { dir: path.join(options.cwd, ".pi", "workflows"), source: "project" },
+    { dir: path.join(homeDir, ".pi", "agent", "workflows"), source: "global" },
+  ];
+}
+
+function isWorkflowFile(fileName: string): boolean {
+  return WORKFLOW_FILE_SUFFIXES.some((suffix) => fileName.endsWith(suffix));
+}
+
+export function workflowFileStem(filePath: string): string {
+  const base = path.basename(filePath);
+  const suffix = WORKFLOW_FILE_SUFFIXES.find((candidate) => base.endsWith(candidate));
+  return suffix ? base.slice(0, -suffix.length) : base;
+}
+
+// Alias the package name to this module's own entry so workflow files can
+// `import { agent } from "pi-workflows"` whether the engine runs from src
+// (tests, tsx) or from the built dist inside the installed package.
+const SELF_ENTRY = path.join(path.dirname(fileURLToPath(import.meta.url)), "index");
+
+/** Load a workflow module from disk. The default export must be `defineWorkflow(...)`. */
+export async function loadWorkflowFile(filePath: string): Promise<WorkflowDefinition> {
+  const absolutePath = path.resolve(filePath);
+  const jiti = createJiti(pathToFileURL(absolutePath).href, {
+    interopDefault: true,
+    moduleCache: false,
+    alias: { "pi-workflows": SELF_ENTRY },
+  });
+  const loaded = (await jiti.import(absolutePath, { default: true })) as unknown;
+  if (!isWorkflowDefinition(loaded)) {
+    throw new Error(`Workflow module must default-export defineWorkflow(...): ${absolutePath}`);
+  }
+  return loaded;
+}
+
+/** Discover named workflows in the project and global workflow directories. */
+export async function discoverWorkflows(
+  options: WorkflowSearchPaths,
+): Promise<DiscoveredWorkflow[]> {
+  const discovered: DiscoveredWorkflow[] = [];
+  const seenNames = new Set<string>();
+  for (const { dir, source } of workflowSearchDirs(options)) {
+    for (const filePath of await listWorkflowFiles(dir)) {
+      const name = workflowFileStem(filePath);
+      if (seenNames.has(name)) {
+        continue;
+      }
+      seenNames.add(name);
+      discovered.push({ name, path: filePath, source });
+    }
+  }
+  return discovered;
+}
+
+async function listWorkflowFiles(dir: string): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((entry) => entry.isFile() && isWorkflowFile(entry.name))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+/**
+ * Resolve a `/workflow` argument to a workflow file. Accepts a discovered
+ * workflow name or a direct path to a `*.workflow.ts` file.
+ */
+export async function resolveWorkflowRef(
+  ref: string,
+  options: WorkflowSearchPaths,
+): Promise<{ path: string; source: DiscoveredWorkflow["source"] }> {
+  if (looksLikePath(ref)) {
+    const absolutePath = path.resolve(options.cwd, ref);
+    await fs.access(absolutePath);
+    return { path: absolutePath, source: "path" };
+  }
+  const discovered = await discoverWorkflows(options);
+  const match = discovered.find((workflow) => workflow.name === ref);
+  if (!match) {
+    const available = discovered.map((workflow) => workflow.name).join(", ") || "(none)";
+    throw new Error(`Unknown workflow ${JSON.stringify(ref)}. Available workflows: ${available}`);
+  }
+  return { path: match.path, source: match.source };
+}
+
+function looksLikePath(ref: string): boolean {
+  return (
+    ref.includes("/") ||
+    ref.includes("\\") ||
+    WORKFLOW_FILE_SUFFIXES.some((suffix) => ref.endsWith(suffix))
+  );
+}

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -130,6 +130,12 @@ function assertValidEdgeShape(edge: WorkflowEdge, index: number): void {
   if (typeof edge.switch.on !== "string" || edge.switch.on.length === 0) {
     fail(`edge ${index} switch.on must be a JSON path string`);
   }
+  // Routing only understands these prefixes; rejecting others here prevents
+  // the source node from executing its side effects before a routing error.
+  const on = edge.switch.on;
+  if (!on.startsWith("$.") && !on.startsWith("$output.") && !on.startsWith("$result.")) {
+    fail(`edge ${index} switch.on must start with "$.", "$output.", or "$result."`);
+  }
   assertRecord(edge.switch.cases, `edge ${index} switch.cases`);
   if (Object.keys(edge.switch.cases).length === 0) {
     fail(`edge ${index} switch.cases must not be empty`);

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -3,6 +3,7 @@ import type {
   ActionNodeDefinition,
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
+  FunctionActionNodeDefinition,
   ShellActionNodeDefinition,
   WorkflowDefinition,
   WorkflowEdge,
@@ -61,13 +62,21 @@ export function assertValidComputeNode(node: ComputeNodeDefinition, nodeId = "co
 }
 
 export function assertValidActionNode(node: ActionNodeDefinition, nodeId = "action"): void {
-  const hasRun = "run" in node && typeof node.run === "function";
-  const hasExec = "exec" in node && typeof node.exec === "function";
-  if (hasRun === hasExec) {
+  // Dispatch discriminates with `"exec" in node`, so validation must use the
+  // same property semantics: a present-but-invalid `exec` is an error even
+  // when a `run` function exists.
+  const hasExec = "exec" in node;
+  const hasRun = "run" in node;
+  if (hasExec === hasRun) {
     fail(`node ${nodeId} requires exactly one of run or exec`);
   }
   if (hasExec) {
+    if (typeof node.exec !== "function") {
+      fail(`node ${nodeId} exec must be a function`);
+    }
     assertOptionalFunction((node as ShellActionNodeDefinition).parse, `node ${nodeId} parse`);
+  } else if (typeof (node as FunctionActionNodeDefinition).run !== "function") {
+    fail(`node ${nodeId} run must be a function`);
   }
   assertCommonNodeFields(node, nodeId);
 }

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -31,8 +31,11 @@ function assertOptionalFunction(value: unknown, description: string): void {
 }
 
 function assertCommonNodeFields(node: WorkflowNodeDefinition, nodeId: string): void {
-  if (node.timeoutMs !== undefined && (typeof node.timeoutMs !== "number" || node.timeoutMs <= 0)) {
-    fail(`node ${nodeId} timeoutMs must be a positive number`);
+  if (
+    node.timeoutMs !== undefined &&
+    (typeof node.timeoutMs !== "number" || !Number.isFinite(node.timeoutMs) || node.timeoutMs <= 0)
+  ) {
+    fail(`node ${nodeId} timeoutMs must be a finite positive number`);
   }
   if (node.statusDetail !== undefined && typeof node.statusDetail !== "string") {
     fail(`node ${nodeId} statusDetail must be a string`);

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -1,0 +1,179 @@
+import type {
+  AgentNodeDefinition,
+  ActionNodeDefinition,
+  CheckpointNodeDefinition,
+  ComputeNodeDefinition,
+  ShellActionNodeDefinition,
+  WorkflowDefinition,
+  WorkflowEdge,
+  WorkflowNodeDefinition,
+} from "./types.js";
+
+const NODE_ID_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+
+function fail(message: string): never {
+  throw new Error(`Invalid workflow definition: ${message}`);
+}
+
+function assertRecord(
+  value: unknown,
+  description: string,
+): asserts value is Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${description} must be an object`);
+  }
+}
+
+function assertOptionalFunction(value: unknown, description: string): void {
+  if (value !== undefined && typeof value !== "function") {
+    fail(`${description} must be a function when provided`);
+  }
+}
+
+function assertCommonNodeFields(node: WorkflowNodeDefinition, nodeId: string): void {
+  if (node.timeoutMs !== undefined && (typeof node.timeoutMs !== "number" || node.timeoutMs <= 0)) {
+    fail(`node ${nodeId} timeoutMs must be a positive number`);
+  }
+  if (node.statusDetail !== undefined && typeof node.statusDetail !== "string") {
+    fail(`node ${nodeId} statusDetail must be a string`);
+  }
+}
+
+export function assertValidAgentNode(node: AgentNodeDefinition, nodeId = "agent"): void {
+  if (typeof node.prompt !== "function") {
+    fail(`node ${nodeId} requires a prompt function`);
+  }
+  if (node.expectedOutput !== undefined && typeof node.expectedOutput !== "string") {
+    fail(`node ${nodeId} expectedOutput must be a string`);
+  }
+  assertOptionalFunction(node.validate, `node ${nodeId} validate`);
+  assertCommonNodeFields(node, nodeId);
+}
+
+export function assertValidComputeNode(node: ComputeNodeDefinition, nodeId = "compute"): void {
+  if (typeof node.run !== "function") {
+    fail(`node ${nodeId} requires a run function`);
+  }
+  assertCommonNodeFields(node, nodeId);
+}
+
+export function assertValidActionNode(node: ActionNodeDefinition, nodeId = "action"): void {
+  const hasRun = "run" in node && typeof node.run === "function";
+  const hasExec = "exec" in node && typeof node.exec === "function";
+  if (hasRun === hasExec) {
+    fail(`node ${nodeId} requires exactly one of run or exec`);
+  }
+  if (hasExec) {
+    assertOptionalFunction((node as ShellActionNodeDefinition).parse, `node ${nodeId} parse`);
+  }
+  assertCommonNodeFields(node, nodeId);
+}
+
+export function assertValidShellActionNode(
+  node: ShellActionNodeDefinition,
+  nodeId = "shell",
+): void {
+  if (typeof node.exec !== "function") {
+    fail(`node ${nodeId} requires an exec function`);
+  }
+  assertOptionalFunction(node.parse, `node ${nodeId} parse`);
+  assertCommonNodeFields(node, nodeId);
+}
+
+export function assertValidCheckpointNode(
+  node: CheckpointNodeDefinition,
+  nodeId = "checkpoint",
+): void {
+  if (node.summary !== undefined && typeof node.summary !== "string") {
+    fail(`node ${nodeId} summary must be a string`);
+  }
+  assertOptionalFunction(node.run, `node ${nodeId} run`);
+  assertCommonNodeFields(node, nodeId);
+}
+
+function assertValidNode(node: WorkflowNodeDefinition, nodeId: string): void {
+  switch (node.nodeType) {
+    case "agent":
+      assertValidAgentNode(node, nodeId);
+      return;
+    case "compute":
+      assertValidComputeNode(node, nodeId);
+      return;
+    case "action":
+      assertValidActionNode(node, nodeId);
+      return;
+    case "checkpoint":
+      assertValidCheckpointNode(node, nodeId);
+      return;
+    default:
+      fail(
+        `node ${nodeId} has unknown nodeType ${String((node as { nodeType?: unknown }).nodeType)}`,
+      );
+  }
+}
+
+function assertValidEdgeShape(edge: WorkflowEdge, index: number): void {
+  assertRecord(edge, `edge ${index}`);
+  if (typeof edge.from !== "string" || edge.from.length === 0) {
+    fail(`edge ${index} requires a from node id`);
+  }
+  if ("to" in edge) {
+    if (typeof edge.to !== "string" || edge.to.length === 0) {
+      fail(`edge ${index} requires a to node id`);
+    }
+    return;
+  }
+  assertRecord(edge.switch, `edge ${index} switch`);
+  if (typeof edge.switch.on !== "string" || edge.switch.on.length === 0) {
+    fail(`edge ${index} switch.on must be a JSON path string`);
+  }
+  assertRecord(edge.switch.cases, `edge ${index} switch.cases`);
+  if (Object.keys(edge.switch.cases).length === 0) {
+    fail(`edge ${index} switch.cases must not be empty`);
+  }
+  for (const [caseKey, target] of Object.entries(edge.switch.cases)) {
+    if (typeof target !== "string" || target.length === 0) {
+      fail(`edge ${index} switch case ${JSON.stringify(caseKey)} must map to a node id`);
+    }
+  }
+}
+
+export function assertValidWorkflowDefinitionShape(definition: WorkflowDefinition): void {
+  assertRecord(definition, "workflow");
+  if (typeof definition.name !== "string" || definition.name.length === 0) {
+    fail("workflow requires a name");
+  }
+  if (
+    definition.title !== undefined &&
+    typeof definition.title !== "string" &&
+    typeof definition.title !== "function"
+  ) {
+    fail("workflow title must be a string or function");
+  }
+  if (typeof definition.startAt !== "string" || definition.startAt.length === 0) {
+    fail("workflow requires startAt");
+  }
+  if (
+    definition.maxSteps !== undefined &&
+    (typeof definition.maxSteps !== "number" ||
+      !Number.isInteger(definition.maxSteps) ||
+      definition.maxSteps <= 0)
+  ) {
+    fail("workflow maxSteps must be a positive integer");
+  }
+  assertRecord(definition.nodes, "workflow nodes");
+  if (Object.keys(definition.nodes).length === 0) {
+    fail("workflow requires at least one node");
+  }
+  for (const [nodeId, node] of Object.entries(definition.nodes)) {
+    if (!NODE_ID_PATTERN.test(nodeId)) {
+      fail(`node id ${JSON.stringify(nodeId)} must match ${NODE_ID_PATTERN.source}`);
+    }
+    assertRecord(node, `node ${nodeId}`);
+    assertValidNode(node, nodeId);
+  }
+  if (!Array.isArray(definition.edges)) {
+    fail("workflow edges must be an array");
+  }
+  definition.edges.forEach(assertValidEdgeShape);
+}

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -172,6 +172,11 @@ export function assertValidWorkflowDefinitionShape(definition: WorkflowDefinitio
     if (!NODE_ID_PATTERN.test(nodeId)) {
       fail(`node id ${JSON.stringify(nodeId)} must match ${NODE_ID_PATTERN.source}`);
     }
+    // Ids like __proto__ or toString would collide with Object prototype
+    // members in the plain-object maps used for outputs and results.
+    if (nodeId in Object.prototype) {
+      fail(`node id ${JSON.stringify(nodeId)} shadows an Object prototype member`);
+    }
     assertRecord(node, `node ${nodeId}`);
     assertValidNode(node, nodeId);
   }

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -124,7 +124,22 @@ export async function runShellAction(
       stderr = appendCapped(stderr, chunk);
     });
 
-    child.once("error", reject);
+    child.once("error", (error) => {
+      // Spawn failures (missing executable, EACCES) still get a receipt so
+      // failed actions remain auditable.
+      const result: ShellActionResult = {
+        command: spec.command,
+        args,
+        cwd,
+        stdout,
+        stderr,
+        exitCode: null,
+        signal: null,
+        durationMs: Date.now() - startMs,
+      };
+      (error as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT] = result;
+      reject(error);
+    });
     // `close` (unlike `exit`) fires only after stdio has fully closed, so
     // captured output is never truncated.
     child.once("close", (exitCode, signalName) => {

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { TimeoutError } from "./errors.js";
+import { CancelledError, TimeoutError } from "./errors.js";
 import type { ShellActionExecution, ShellActionResult } from "./types.js";
 
 export function renderShellCommand(command: string, args: string[]): string {
@@ -11,10 +11,13 @@ function shellFailure(
   spec: ShellActionExecution,
   args: string[],
   result: ShellActionResult,
-  timedOut: boolean,
+  killedBy: "timeout" | "abort" | null,
 ): Error | undefined {
-  if (timedOut) {
+  if (killedBy === "timeout") {
     return new TimeoutError(spec.timeoutMs ?? 0);
+  }
+  if (killedBy === "abort") {
+    return new CancelledError();
   }
   if (((result.exitCode ?? 0) !== 0 || result.signal != null) && spec.allowNonZeroExit !== true) {
     const status = result.signal ? `signal ${result.signal}` : `exit ${String(result.exitCode)}`;
@@ -26,7 +29,10 @@ function shellFailure(
   return undefined;
 }
 
-export async function runShellAction(spec: ShellActionExecution): Promise<ShellActionResult> {
+export async function runShellAction(
+  spec: ShellActionExecution,
+  signal?: AbortSignal,
+): Promise<ShellActionResult> {
   const cwd = spec.cwd ?? process.cwd();
   const args = spec.args ?? [];
   const startMs = Date.now();
@@ -40,8 +46,17 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
 
   let stdout = "";
   let stderr = "";
-  let timedOut = false;
+  let killedBy: "timeout" | "abort" | null = null;
   let timeout: NodeJS.Timeout | undefined;
+
+  const kill = (reason: "timeout" | "abort") => {
+    killedBy ??= reason;
+    child.kill("SIGTERM");
+    setTimeout(() => {
+      child.kill("SIGKILL");
+    }, 1_000).unref();
+  };
+  const onAbort = () => kill("abort");
 
   const finish = new Promise<ShellActionResult>((resolve, reject) => {
     child.stdout.setEncoding("utf8");
@@ -54,7 +69,9 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     });
 
     child.once("error", reject);
-    child.once("exit", (exitCode, signal) => {
+    // `close` (unlike `exit`) fires only after stdio has fully closed, so
+    // captured output is never truncated.
+    child.once("close", (exitCode, signalName) => {
       const result: ShellActionResult = {
         command: spec.command,
         args,
@@ -62,10 +79,10 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
         stdout,
         stderr,
         exitCode,
-        signal,
+        signal: signalName,
         durationMs: Date.now() - startMs,
       };
-      const error = shellFailure(spec, args, result, timedOut);
+      const error = shellFailure(spec, args, result, killedBy);
       if (error) {
         reject(error);
         return;
@@ -80,13 +97,14 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
   child.stdin.end();
 
   if (spec.timeoutMs != null && spec.timeoutMs > 0) {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      setTimeout(() => {
-        child.kill("SIGKILL");
-      }, 1_000).unref();
-    }, spec.timeoutMs);
+    timeout = setTimeout(() => kill("timeout"), spec.timeoutMs);
+  }
+  if (signal) {
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
   }
 
   try {
@@ -95,5 +113,6 @@ export async function runShellAction(spec: ShellActionExecution): Promise<ShellA
     if (timeout) {
       clearTimeout(timeout);
     }
+    signal?.removeEventListener("abort", onAbort);
   }
 }

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -36,12 +36,16 @@ export async function runShellAction(
   const cwd = spec.cwd ?? process.cwd();
   const args = spec.args ?? [];
   const startMs = Date.now();
+  // POSIX: run in its own process group so timeout/abort can kill the whole
+  // tree, including descendants that inherited the stdio pipes.
+  const useProcessGroup = process.platform !== "win32";
   const child = spawn(spec.command, args, {
     cwd,
     env: { ...process.env, ...spec.env },
     shell: spec.shell,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
+    detached: useProcessGroup,
   });
 
   let stdout = "";
@@ -49,11 +53,23 @@ export async function runShellAction(
   let killedBy: "timeout" | "abort" | null = null;
   let timeout: NodeJS.Timeout | undefined;
 
+  const signalTree = (killSignal: NodeJS.Signals) => {
+    if (useProcessGroup && child.pid !== undefined) {
+      try {
+        process.kill(-child.pid, killSignal);
+        return;
+      } catch {
+        // Group already gone; fall back to the direct child.
+      }
+    }
+    child.kill(killSignal);
+  };
+
   const kill = (reason: "timeout" | "abort") => {
     killedBy ??= reason;
-    child.kill("SIGTERM");
+    signalTree("SIGTERM");
     setTimeout(() => {
-      child.kill("SIGKILL");
+      signalTree("SIGKILL");
     }, 1_000).unref();
   };
   const onAbort = () => kill("abort");

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -52,6 +52,11 @@ export async function runShellAction(
   spec: ShellActionExecution,
   signal?: AbortSignal,
 ): Promise<ShellActionResult> {
+  // The node may have been cancelled while an async `exec` callback resolved;
+  // never start side effects for an already-abandoned attempt.
+  if (signal?.aborted) {
+    throw new CancelledError();
+  }
   const cwd = spec.cwd ?? process.cwd();
   const args = spec.args ?? [];
   const startMs = Date.now();
@@ -98,12 +103,14 @@ export async function runShellAction(
     child.kill(killSignal);
   };
 
+  let killEscalation: NodeJS.Timeout | undefined;
   const kill = (reason: "timeout" | "abort") => {
     killedBy ??= reason;
     signalTree("SIGTERM");
-    setTimeout(() => {
+    killEscalation ??= setTimeout(() => {
       signalTree("SIGKILL");
-    }, 1_000).unref();
+    }, 1_000);
+    killEscalation.unref();
   };
   const onAbort = () => kill("abort");
 
@@ -142,6 +149,9 @@ export async function runShellAction(
     });
   });
 
+  // A child that exits without consuming stdin emits EPIPE; without a
+  // listener that would crash the whole process instead of just this action.
+  child.stdin.on("error", () => {});
   if (spec.stdin != null) {
     child.stdin.write(spec.stdin);
   }
@@ -163,6 +173,11 @@ export async function runShellAction(
   } finally {
     if (timeout) {
       clearTimeout(timeout);
+    }
+    if (killEscalation) {
+      // The group pid may be reused after the child exits; never let the
+      // delayed SIGKILL fire once the command has fully closed.
+      clearTimeout(killEscalation);
     }
     signal?.removeEventListener("abort", onAbort);
   }

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -1,0 +1,99 @@
+import { spawn } from "node:child_process";
+import { TimeoutError } from "./errors.js";
+import type { ShellActionExecution, ShellActionResult } from "./types.js";
+
+export function renderShellCommand(command: string, args: string[]): string {
+  const renderedArgs = args.map((arg) => JSON.stringify(arg)).join(" ");
+  return renderedArgs.length > 0 ? `${command} ${renderedArgs}` : command;
+}
+
+function shellFailure(
+  spec: ShellActionExecution,
+  args: string[],
+  result: ShellActionResult,
+  timedOut: boolean,
+): Error | undefined {
+  if (timedOut) {
+    return new TimeoutError(spec.timeoutMs ?? 0);
+  }
+  if (((result.exitCode ?? 0) !== 0 || result.signal != null) && spec.allowNonZeroExit !== true) {
+    const status = result.signal ? `signal ${result.signal}` : `exit ${String(result.exitCode)}`;
+    const details = result.stderr.length > 0 ? `\n${result.stderr.trim()}` : "";
+    return new Error(
+      `Shell action failed (${renderShellCommand(spec.command, args)}): ${status}${details}`,
+    );
+  }
+  return undefined;
+}
+
+export async function runShellAction(spec: ShellActionExecution): Promise<ShellActionResult> {
+  const cwd = spec.cwd ?? process.cwd();
+  const args = spec.args ?? [];
+  const startMs = Date.now();
+  const child = spawn(spec.command, args, {
+    cwd,
+    env: { ...process.env, ...spec.env },
+    shell: spec.shell,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let timedOut = false;
+  let timeout: NodeJS.Timeout | undefined;
+
+  const finish = new Promise<ShellActionResult>((resolve, reject) => {
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.once("error", reject);
+    child.once("exit", (exitCode, signal) => {
+      const result: ShellActionResult = {
+        command: spec.command,
+        args,
+        cwd,
+        stdout,
+        stderr,
+        exitCode,
+        signal,
+        durationMs: Date.now() - startMs,
+      };
+      const error = shellFailure(spec, args, result, timedOut);
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(result);
+    });
+  });
+
+  if (spec.stdin != null) {
+    child.stdin.write(spec.stdin);
+  }
+  child.stdin.end();
+
+  if (spec.timeoutMs != null && spec.timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        child.kill("SIGKILL");
+      }, 1_000).unref();
+    }, spec.timeoutMs);
+  }
+
+  try {
+    return await finish;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -2,6 +2,25 @@ import { spawn } from "node:child_process";
 import { CancelledError, TimeoutError } from "./errors.js";
 import type { ShellActionExecution, ShellActionResult } from "./types.js";
 
+/** Default cap on captured stdout/stderr, each. */
+const DEFAULT_MAX_OUTPUT_CHARS = 1_000_000;
+const TRUNCATION_MARKER = "\n…[output truncated]";
+
+const SHELL_RESULT = Symbol.for("pi-workflows.shell-result");
+
+/**
+ * Retrieve the shell result attached to an error thrown by
+ * {@link runShellAction}, so callers can persist the action receipt even when
+ * the command failed.
+ */
+export function shellResultFromError(error: unknown): ShellActionResult | null {
+  if (error instanceof Error) {
+    const attached = (error as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT];
+    return attached ?? null;
+  }
+  return null;
+}
+
 export function renderShellCommand(command: string, args: string[]): string {
   const renderedArgs = args.map((arg) => JSON.stringify(arg)).join(" ");
   return renderedArgs.length > 0 ? `${command} ${renderedArgs}` : command;
@@ -53,6 +72,20 @@ export async function runShellAction(
   let killedBy: "timeout" | "abort" | null = null;
   let timeout: NodeJS.Timeout | undefined;
 
+  // Cap retained output so a verbose or unending command cannot exhaust
+  // memory before its timeout fires.
+  const maxOutputChars = spec.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const appendCapped = (current: string, chunk: string): string => {
+    if (current.endsWith(TRUNCATION_MARKER)) {
+      return current;
+    }
+    const room = maxOutputChars - current.length;
+    if (chunk.length <= room) {
+      return current + chunk;
+    }
+    return current + chunk.slice(0, Math.max(0, room)) + TRUNCATION_MARKER;
+  };
+
   const signalTree = (killSignal: NodeJS.Signals) => {
     if (useProcessGroup && child.pid !== undefined) {
       try {
@@ -78,10 +111,10 @@ export async function runShellAction(
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+      stdout = appendCapped(stdout, chunk);
     });
     child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
+      stderr = appendCapped(stderr, chunk);
     });
 
     child.once("error", reject);
@@ -100,6 +133,8 @@ export async function runShellAction(
       };
       const error = shellFailure(spec, args, result, killedBy);
       if (error) {
+        // Attach the result so callers can persist the action receipt.
+        (error as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT] = result;
         reject(error);
         return;
       }

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1,0 +1,234 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  WorkflowDefinition,
+  WorkflowDefinitionSnapshot,
+  WorkflowNodeDefinition,
+  WorkflowNodeSnapshot,
+  WorkflowRunManifest,
+  WorkflowRunState,
+  WorkflowTraceEvent,
+  WorkflowTraceEventDraft,
+} from "./types.js";
+
+export const RUN_BUNDLE_SCHEMA = "pi-workflows.run-bundle.v1" as const;
+export const TRACE_EVENT_SCHEMA = "pi-workflows.trace-event.v1" as const;
+export const DEFINITION_SNAPSHOT_SCHEMA = "pi-workflows.definition-snapshot.v1" as const;
+
+const MANIFEST_PATH = "manifest.json";
+const WORKFLOW_SNAPSHOT_PATH = "workflow.json";
+const STATE_PATH = "state.json";
+const TRACE_PATH = "trace.ndjson";
+
+/** Runs directory: `$PI_WORKFLOWS_RUNS_DIR` or `~/.pi/agent/workflows/runs`. */
+export function workflowRunsBaseDir(homeDir: string = os.homedir()): string {
+  const override = process.env.PI_WORKFLOWS_RUNS_DIR;
+  if (override !== undefined && override.length > 0) {
+    return override;
+  }
+  return path.join(homeDir, ".pi", "agent", "workflows", "runs");
+}
+
+export function createRunId(workflowName: string, now: Date = new Date()): string {
+  const stamp = now
+    .toISOString()
+    .replaceAll(/[-:]/g, "")
+    .replace(/\.\d+Z$/, "Z");
+  const slug = workflowName
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/(^-|-$)/g, "")
+    .slice(0, 40);
+  return `${stamp}-${slug || "workflow"}-${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Persists run bundles. A bundle directory contains `manifest.json`,
+ * `workflow.json` (definition snapshot), `state.json` (full run projection,
+ * atomically replaced), and `trace.ndjson` (append-only event log).
+ */
+export class WorkflowRunStore {
+  readonly outputRoot: string;
+  private readonly traceSeqByRun = new Map<string, number>();
+  private readonly appendChainByPath = new Map<string, Promise<void>>();
+
+  constructor(outputRoot: string = workflowRunsBaseDir()) {
+    this.outputRoot = outputRoot;
+  }
+
+  runDirFor(runId: string): string {
+    return path.join(this.outputRoot, runId);
+  }
+
+  async initializeRunBundle(
+    workflow: WorkflowDefinition,
+    state: WorkflowRunState,
+  ): Promise<string> {
+    const runDir = this.runDirFor(state.runId);
+    await fs.mkdir(runDir, { recursive: true });
+    this.traceSeqByRun.set(runDir, 0);
+
+    await writeJsonAtomic(
+      path.join(runDir, WORKFLOW_SNAPSHOT_PATH),
+      createDefinitionSnapshot(workflow),
+    );
+    await writeJsonAtomic(path.join(runDir, MANIFEST_PATH), createManifest(state));
+    await writeJsonAtomic(path.join(runDir, STATE_PATH), state);
+    await this.appendJsonLine(path.join(runDir, TRACE_PATH), null);
+
+    return runDir;
+  }
+
+  async writeSnapshot(
+    runDir: string,
+    state: WorkflowRunState,
+    event: WorkflowTraceEventDraft,
+  ): Promise<WorkflowTraceEvent> {
+    state.updatedAt = new Date().toISOString();
+    await writeJsonAtomic(path.join(runDir, STATE_PATH), state);
+    await writeJsonAtomic(path.join(runDir, MANIFEST_PATH), createManifest(state));
+    return await this.appendTrace(runDir, state, event);
+  }
+
+  async appendTrace(
+    runDir: string,
+    state: WorkflowRunState,
+    event: WorkflowTraceEventDraft,
+  ): Promise<WorkflowTraceEvent> {
+    const traceEvent: WorkflowTraceEvent = {
+      seq: this.nextTraceSeq(runDir),
+      at: new Date().toISOString(),
+      runId: state.runId,
+      ...event,
+    };
+    await this.appendJsonLine(path.join(runDir, TRACE_PATH), traceEvent);
+    return traceEvent;
+  }
+
+  private nextTraceSeq(runDir: string): number {
+    const next = (this.traceSeqByRun.get(runDir) ?? 0) + 1;
+    this.traceSeqByRun.set(runDir, next);
+    return next;
+  }
+
+  private async appendJsonLine(filePath: string, value: unknown): Promise<void> {
+    const prior = this.appendChainByPath.get(filePath) ?? Promise.resolve();
+    const nextWrite = prior.then(async () => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.appendFile(filePath, value === null ? "" : `${JSON.stringify(value)}\n`, "utf8");
+    });
+    const tracked = nextWrite.finally(() => {
+      if (this.appendChainByPath.get(filePath) === tracked) {
+        this.appendChainByPath.delete(filePath);
+      }
+    });
+    this.appendChainByPath.set(filePath, tracked);
+    await tracked;
+  }
+}
+
+export type LoadedRunBundle = {
+  runDir: string;
+  manifest: WorkflowRunManifest;
+  state: WorkflowRunState;
+  snapshot: WorkflowDefinitionSnapshot | null;
+};
+
+/** Read a run bundle from disk. Returns null when the bundle is unreadable. */
+export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | null> {
+  const manifest = await readJsonFile<WorkflowRunManifest>(path.join(runDir, MANIFEST_PATH));
+  const state = await readJsonFile<WorkflowRunState>(path.join(runDir, STATE_PATH));
+  if (!manifest || !state || manifest.schema !== RUN_BUNDLE_SCHEMA) {
+    return null;
+  }
+  const snapshot = await readJsonFile<WorkflowDefinitionSnapshot>(
+    path.join(runDir, WORKFLOW_SNAPSHOT_PATH),
+  );
+  return { runDir, manifest, state, snapshot };
+}
+
+/** List run bundles under `outputRoot`, most recently started first. */
+export async function listRunBundles(outputRoot: string): Promise<LoadedRunBundle[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(outputRoot);
+  } catch {
+    return [];
+  }
+  const bundles: LoadedRunBundle[] = [];
+  for (const entry of entries) {
+    const bundle = await readRunBundle(path.join(outputRoot, entry));
+    if (bundle) {
+      bundles.push(bundle);
+    }
+  }
+  bundles.sort((a, b) => b.state.startedAt.localeCompare(a.state.startedAt));
+  return bundles;
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function createManifest(state: WorkflowRunState): WorkflowRunManifest {
+  return {
+    schema: RUN_BUNDLE_SCHEMA,
+    runId: state.runId,
+    workflowName: state.workflowName,
+    ...(state.runTitle !== undefined ? { runTitle: state.runTitle } : {}),
+    ...(state.workflowPath !== undefined ? { workflowPath: state.workflowPath } : {}),
+    startedAt: state.startedAt,
+    ...(state.finishedAt !== undefined ? { finishedAt: state.finishedAt } : {}),
+    status: state.status,
+    traceSchema: TRACE_EVENT_SCHEMA,
+    paths: {
+      workflow: WORKFLOW_SNAPSHOT_PATH,
+      state: STATE_PATH,
+      trace: TRACE_PATH,
+    },
+  };
+}
+
+export function createDefinitionSnapshot(workflow: WorkflowDefinition): WorkflowDefinitionSnapshot {
+  return {
+    schema: DEFINITION_SNAPSHOT_SCHEMA,
+    name: workflow.name,
+    startAt: workflow.startAt,
+    nodes: Object.fromEntries(
+      Object.entries(workflow.nodes).map(([nodeId, node]) => [nodeId, snapshotNode(node)]),
+    ),
+    edges: structuredClone(workflow.edges),
+  };
+}
+
+function snapshotNode(node: WorkflowNodeDefinition): WorkflowNodeSnapshot {
+  const common: WorkflowNodeSnapshot = {
+    nodeType: node.nodeType,
+    ...(node.timeoutMs !== undefined ? { timeoutMs: node.timeoutMs } : {}),
+    ...(node.statusDetail !== undefined ? { statusDetail: node.statusDetail } : {}),
+  };
+  if (node.nodeType === "agent" && node.expectedOutput !== undefined) {
+    common.expectedOutput = node.expectedOutput;
+  }
+  if (node.nodeType === "checkpoint" && node.summary !== undefined) {
+    common.summary = node.summary;
+  }
+  if (node.nodeType === "action") {
+    common.actionExecution = "exec" in node ? "shell" : "function";
+  }
+  return common;
+}
+
+async function writeJsonAtomic(filePath: string, value: unknown): Promise<void> {
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fs.rename(tempPath, filePath);
+}

--- a/src/workflows/text.ts
+++ b/src/workflows/text.ts
@@ -1,0 +1,34 @@
+/** Remove ANSI escape sequences (CSI style) from a string. */
+export function stripAnsi(text: string): string {
+  let result = "";
+  let index = 0;
+  while (index < text.length) {
+    if (text[index] === "\u001b" && text[index + 1] === "[") {
+      index += 2;
+      while (index < text.length && !/[A-Za-z]/.test(text[index] as string)) {
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    result += text[index];
+    index += 1;
+  }
+  return result;
+}
+
+/**
+ * Remove ANSI escapes and control characters from untrusted text (model
+ * outputs, errors, titles) so rendering it cannot alter terminal state. Line
+ * breaks and tabs collapse to single spaces because callers interpolate the
+ * result into single terminal lines, where a stray newline would break
+ * viewport math and allow fake rows.
+ */
+export function sanitizeText(text: string): string {
+  return (
+    stripAnsi(text)
+      .replaceAll(/[\t\n\r]+/g, " ")
+      // eslint-disable-next-line no-control-regex
+      .replaceAll(/[\u0000-\u001f\u007f]/g, "")
+  );
+}

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -80,6 +80,8 @@ export type ShellActionExecution = {
   shell?: boolean | string;
   allowNonZeroExit?: boolean;
   timeoutMs?: number;
+  /** Cap on captured stdout/stderr each, default 1,000,000 characters. */
+  maxOutputChars?: number;
 };
 
 export type ShellActionResult = {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -1,0 +1,290 @@
+export type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * Context passed to node callbacks (prompt builders, compute/action runners,
+ * validators). `outputs` maps node ids to their accepted outputs; `results`
+ * maps node ids to the full result record of their latest attempt.
+ */
+export type WorkflowNodeContext<TInput = unknown> = {
+  input: TInput;
+  outputs: Record<string, unknown>;
+  results: Record<string, WorkflowNodeResult>;
+  state: WorkflowRunState;
+};
+
+export type WorkflowNodeCommon = {
+  /** Per-node timeout. Falls back to the engine default (15 minutes). */
+  timeoutMs?: number;
+  /** Short human-readable label shown in the viewer while the node runs. */
+  statusDetail?: string;
+};
+
+/**
+ * Edges route between nodes. A node has at most one outgoing edge: either a
+ * plain `to` edge or a `switch` edge that routes on a JSON path into the
+ * node's output (`$.field`, `$output.field`) or result (`$result.outcome`).
+ */
+export type WorkflowEdge =
+  | {
+      from: string;
+      to: string;
+    }
+  | {
+      from: string;
+      switch: {
+        on: string;
+        cases: Record<string, string>;
+      };
+    };
+
+/**
+ * A model-shaped step. The engine sends the prompt into the pi conversation
+ * and the model completes the step by calling the `workflow` tool with a JSON
+ * output. `expectedOutput` is appended to the step contract so the model
+ * knows what shape to submit. `validate` may reject (throw) or normalize the
+ * submitted output; rejections are surfaced to the model so it can retry
+ * within the same step.
+ */
+export type AgentNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "agent";
+  prompt: (context: WorkflowNodeContext) => MaybePromise<string>;
+  expectedOutput?: string;
+  validate?: (output: unknown, context: WorkflowNodeContext) => MaybePromise<unknown>;
+};
+
+/** A pure local function: shape inputs, route, format, derive values. */
+export type ComputeNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "compute";
+  run: (context: WorkflowNodeContext) => MaybePromise<unknown>;
+};
+
+/** A deterministic runtime-owned step implemented as a local function. */
+export type FunctionActionNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "action";
+  run: (context: WorkflowNodeContext) => MaybePromise<unknown>;
+};
+
+export type ShellActionExecution = {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string;
+  shell?: boolean | string;
+  allowNonZeroExit?: boolean;
+  timeoutMs?: number;
+};
+
+export type ShellActionResult = {
+  command: string;
+  args: string[];
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  durationMs: number;
+};
+
+/** A deterministic runtime-owned step implemented as a shell command. */
+export type ShellActionNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "action";
+  exec: (context: WorkflowNodeContext) => MaybePromise<ShellActionExecution>;
+  parse?: (result: ShellActionResult, context: WorkflowNodeContext) => MaybePromise<unknown>;
+};
+
+export type ActionNodeDefinition = FunctionActionNodeDefinition | ShellActionNodeDefinition;
+
+/**
+ * A pause point. The run terminates with status `waiting` so a human (or an
+ * external trigger) can decide how to continue. The optional `run` callback
+ * produces the checkpoint's output before the run pauses.
+ */
+export type CheckpointNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "checkpoint";
+  summary?: string;
+  run?: (context: WorkflowNodeContext) => MaybePromise<unknown>;
+};
+
+export type WorkflowNodeDefinition =
+  | AgentNodeDefinition
+  | ComputeNodeDefinition
+  | ActionNodeDefinition
+  | CheckpointNodeDefinition;
+
+export type WorkflowDefinition = {
+  name: string;
+  /** Optional human-readable run title (static or derived from input). */
+  title?:
+    | string
+    | ((context: { input: unknown; workflowName: string }) => MaybePromise<string | undefined>);
+  startAt: string;
+  nodes: Record<string, WorkflowNodeDefinition>;
+  edges: WorkflowEdge[];
+  /** Guard against unbounded loops. Defaults to the engine's maxSteps. */
+  maxSteps?: number;
+};
+
+export type WorkflowNodeOutcome = "ok" | "timed_out" | "failed" | "cancelled";
+
+export type WorkflowNodeResult = {
+  attemptId: string;
+  nodeId: string;
+  nodeType: WorkflowNodeDefinition["nodeType"];
+  outcome: WorkflowNodeOutcome;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  output?: unknown;
+  error?: string;
+};
+
+export type WorkflowActionReceipt = {
+  actionType: "shell" | "function";
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  durationMs?: number;
+};
+
+export type WorkflowStepRecord = {
+  attemptId: string;
+  nodeId: string;
+  nodeType: WorkflowNodeDefinition["nodeType"];
+  outcome: WorkflowNodeOutcome;
+  startedAt: string;
+  finishedAt: string;
+  promptText: string | null;
+  output: unknown;
+  error?: string;
+  action?: WorkflowActionReceipt;
+};
+
+export type WorkflowRunStatus =
+  | "running"
+  | "waiting"
+  | "completed"
+  | "failed"
+  | "timed_out"
+  | "cancelled";
+
+export type WorkflowRunState = {
+  runId: string;
+  workflowName: string;
+  runTitle?: string;
+  workflowPath?: string;
+  startedAt: string;
+  finishedAt?: string;
+  updatedAt: string;
+  status: WorkflowRunStatus;
+  input: unknown;
+  outputs: Record<string, unknown>;
+  results: Record<string, WorkflowNodeResult>;
+  steps: WorkflowStepRecord[];
+  currentNode?: string;
+  currentAttemptId?: string;
+  currentNodeType?: WorkflowNodeDefinition["nodeType"];
+  currentNodeStartedAt?: string;
+  statusDetail?: string;
+  waitingOn?: string;
+  finalOutput?: unknown;
+  error?: string;
+};
+
+export type WorkflowNodeSnapshot = {
+  nodeType: WorkflowNodeDefinition["nodeType"];
+  timeoutMs?: number;
+  statusDetail?: string;
+  summary?: string;
+  expectedOutput?: string;
+  actionExecution?: "function" | "shell";
+};
+
+export type WorkflowDefinitionSnapshot = {
+  schema: "pi-workflows.definition-snapshot.v1";
+  name: string;
+  startAt: string;
+  nodes: Record<string, WorkflowNodeSnapshot>;
+  edges: WorkflowEdge[];
+};
+
+export type WorkflowTraceEvent = {
+  seq: number;
+  at: string;
+  scope: "run" | "node" | "agent" | "action";
+  type: string;
+  runId: string;
+  nodeId?: string;
+  attemptId?: string;
+  payload: Record<string, unknown>;
+};
+
+export type WorkflowTraceEventDraft = Omit<WorkflowTraceEvent, "seq" | "at" | "runId">;
+
+export type WorkflowRunManifest = {
+  schema: "pi-workflows.run-bundle.v1";
+  runId: string;
+  workflowName: string;
+  runTitle?: string;
+  workflowPath?: string;
+  startedAt: string;
+  finishedAt?: string;
+  status: WorkflowRunStatus;
+  traceSchema: "pi-workflows.trace-event.v1";
+  paths: {
+    workflow: string;
+    state: string;
+    trace: string;
+  };
+};
+
+export type WorkflowRunResult = {
+  runDir: string;
+  state: WorkflowRunState;
+};
+
+/** The step contract handed to the executor alongside the prompt. */
+export type AgentStepContract = {
+  runId: string;
+  workflowName: string;
+  nodeId: string;
+  attemptId: string;
+  expectedOutput?: string;
+};
+
+export type AgentStepRequest = {
+  contract: AgentStepContract;
+  prompt: string;
+  /**
+   * Validate a submission from the model. Returns the normalized output or an
+   * error message the executor should surface to the model for retry.
+   */
+  accept: (output: unknown) => Promise<{ ok: true; value: unknown } | { ok: false; error: string }>;
+};
+
+export type AgentStepSubmission = {
+  output: unknown;
+};
+
+/**
+ * Runs one agent step to completion. Implementations deliver the prompt to
+ * the model and resolve once a submission has been accepted via `accept`.
+ * Must reject with an `AbortError`-like error when `signal` aborts.
+ */
+export interface AgentStepExecutor {
+  runAgentStep(request: AgentStepRequest, signal: AbortSignal): Promise<AgentStepSubmission>;
+}
+
+export type WorkflowEngineOptions = {
+  executor: AgentStepExecutor;
+  /** Root directory for run bundles. Defaults to `~/.pi/agent/workflows/runs`. */
+  outputRoot?: string;
+  /** Default per-node timeout. Defaults to 15 minutes. */
+  defaultNodeTimeoutMs?: number;
+  /** Guard against unbounded graph loops. Defaults to 100 executed steps. */
+  maxSteps?: number;
+  /** Observer invoked after every persisted trace event. */
+  onEvent?: (event: WorkflowTraceEvent, state: WorkflowRunState) => void;
+};

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -10,6 +10,13 @@ export type WorkflowNodeContext<TInput = unknown> = {
   outputs: Record<string, unknown>;
   results: Record<string, WorkflowNodeResult>;
   state: WorkflowRunState;
+  /**
+   * Aborted when the node times out or the run is cancelled. Long-running
+   * callbacks should observe it (pass it to fetch/spawn or check
+   * `signal.aborted`) so side effects stop when the engine gives up on the
+   * node.
+   */
+  signal: AbortSignal;
 };
 
 export type WorkflowNodeCommon = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,110 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { main, parseCliArgs } from "../src/viewer/cli.js";
+import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { ScriptedExecutor, makeTempDir } from "./helpers.js";
+
+async function makeCompletedRun(outputRoot: string): Promise<string> {
+  const workflow = defineWorkflow({
+    name: "cli-demo",
+    startAt: "one",
+    nodes: { one: compute({ run: () => ({ ok: true }) }) },
+    edges: [],
+  });
+  const engine = new WorkflowEngine({ executor: new ScriptedExecutor(), outputRoot });
+  const { state } = await engine.run(workflow, {});
+  return state.runId;
+}
+
+let stdout: string;
+let stderr: string;
+
+beforeEach(() => {
+  stdout = "";
+  stderr = "";
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout += String(chunk);
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    stderr += String(chunk);
+    return true;
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseCliArgs", () => {
+  it("defaults to view with the standard runs dir", () => {
+    const args = parseCliArgs([]);
+    expect(args.command).toBe("view");
+    expect(args.dir).toContain(path.join(".pi", "agent", "workflows", "runs"));
+    expect(args.once).toBe(false);
+  });
+
+  it("parses command, run id, dir, and once", () => {
+    const args = parseCliArgs(["view", "run-123", "--dir", "/tmp/runs", "--once"]);
+    expect(args).toEqual({ command: "view", runId: "run-123", dir: "/tmp/runs", once: true });
+  });
+
+  it("parses runs command and help", () => {
+    expect(parseCliArgs(["runs"]).command).toBe("runs");
+    expect(parseCliArgs(["--help"]).command).toBe("help");
+  });
+
+  it("rejects unknown flags and missing --dir values", () => {
+    expect(() => parseCliArgs(["view", "--nope"])).toThrow(/Unknown argument/);
+    expect(() => parseCliArgs(["view", "--dir"])).toThrow(/--dir requires/);
+  });
+});
+
+describe("pi-workflows CLI", () => {
+  it("prints usage for help", async () => {
+    expect(await main(["--help"])).toBe(0);
+    expect(stdout).toContain("pi-workflows — live terminal viewer");
+  });
+
+  it("lists runs", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-cli");
+    const runId = await makeCompletedRun(outputRoot);
+    expect(await main(["runs", "--dir", outputRoot])).toBe(0);
+    expect(stdout).toContain(runId);
+    expect(stdout).toContain("completed");
+  });
+
+  it("reports an empty runs dir", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-cli");
+    expect(await main(["runs", "--dir", outputRoot])).toBe(0);
+    expect(stdout).toContain("No workflow runs found");
+  });
+
+  it("renders a run detail snapshot with --once", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-cli");
+    const runId = await makeCompletedRun(outputRoot);
+    expect(await main(["view", runId, "--dir", outputRoot, "--once"])).toBe(0);
+    expect(stdout).toContain("workflow cli-demo");
+    expect(stdout).toContain("one [compute]");
+  });
+
+  it("renders the run list with --once and no run id", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-cli");
+    await makeCompletedRun(outputRoot);
+    expect(await main(["view", "--dir", outputRoot, "--once"])).toBe(0);
+    expect(stdout).toContain("pi-workflows — runs");
+  });
+
+  it("fails cleanly for unknown runs, bad args, and unknown commands", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-cli");
+    expect(await main(["view", "nope", "--dir", outputRoot, "--once"])).toBe(1);
+    expect(stderr).toContain("Run not found");
+
+    expect(await main(["view", "--bogus"])).toBe(2);
+    expect(stderr).toContain("Unknown argument");
+
+    expect(await main(["frobnicate"])).toBe(2);
+    expect(stderr).toContain("Unknown command");
+  });
+});

--- a/test/decision.test.ts
+++ b/test/decision.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { decision, decisionEdge } from "../src/workflows/decision.js";
+import type { WorkflowNodeContext, WorkflowRunState } from "../src/workflows/types.js";
+
+function makeContext(): WorkflowNodeContext {
+  const state = {
+    runId: "r",
+    workflowName: "w",
+    startedAt: "",
+    updatedAt: "",
+    status: "running",
+    input: {},
+    outputs: {},
+    results: {},
+    steps: [],
+  } as WorkflowRunState;
+  return { input: {}, outputs: {}, results: {}, state };
+}
+
+describe("decision", () => {
+  const node = decision({ choices: ["y", "n"] as const, question: "Same? y/n" });
+
+  it("builds an agent node with an expected output contract", () => {
+    expect(node.nodeType).toBe("agent");
+    expect(node.expectedOutput).toContain('"route"');
+    expect(node.expectedOutput).toContain('"y" | "n"');
+  });
+
+  it("renders the question and choices in the prompt", async () => {
+    const prompt = await node.prompt(makeContext());
+    expect(prompt).toContain("Same? y/n");
+    expect(prompt).toContain('"y" | "n"');
+  });
+
+  it("supports question functions", async () => {
+    const dynamic = decision({ choices: ["a"] as const, question: () => "Dynamic?" });
+    expect(await dynamic.prompt(makeContext())).toContain("Dynamic?");
+  });
+
+  it("accepts a valid choice", async () => {
+    const output = await node.validate?.({ route: "y", reason: "match" }, makeContext());
+    expect(output).toEqual({ route: "y", reason: "match" });
+  });
+
+  it("accepts JSON submitted as a string", async () => {
+    const output = await node.validate?.(`{"route":"n","reason":"differs"}`, makeContext());
+    expect(output).toEqual({ route: "n", reason: "differs" });
+  });
+
+  it("rejects invalid choices", async () => {
+    await expect(async () => node.validate?.({ route: "maybe" }, makeContext())).rejects.toThrow(
+      /invalid route/,
+    );
+  });
+
+  it("rejects non-object outputs", async () => {
+    await expect(async () => node.validate?.([1, 2], makeContext())).rejects.toThrow(/JSON object/);
+    await expect(async () => node.validate?.(null, makeContext())).rejects.toThrow(/JSON object/);
+  });
+
+  it("supports custom fields", async () => {
+    const custom = decision({ choices: ["bug"] as const, question: "q", field: "kind" });
+    expect(await custom.validate?.({ kind: "bug" }, makeContext())).toEqual({ kind: "bug" });
+  });
+
+  it("rejects invalid field names", () => {
+    expect(() => decision({ choices: ["a"] as const, question: "q", field: "bad-field" })).toThrow(
+      /simple JSON key/,
+    );
+  });
+
+  it("rejects empty and duplicate choices", () => {
+    expect(() => decision({ choices: [] as unknown as readonly ["x"], question: "q" })).toThrow(
+      /at least one/,
+    );
+    expect(() => decision({ choices: ["a", "a"] as const, question: "q" })).toThrow(/unique/);
+  });
+});
+
+describe("decisionEdge", () => {
+  it("builds a switch edge over the decision field", () => {
+    const edge = decisionEdge({
+      from: "d",
+      choices: ["y", "n"] as const,
+      cases: { y: "a", n: "b" },
+    });
+    expect(edge).toEqual({ from: "d", switch: { on: "$.route", cases: { y: "a", n: "b" } } });
+  });
+
+  it("uses custom fields in the path", () => {
+    const edge = decisionEdge({
+      from: "d",
+      choices: ["bug"] as const,
+      field: "kind",
+      cases: { bug: "fix" },
+    });
+    expect(edge).toEqual({ from: "d", switch: { on: "$.kind", cases: { bug: "fix" } } });
+  });
+
+  it("rejects missing cases", () => {
+    expect(() =>
+      decisionEdge({
+        from: "d",
+        choices: ["y", "n"] as const,
+        cases: { y: "a" } as Record<"y" | "n", string>,
+      }),
+    ).toThrow(/missing case/);
+  });
+});

--- a/test/decision.test.ts
+++ b/test/decision.test.ts
@@ -14,7 +14,7 @@ function makeContext(): WorkflowNodeContext {
     results: {},
     steps: [],
   } as WorkflowRunState;
-  return { input: {}, outputs: {}, results: {}, state };
+  return { input: {}, outputs: {}, results: {}, state, signal: new AbortController().signal };
 }
 
 describe("decision", () => {

--- a/test/e2e/mock-openai.ts
+++ b/test/e2e/mock-openai.ts
@@ -1,0 +1,146 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+type ChatMessage = {
+  role: string;
+  content?: unknown;
+  tool_calls?: unknown[];
+};
+
+type ChatRequest = {
+  messages: ChatMessage[];
+  stream?: boolean;
+};
+
+export type MockModelReply =
+  | { kind: "text"; text: string }
+  | { kind: "tool"; toolName: string; args: Record<string, unknown> };
+
+export type MockModelScript = (request: {
+  messages: ChatMessage[];
+  lastUserText: string;
+  lastRole: string;
+}) => MockModelReply;
+
+function messageText(message: ChatMessage | undefined): string {
+  if (!message) {
+    return "";
+  }
+  const content = message.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "object" && part !== null && "text" in part
+          ? String((part as { text: unknown }).text)
+          : "",
+      )
+      .join("\n");
+  }
+  return "";
+}
+
+function sseChunks(reply: MockModelReply): string[] {
+  const id = `chatcmpl-mock-${Date.now()}`;
+  const base = {
+    id,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: "mock-model",
+  };
+  const chunks: object[] = [];
+  if (reply.kind === "tool") {
+    chunks.push({
+      ...base,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: "assistant",
+            tool_calls: [
+              {
+                index: 0,
+                id: `call-${Date.now()}`,
+                type: "function",
+                function: { name: reply.toolName, arguments: JSON.stringify(reply.args) },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    });
+    chunks.push({ ...base, choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] });
+  } else {
+    chunks.push({
+      ...base,
+      choices: [
+        { index: 0, delta: { role: "assistant", content: reply.text }, finish_reason: null },
+      ],
+    });
+    chunks.push({ ...base, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+  }
+  const usage = { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 };
+  const lines = chunks.map(
+    (chunk, index) =>
+      `data: ${JSON.stringify(index === chunks.length - 1 ? { ...chunk, usage } : chunk)}\n\n`,
+  );
+  lines.push("data: [DONE]\n\n");
+  return lines;
+}
+
+/**
+ * Minimal OpenAI-compatible chat-completions server for non-destructive E2E
+ * tests. The provided script decides, per request, whether the fake model
+ * answers with text or calls a tool.
+ */
+export async function startMockOpenAiServer(script: MockModelScript): Promise<{
+  baseUrl: string;
+  requests: ChatRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: ChatRequest[] = [];
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || !req.url?.includes("/chat/completions")) {
+      res.writeHead(404).end();
+      return;
+    }
+    let body = "";
+    req.on("data", (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+    });
+    req.on("end", () => {
+      const parsed = JSON.parse(body) as ChatRequest;
+      requests.push(parsed);
+      const lastMessage = parsed.messages.at(-1);
+      const lastUser = [...parsed.messages].reverse().find((message) => message.role === "user");
+      const reply = script({
+        messages: parsed.messages,
+        lastUserText: messageText(lastUser),
+        lastRole: lastMessage?.role ?? "",
+      });
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      });
+      for (const chunk of sseChunks(reply)) {
+        res.write(chunk);
+      }
+      res.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -1,0 +1,292 @@
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { WorkflowRunState } from "../../src/workflows/types.js";
+import { makeTempDir } from "../helpers.js";
+import { startMockOpenAiServer } from "./mock-openai.js";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
+const EXTENSION_PATH = path.join(REPO_ROOT, "src", "extension", "index.ts");
+
+const E2E_WORKFLOW = `import { agent, decision, decisionEdge, defineWorkflow, shell } from "pi-workflows";
+
+const choices = ["y", "n"] as const;
+
+export default defineWorkflow({
+  name: "e2e",
+  title: ({ input }) => \`e2e: \${(input as { task?: string }).task ?? "unnamed"}\`,
+  startAt: "propose",
+  nodes: {
+    propose: agent({
+      prompt: ({ input }) => \`Propose a solution for: \${(input as { task?: string }).task}\`,
+      expectedOutput: '{ "proposal": "one sentence" }',
+    }),
+    confirm: decision({
+      choices,
+      question: ({ outputs }) =>
+        \`Is this the holy grail? \${JSON.stringify(outputs.propose)}\`,
+    }),
+    implement: shell({
+      exec: () => ({ command: "printf", args: ["%s", "implemented"] }),
+      parse: (result) => ({ marker: result.stdout }),
+    }),
+    stop: shell({
+      exec: () => ({ command: "printf", args: ["%s", "stopped"] }),
+      parse: (result) => ({ marker: result.stdout }),
+    }),
+  },
+  edges: [
+    { from: "propose", to: "confirm" },
+    decisionEdge({ from: "confirm", choices, cases: { y: "implement", n: "stop" } }),
+  ],
+});
+`;
+
+type RpcHandle = {
+  child: ChildProcess;
+  stdoutLines: string[];
+  stderr: () => string;
+  send: (command: Record<string, unknown>) => void;
+  stop: () => Promise<void>;
+};
+
+function startPiRpc(options: { cwd: string; env: Record<string, string> }): RpcHandle {
+  const child = spawn(
+    process.execPath,
+    [
+      PI_BIN,
+      "--mode",
+      "rpc",
+      "--no-session",
+      "--no-extensions",
+      "--no-skills",
+      "--no-themes",
+      "--no-prompt-templates",
+      "--no-context-files",
+      "--offline",
+      "-e",
+      EXTENSION_PATH,
+      "--provider",
+      "mock",
+      "--model",
+      "mock-model",
+    ],
+    {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+
+  const stdoutLines: string[] = [];
+  let stdoutBuffer = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdoutBuffer += chunk.toString("utf8");
+    const lines = stdoutBuffer.split("\n");
+    stdoutBuffer = lines.pop() ?? "";
+    stdoutLines.push(...lines.filter((line) => line.trim().length > 0));
+  });
+  let stderrText = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderrText += chunk.toString("utf8");
+  });
+
+  return {
+    child,
+    stdoutLines,
+    stderr: () => stderrText,
+    send: (command) => {
+      child.stdin?.write(`${JSON.stringify(command)}\n`);
+    },
+    stop: async () => {
+      child.stdin?.end();
+      const exited = new Promise<void>((resolve) => {
+        child.once("exit", () => resolve());
+      });
+      child.kill("SIGTERM");
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, 3_000));
+      await Promise.race([exited, timeout]);
+      if (child.exitCode === null) {
+        child.kill("SIGKILL");
+      }
+    },
+  };
+}
+
+async function waitForRunState(
+  runsDir: string,
+  predicate: (state: WorkflowRunState) => boolean,
+  onTimeout: () => string,
+  timeoutMs = 90_000,
+): Promise<{ state: WorkflowRunState; runDir: string }> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const entries = await fs.readdir(runsDir).catch(() => [] as string[]);
+    for (const entry of entries) {
+      const runDir = path.join(runsDir, entry);
+      try {
+        const raw = await fs.readFile(path.join(runDir, "state.json"), "utf8");
+        const state = JSON.parse(raw) as WorkflowRunState;
+        if (predicate(state)) {
+          return { state, runDir };
+        }
+      } catch {
+        // partial write or not a bundle; retry
+      }
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for workflow run state.\n${onTimeout()}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+}
+
+describe.sequential("pi-workflows end to end", () => {
+  let mock: Awaited<ReturnType<typeof startMockOpenAiServer>>;
+  let pi: RpcHandle;
+  let runsDir: string;
+  let projectDir: string;
+
+  beforeAll(async () => {
+    // The scripted "model": answers each workflow step contract through the
+    // workflow tool and ends its turn after each tool result.
+    mock = await startMockOpenAiServer(({ lastUserText, lastRole }) => {
+      if (lastRole === "tool") {
+        return { kind: "text", text: "Step submitted." };
+      }
+      const stepMatch = lastUserText.match(
+        /workflow step contract \(workflow: e2e, step: ([a-z_]+)\)/i,
+      );
+      const step = stepMatch?.[1];
+      if (step === "propose") {
+        return {
+          kind: "tool",
+          toolName: "workflow",
+          args: { step: "propose", output: { proposal: "Ship the boring, proven design." } },
+        };
+      }
+      if (step === "confirm") {
+        return {
+          kind: "tool",
+          toolName: "workflow",
+          args: {
+            step: "confirm",
+            output: { route: "y", reason: "proposal matches the holy grail" },
+          },
+        };
+      }
+      return { kind: "text", text: "Nothing to do." };
+    });
+
+    projectDir = await makeTempDir("pi-workflows-e2e-project");
+    runsDir = await makeTempDir("pi-workflows-e2e-runs");
+    const agentDir = await makeTempDir("pi-workflows-e2e-agent");
+
+    await fs.mkdir(path.join(projectDir, ".pi", "workflows"), { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "e2e.workflow.ts"),
+      E2E_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify(
+        {
+          providers: {
+            mock: {
+              name: "Mock",
+              baseUrl: mock.baseUrl,
+              api: "openai-completions",
+              apiKey: "mock-key",
+              compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
+              models: [{ id: "mock-model" }],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    pi = startPiRpc({
+      cwd: projectDir,
+      env: {
+        PI_CODING_AGENT_DIR: agentDir,
+        PI_WORKFLOWS_RUNS_DIR: runsDir,
+      },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await pi?.stop();
+    await mock?.close();
+  });
+
+  it("runs a workflow to completion inside a real pi session", async () => {
+    pi.send({ id: "wf-1", type: "prompt", message: "/workflow e2e ship it" });
+
+    const { state, runDir } = await waitForRunState(
+      runsDir,
+      (candidate) => candidate.status === "completed" || candidate.status === "failed",
+      () => `pi stderr:\n${pi.stderr()}\npi stdout tail:\n${pi.stdoutLines.slice(-15).join("\n")}`,
+    );
+
+    expect(state.status).toBe("completed");
+    expect(state.workflowName).toBe("e2e");
+    expect(state.runTitle).toBe("e2e: ship it");
+    expect(state.steps.map((step) => step.nodeId)).toEqual(["propose", "confirm", "implement"]);
+    expect(state.outputs.propose).toEqual({ proposal: "Ship the boring, proven design." });
+    expect(state.outputs.confirm).toMatchObject({ route: "y" });
+    expect(state.finalOutput).toEqual({ marker: "implemented" });
+
+    const manifest = JSON.parse(await fs.readFile(path.join(runDir, "manifest.json"), "utf8")) as {
+      status: string;
+    };
+    expect(manifest.status).toBe("completed");
+
+    const trace = await fs.readFile(path.join(runDir, "trace.ndjson"), "utf8");
+    const types = trace
+      .trim()
+      .split("\n")
+      .map((line) => (JSON.parse(line) as { type: string }).type);
+    expect(types[0]).toBe("run_started");
+    expect(types.at(-1)).toBe("run_completed");
+    expect(types).toContain("agent_prompt_sent");
+
+    // The mock server must have been driven through the workflow tool.
+    const toolRequests = mock.requests.filter((request) =>
+      request.messages.some((message) => message.role === "tool"),
+    );
+    expect(toolRequests.length).toBeGreaterThanOrEqual(2);
+  }, 120_000);
+
+  it("renders the finished run in the viewer CLI", async () => {
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) => candidate.status === "completed",
+      () => "expected the previous test to have completed a run",
+      5_000,
+    );
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        path.join(REPO_ROOT, "src", "viewer", "cli.ts"),
+        "view",
+        state.runId,
+        "--once",
+      ],
+      { cwd: REPO_ROOT, env: { ...process.env, PI_WORKFLOWS_RUNS_DIR: runsDir, NO_COLOR: "1" } },
+    );
+    expect(stdout).toContain("workflow e2e");
+    expect(stdout).toContain("✓ propose [agent]");
+    expect(stdout).toContain("✓ confirm [agent]");
+    expect(stdout).toContain("✓ implement [action]");
+  }, 30_000);
+});

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -159,14 +159,19 @@ describe.sequential("pi-workflows end to end", () => {
         return { kind: "text", text: "Step submitted." };
       }
       const stepMatch = lastUserText.match(
-        /workflow step contract \(workflow: e2e, step: ([a-z_]+)\)/i,
+        /workflow step contract \(workflow: e2e, step: ([a-z_]+), attempt: ([a-z0-9-]+)\)/i,
       );
       const step = stepMatch?.[1];
+      const attempt = stepMatch?.[2] ?? "";
       if (step === "propose") {
         return {
           kind: "tool",
           toolName: "workflow",
-          args: { step: "propose", output: { proposal: "Ship the boring, proven design." } },
+          args: {
+            step: "propose",
+            attempt,
+            output: { proposal: "Ship the boring, proven design." },
+          },
         };
       }
       if (step === "confirm") {
@@ -175,6 +180,7 @@ describe.sequential("pi-workflows end to end", () => {
           toolName: "workflow",
           args: {
             step: "confirm",
+            attempt,
             output: { route: "y", reason: "proposal matches the holy grail" },
           },
         };

--- a/test/engine-more.test.ts
+++ b/test/engine-more.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { ansi } from "../src/viewer/ansi.js";
+import { stripAnsi } from "../src/viewer/ansi.js";
+import { renderRunListLines, statusLabel } from "../src/viewer/render.js";
+import { action, checkpoint, compute, defineWorkflow, shell } from "../src/workflows/definition.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { ScriptedExecutor, makeTempDir } from "./helpers.js";
+
+async function makeEngine() {
+  const outputRoot = await makeTempDir("pi-workflows-engine-more");
+  return new WorkflowEngine({ executor: new ScriptedExecutor(), outputRoot });
+}
+
+describe("WorkflowEngine additional paths", () => {
+  it("exposes its output root", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-root");
+    const engine = new WorkflowEngine({ executor: new ScriptedExecutor(), outputRoot });
+    expect(engine.outputRoot).toBe(outputRoot);
+  });
+
+  it("runs function action nodes and records receipts", async () => {
+    const workflow = defineWorkflow({
+      name: "fn-action",
+      startAt: "act",
+      nodes: { act: action({ run: ({ input }) => ({ echoed: input }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, { x: 1 });
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toEqual({ echoed: { x: 1 } });
+    expect(state.steps[0]?.action).toEqual({ actionType: "function" });
+  });
+
+  it("runs shell actions without a parse function", async () => {
+    const workflow = defineWorkflow({
+      name: "raw-shell",
+      startAt: "run_cmd",
+      nodes: { run_cmd: shell({ exec: () => ({ command: "printf", args: ["%s", "raw"] }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toMatchObject({ stdout: "raw", exitCode: 0 });
+  });
+
+  it("supports checkpoint nodes with a custom run function", async () => {
+    const workflow = defineWorkflow({
+      name: "custom-checkpoint",
+      startAt: "hold",
+      nodes: { hold: checkpoint({ run: () => ({ report: "ready for review" }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("waiting");
+    expect(state.finalOutput).toEqual({ report: "ready for review" });
+  });
+
+  it("uses string titles verbatim and tolerates undefined title functions", async () => {
+    const literal = defineWorkflow({
+      name: "titled-literal",
+      title: "fixed title",
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => null }) },
+      edges: [],
+    });
+    const { state: literalState } = await (await makeEngine()).run(literal, {});
+    expect(literalState.runTitle).toBe("fixed title");
+
+    const dynamic = defineWorkflow({
+      name: "titled-undefined",
+      title: () => undefined,
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => null }) },
+      edges: [],
+    });
+    const { state: dynamicState } = await (await makeEngine()).run(dynamic, {});
+    expect(dynamicState.runTitle).toBeUndefined();
+  });
+
+  it("wraps non-Error throws in a failure message", async () => {
+    const workflow = defineWorkflow({
+      name: "string-throw",
+      startAt: "boom",
+      nodes: {
+        boom: compute({
+          run: () => {
+            throw "string failure";
+          },
+        }),
+      },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("failed");
+    expect(state.error).toBe("string failure");
+  });
+});
+
+describe("render status colors", () => {
+  it("colors every run status", () => {
+    for (const status of [
+      "running",
+      "waiting",
+      "completed",
+      "failed",
+      "timed_out",
+      "cancelled",
+    ] as const) {
+      expect(stripAnsi(statusLabel(status))).toBe(status);
+    }
+  });
+
+  it("styles text with each ansi helper", () => {
+    for (const style of [
+      ansi.bold,
+      ansi.dim,
+      ansi.red,
+      ansi.green,
+      ansi.yellow,
+      ansi.blue,
+      ansi.magenta,
+      ansi.cyan,
+    ]) {
+      expect(stripAnsi(style("x"))).toBe("x");
+    }
+  });
+
+  it("scrolls long run lists around the selection", () => {
+    const bundles = Array.from({ length: 30 }, (_ignored, index) => ({
+      runDir: `/tmp/run-${index}`,
+      manifest: {
+        schema: "pi-workflows.run-bundle.v1" as const,
+        runId: `run-${index}`,
+        workflowName: "demo",
+        startedAt: "2026-07-19T00:00:00.000Z",
+        status: "completed" as const,
+        traceSchema: "pi-workflows.trace-event.v1" as const,
+        paths: { workflow: "workflow.json", state: "state.json", trace: "trace.ndjson" },
+      },
+      state: {
+        runId: `run-${index}`,
+        workflowName: "demo",
+        runTitle: `title ${index}`,
+        startedAt: "2026-07-19T00:00:00.000Z",
+        finishedAt: "2026-07-19T00:00:10.000Z",
+        updatedAt: "2026-07-19T00:00:10.000Z",
+        status: "completed" as const,
+        input: {},
+        outputs: {},
+        results: {},
+        steps: [],
+      },
+      snapshot: null,
+    }));
+    const lines = renderRunListLines(bundles, 25, { width: 120, height: 10 }, new Date());
+    const text = lines.map(stripAnsi).join("\n");
+    expect(text).toContain("run-25");
+    expect(text).not.toContain("run-0 ");
+  });
+});

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -72,12 +72,16 @@ describe("WorkflowEngine", () => {
 
     await engine.run(workflow, {});
 
-    const prompt = executor.requests[0]?.prompt ?? "";
+    const request = executor.requests[0];
+    const prompt = request?.prompt ?? "";
+    const attemptId = request?.contract.attemptId ?? "";
     expect(prompt).toContain("Base prompt");
     expect(prompt).toContain("Workflow step contract");
-    expect(prompt).toContain(`{"step": "ask", "output": <your result>}`);
+    expect(prompt).toContain(`{"step": "ask", "attempt": "${attemptId}", "output": <your result>}`);
     expect(prompt).toContain(`Expected output: { "x": 1 }`);
-    expect(prompt).toBe(appendStepContract("Base prompt", "contract", "ask", `{ "x": 1 }`));
+    expect(prompt).toBe(
+      appendStepContract("Base prompt", "contract", "ask", attemptId, `{ "x": 1 }`),
+    );
   });
 
   it("routes decisions through switch edges", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -114,9 +114,8 @@ describe("WorkflowEngine", () => {
       startAt: "hold",
       nodes: {
         hold: checkpoint({ summary: "needs review" }),
-        after: compute({ run: () => "never" }),
       },
-      edges: [{ from: "hold", to: "after" }],
+      edges: [],
     });
     const { engine } = await makeEngine(new ScriptedExecutor());
 

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1,0 +1,346 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { decision, decisionEdge } from "../src/workflows/decision.js";
+import { agent, checkpoint, compute, defineWorkflow, shell } from "../src/workflows/definition.js";
+import { WorkflowEngine, appendStepContract } from "../src/workflows/engine.js";
+import { readRunBundle } from "../src/workflows/store.js";
+import type { WorkflowTraceEvent } from "../src/workflows/types.js";
+import { ScriptedExecutor, makeTempDir } from "./helpers.js";
+
+async function makeEngine(
+  executor: ScriptedExecutor,
+  options: { maxSteps?: number; defaultNodeTimeoutMs?: number } = {},
+) {
+  const outputRoot = await makeTempDir("pi-workflows-engine");
+  const events: WorkflowTraceEvent[] = [];
+  const engine = new WorkflowEngine({
+    executor,
+    outputRoot,
+    onEvent: (event) => events.push(event),
+    ...options,
+  });
+  return { engine, outputRoot, events };
+}
+
+describe("WorkflowEngine", () => {
+  it("runs a linear agent + compute workflow to completion", async () => {
+    const workflow = defineWorkflow({
+      name: "linear",
+      startAt: "ask",
+      nodes: {
+        ask: agent({ prompt: () => "Question?", expectedOutput: `{ "answer": "text" }` }),
+        summarize: compute({
+          run: ({ outputs }) => ({ final: (outputs.ask as { answer: string }).answer }),
+        }),
+      },
+      edges: [{ from: "ask", to: "summarize" }],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { output: { answer: "42" } });
+    const { engine, events } = await makeEngine(executor);
+
+    const { state, runDir } = await engine.run(workflow, { q: "6x7" });
+
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toEqual({ final: "42" });
+    expect(state.steps.map((step) => step.nodeId)).toEqual(["ask", "summarize"]);
+    expect(events.at(-1)?.type).toBe("run_completed");
+
+    const bundle = await readRunBundle(runDir);
+    expect(bundle?.state.status).toBe("completed");
+    expect(bundle?.manifest.status).toBe("completed");
+    expect(bundle?.snapshot?.nodes.ask?.nodeType).toBe("agent");
+
+    const trace = await fs.readFile(path.join(runDir, "trace.ndjson"), "utf8");
+    const lines = trace
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as WorkflowTraceEvent);
+    expect(lines[0]?.type).toBe("run_started");
+    expect(lines.map((line) => line.seq)).toEqual(lines.map((_line, index) => index + 1));
+  });
+
+  it("appends the step contract to agent prompts", async () => {
+    const workflow = defineWorkflow({
+      name: "contract",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "Base prompt", expectedOutput: `{ "x": 1 }` }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { output: { x: 1 } });
+    const { engine } = await makeEngine(executor);
+
+    await engine.run(workflow, {});
+
+    const prompt = executor.requests[0]?.prompt ?? "";
+    expect(prompt).toContain("Base prompt");
+    expect(prompt).toContain("Workflow step contract");
+    expect(prompt).toContain(`{"step": "ask", "output": <your result>}`);
+    expect(prompt).toContain(`Expected output: { "x": 1 }`);
+    expect(prompt).toBe(appendStepContract("Base prompt", "contract", "ask", `{ "x": 1 }`));
+  });
+
+  it("routes decisions through switch edges", async () => {
+    const choices = ["y", "n"] as const;
+    const workflow = defineWorkflow({
+      name: "routed",
+      startAt: "pick",
+      nodes: {
+        pick: decision({ choices, question: "Same?" }),
+        yes_lane: compute({ run: () => "yes" }),
+        no_lane: compute({ run: () => "no" }),
+      },
+      edges: [decisionEdge({ from: "pick", choices, cases: { y: "yes_lane", n: "no_lane" } })],
+    });
+    const executor = new ScriptedExecutor().respond("pick", {
+      output: { route: "n", reason: "differs" },
+    });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("completed");
+    expect(state.steps.map((step) => step.nodeId)).toEqual(["pick", "no_lane"]);
+    expect(state.finalOutput).toBe("no");
+  });
+
+  it("pauses at checkpoints with waiting status", async () => {
+    const workflow = defineWorkflow({
+      name: "paused",
+      startAt: "hold",
+      nodes: {
+        hold: checkpoint({ summary: "needs review" }),
+        after: compute({ run: () => "never" }),
+      },
+      edges: [{ from: "hold", to: "after" }],
+    });
+    const { engine } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("waiting");
+    expect(state.waitingOn).toBe("hold");
+    expect(state.finalOutput).toEqual({ summary: "needs review" });
+    expect(state.steps.map((step) => step.nodeId)).toEqual(["hold"]);
+  });
+
+  it("runs shell actions and records receipts", async () => {
+    const workflow = defineWorkflow({
+      name: "shelly",
+      startAt: "echo",
+      nodes: {
+        echo: shell({
+          exec: () => ({ command: "printf", args: ["%s", "hi"] }),
+          parse: (result) => ({ stdout: result.stdout }),
+        }),
+      },
+      edges: [],
+    });
+    const { engine } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toEqual({ stdout: "hi" });
+    expect(state.steps[0]?.action).toMatchObject({
+      actionType: "shell",
+      command: "printf",
+      exitCode: 0,
+    });
+  });
+
+  it("fails the run when a node fails without outcome routing", async () => {
+    const workflow = defineWorkflow({
+      name: "broken",
+      startAt: "boom",
+      nodes: { boom: compute({ run: () => Promise.reject(new Error("kaput")) }) },
+      edges: [],
+    });
+    const { engine, events } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("failed");
+    expect(state.error).toBe("kaput");
+    expect(state.results.boom?.outcome).toBe("failed");
+    expect(events.at(-1)?.type).toBe("run_failed");
+  });
+
+  it("routes failures through $result.outcome switch edges", async () => {
+    const workflow = defineWorkflow({
+      name: "recovering",
+      startAt: "boom",
+      nodes: {
+        boom: compute({ run: () => Promise.reject(new Error("kaput")) }),
+        recover: compute({ run: () => "recovered" }),
+      },
+      edges: [{ from: "boom", switch: { on: "$result.outcome", cases: { failed: "recover" } } }],
+    });
+    const { engine } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toBe("recovered");
+  });
+
+  it("times out hung agent steps", async () => {
+    const workflow = defineWorkflow({
+      name: "hung",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "?", timeoutMs: 50 }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { hang: true });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("timed_out");
+    expect(state.results.ask?.outcome).toBe("timed_out");
+  });
+
+  it("supports cancel() while an agent step is pending", async () => {
+    const workflow = defineWorkflow({
+      name: "cancellable",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "?" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { hang: true });
+    const { engine } = await makeEngine(executor);
+
+    const runPromise = engine.run(workflow, {});
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    engine.cancel();
+    const { state } = await runPromise;
+
+    expect(state.status).toBe("cancelled");
+    expect(state.results.ask?.outcome).toBe("cancelled");
+  });
+
+  it("supports validation retry loops within one step", async () => {
+    const workflow = defineWorkflow({
+      name: "validating",
+      startAt: "pick",
+      nodes: { pick: decision({ choices: ["a", "b"] as const, question: "?" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("pick", async (request) => {
+      const first = await request.accept({ route: "zzz" });
+      expect(first.ok).toBe(false);
+      const second = await request.accept({ route: "b" });
+      if (!second.ok) {
+        throw new Error("expected acceptance");
+      }
+      return { output: second.value };
+    });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("completed");
+    expect(state.outputs.pick).toEqual({ route: "b" });
+  });
+
+  it("normalizes string outputs containing JSON", async () => {
+    const workflow = defineWorkflow({
+      name: "stringy",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "?" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { output: `{"answer":"parsed"}` });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.outputs.ask).toEqual({ answer: "parsed" });
+  });
+
+  it("keeps plain-string outputs that are not JSON", async () => {
+    const workflow = defineWorkflow({
+      name: "plain",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "?" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { output: "just text" });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.outputs.ask).toBe("just text");
+  });
+
+  it("enforces maxSteps against loops", async () => {
+    const workflow = defineWorkflow({
+      name: "looping",
+      maxSteps: 5,
+      startAt: "spin",
+      nodes: { spin: compute({ run: () => ({ next: "spin" }) }) },
+      edges: [{ from: "spin", to: "spin" }],
+    });
+    const { engine } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("failed");
+    expect(state.error).toMatch(/maxSteps=5/);
+  });
+
+  it("loops through fix cycles like autoimplement", async () => {
+    const choices = ["clean", "issues_found"] as const;
+    const workflow = defineWorkflow({
+      name: "fixloop",
+      startAt: "verify",
+      nodes: {
+        verify: agent({ prompt: () => "verify" }),
+        review: decision({ choices, question: "clean?" }),
+        fix: agent({ prompt: () => "fix" }),
+        done: compute({ run: () => "done" }),
+      },
+      edges: [
+        { from: "verify", to: "review" },
+        decisionEdge({ from: "review", choices, cases: { clean: "done", issues_found: "fix" } }),
+        { from: "fix", to: "verify" },
+      ],
+    });
+    const executor = new ScriptedExecutor()
+      .respond("verify", { output: { passed: true } })
+      .respond(
+        "review",
+        { output: { route: "issues_found", reason: "bug" } },
+        { output: { route: "clean", reason: "ok" } },
+      )
+      .respond("fix", { output: { fixed: "bug" } });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("completed");
+    expect(state.steps.map((step) => step.nodeId)).toEqual([
+      "verify",
+      "review",
+      "fix",
+      "verify",
+      "review",
+      "done",
+    ]);
+  });
+
+  it("resolves run titles from functions", async () => {
+    const workflow = defineWorkflow({
+      name: "titled",
+      title: ({ input }) => `run for ${(input as { task: string }).task}`,
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => null }) },
+      edges: [],
+    });
+    const { engine } = await makeEngine(new ScriptedExecutor());
+
+    const { state } = await engine.run(workflow, { task: "X" });
+
+    expect(state.runTitle).toBe("run for X");
+  });
+});

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -34,7 +34,7 @@ describe("ConversationStepExecutor", () => {
     expect(sent).toEqual([{ prompt: "Do the step", streaming: false }]);
     expect(executor.pendingStepId).toBe("step1");
 
-    const result = await executor.submit("step1", { x: 1 });
+    const result = await executor.submit("step1", "a1", { x: 1 });
     expect(result.accepted).toBe(true);
     await expect(stepPromise).resolves.toEqual({ output: { x: 1 } });
     expect(executor.pendingStepId).toBeNull();
@@ -45,12 +45,12 @@ describe("ConversationStepExecutor", () => {
     executor.setStreaming(true);
     void executor.runAgentStep(makeRequest(), new AbortController().signal);
     expect(sent[0]?.streaming).toBe(true);
-    await executor.submit("step1", {});
+    await executor.submit("step1", "a1", {});
   });
 
   it("rejects submissions when no step is pending", async () => {
     const { executor } = makeExecutor();
-    const result = await executor.submit("step1", {});
+    const result = await executor.submit("step1", "a1", {});
     expect(result.accepted).toBe(false);
     expect(result.message).toMatch(/No workflow step/);
   });
@@ -59,11 +59,24 @@ describe("ConversationStepExecutor", () => {
     const { executor } = makeExecutor();
     const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
 
-    const result = await executor.submit("other", {});
+    const result = await executor.submit("other", "a1", {});
     expect(result.accepted).toBe(false);
     expect(result.message).toMatch(/pending step is "step1"/);
 
-    await executor.submit("step1", {});
+    await executor.submit("step1", "a1", {});
+    await stepPromise;
+  });
+
+  it("rejects submissions with a stale attempt id", async () => {
+    const { executor } = makeExecutor();
+    const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
+
+    const stale = await executor.submit("step1", "a0", {});
+    expect(stale.accepted).toBe(false);
+    expect(stale.message).toMatch(/Stale attempt id "a0".*pending attempt is "a1"/);
+    expect(executor.pendingStepId).toBe("step1");
+
+    await executor.submit("step1", "a1", {});
     await stepPromise;
   });
 
@@ -77,12 +90,12 @@ describe("ConversationStepExecutor", () => {
     });
     const stepPromise = executor.runAgentStep(request, new AbortController().signal);
 
-    const rejected = await executor.submit("step1", { ok: false });
+    const rejected = await executor.submit("step1", "a1", { ok: false });
     expect(rejected.accepted).toBe(false);
     expect(rejected.message).toMatch(/bad shape/);
     expect(executor.pendingStepId).toBe("step1");
 
-    const accepted = await executor.submit("step1", { ok: true });
+    const accepted = await executor.submit("step1", "a1", { ok: true });
     expect(accepted.accepted).toBe(true);
     await stepPromise;
   });
@@ -110,7 +123,7 @@ describe("ConversationStepExecutor", () => {
     await expect(
       executor.runAgentStep(makeRequest(), new AbortController().signal),
     ).rejects.toThrow(/already awaiting/);
-    await executor.submit("step1", {});
+    await executor.submit("step1", "a1", {});
     await stepPromise;
   });
 

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { ConversationStepExecutor, type PromptDelivery } from "../src/extension/executor.js";
+import type { AgentStepRequest } from "../src/workflows/types.js";
+
+function makeRequest(overrides: Partial<AgentStepRequest> = {}): AgentStepRequest {
+  return {
+    contract: {
+      runId: "r1",
+      workflowName: "w",
+      nodeId: "step1",
+      attemptId: "a1",
+      expectedOutput: `{ "x": 1 }`,
+    },
+    prompt: "Do the step",
+    accept: async (output) => ({ ok: true, value: output }),
+    ...overrides,
+  };
+}
+
+function makeExecutor(options: { maxNudges?: number } = {}) {
+  const sent: PromptDelivery[] = [];
+  const executor = new ConversationStepExecutor({
+    sendPrompt: (delivery) => sent.push(delivery),
+    ...options,
+  });
+  return { executor, sent };
+}
+
+describe("ConversationStepExecutor", () => {
+  it("delivers the prompt and resolves on an accepted submission", async () => {
+    const { executor, sent } = makeExecutor();
+    const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
+
+    expect(sent).toEqual([{ prompt: "Do the step", streaming: false }]);
+    expect(executor.pendingStepId).toBe("step1");
+
+    const result = await executor.submit("step1", { x: 1 });
+    expect(result.accepted).toBe(true);
+    await expect(stepPromise).resolves.toEqual({ output: { x: 1 } });
+    expect(executor.pendingStepId).toBeNull();
+  });
+
+  it("marks deliveries as streaming when the agent is mid-run", async () => {
+    const { executor, sent } = makeExecutor();
+    executor.setStreaming(true);
+    void executor.runAgentStep(makeRequest(), new AbortController().signal);
+    expect(sent[0]?.streaming).toBe(true);
+    await executor.submit("step1", {});
+  });
+
+  it("rejects submissions when no step is pending", async () => {
+    const { executor } = makeExecutor();
+    const result = await executor.submit("step1", {});
+    expect(result.accepted).toBe(false);
+    expect(result.message).toMatch(/No workflow step/);
+  });
+
+  it("rejects submissions for the wrong step id", async () => {
+    const { executor } = makeExecutor();
+    const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
+
+    const result = await executor.submit("other", {});
+    expect(result.accepted).toBe(false);
+    expect(result.message).toMatch(/pending step is "step1"/);
+
+    await executor.submit("step1", {});
+    await stepPromise;
+  });
+
+  it("surfaces validation errors and keeps the step pending", async () => {
+    const { executor } = makeExecutor();
+    const request = makeRequest({
+      accept: async (output) =>
+        (output as { ok?: boolean }).ok === true
+          ? { ok: true, value: output }
+          : { ok: false, error: "bad shape" },
+    });
+    const stepPromise = executor.runAgentStep(request, new AbortController().signal);
+
+    const rejected = await executor.submit("step1", { ok: false });
+    expect(rejected.accepted).toBe(false);
+    expect(rejected.message).toMatch(/bad shape/);
+    expect(executor.pendingStepId).toBe("step1");
+
+    const accepted = await executor.submit("step1", { ok: true });
+    expect(accepted.accepted).toBe(true);
+    await stepPromise;
+  });
+
+  it("rejects the step when the signal aborts", async () => {
+    const { executor } = makeExecutor();
+    const abort = new AbortController();
+    const stepPromise = executor.runAgentStep(makeRequest(), abort.signal);
+    abort.abort(new Error("timed out"));
+    await expect(stepPromise).rejects.toThrow(/timed out/);
+    expect(executor.pendingStepId).toBeNull();
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const { executor, sent } = makeExecutor();
+    const abort = new AbortController();
+    abort.abort(new Error("gone"));
+    await expect(executor.runAgentStep(makeRequest(), abort.signal)).rejects.toThrow(/gone/);
+    expect(sent).toEqual([]);
+  });
+
+  it("refuses concurrent steps", async () => {
+    const { executor } = makeExecutor();
+    const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
+    await expect(
+      executor.runAgentStep(makeRequest(), new AbortController().signal),
+    ).rejects.toThrow(/already awaiting/);
+    await executor.submit("step1", {});
+    await stepPromise;
+  });
+
+  it("nudges on settle up to the budget, then fails the step", async () => {
+    const { executor, sent } = makeExecutor({ maxNudges: 2 });
+    const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
+
+    expect(executor.handleAgentSettled()).toBe(true);
+    expect(executor.handleAgentSettled()).toBe(true);
+    expect(sent).toHaveLength(3);
+    expect(sent[1]?.prompt).toMatch(/Reminder: workflow step "step1"/);
+    expect(sent[1]?.prompt).toContain(`{ "x": 1 }`);
+
+    expect(executor.handleAgentSettled()).toBe(false);
+    await expect(stepPromise).rejects.toThrow(/without submitting step "step1"/);
+    expect(executor.pendingStepId).toBeNull();
+  });
+
+  it("does nothing on settle without a pending step", () => {
+    const { executor, sent } = makeExecutor();
+    expect(executor.handleAgentSettled()).toBe(false);
+    expect(sent).toEqual([]);
+  });
+});

--- a/test/extension-args.test.ts
+++ b/test/extension-args.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseWorkflowArgs } from "../src/extension/index.js";
+
+describe("parseWorkflowArgs", () => {
+  it("lists on empty args", () => {
+    expect(parseWorkflowArgs("")).toEqual({ kind: "list" });
+    expect(parseWorkflowArgs("   ")).toEqual({ kind: "list" });
+  });
+
+  it("parses cancel", () => {
+    expect(parseWorkflowArgs("cancel")).toEqual({ kind: "cancel" });
+  });
+
+  it("parses a bare workflow ref", () => {
+    expect(parseWorkflowArgs("echo")).toEqual({ kind: "run", ref: "echo", input: {} });
+  });
+
+  it("treats trailing text as the task input", () => {
+    expect(parseWorkflowArgs("autoimplement fix the flaky test")).toEqual({
+      kind: "run",
+      ref: "autoimplement",
+      input: { task: "fix the flaky test" },
+    });
+  });
+
+  it("parses --input-json", () => {
+    expect(parseWorkflowArgs(`branch --input-json {"task":"x"}`)).toEqual({
+      kind: "run",
+      ref: "branch",
+      input: { task: "x" },
+    });
+  });
+
+  it("rejects --input-json without a value", () => {
+    expect(() => parseWorkflowArgs("branch --input-json")).toThrow(/requires a JSON value/);
+  });
+
+  it("rejects malformed --input-json", () => {
+    expect(() => parseWorkflowArgs("branch --input-json {broken")).toThrow();
+  });
+
+  it("supports path refs", () => {
+    expect(parseWorkflowArgs("./examples/workflows/echo.workflow.ts hello")).toEqual({
+      kind: "run",
+      ref: "./examples/workflows/echo.workflow.ts",
+      input: { task: "hello" },
+    });
+  });
+});

--- a/test/extension-args.test.ts
+++ b/test/extension-args.test.ts
@@ -39,6 +39,14 @@ describe("parseWorkflowArgs", () => {
     expect(() => parseWorkflowArgs("branch --input-json {broken")).toThrow();
   });
 
+  it("treats task text starting with --input-json as plain text", () => {
+    expect(parseWorkflowArgs("echo --input-jsonschema help")).toEqual({
+      kind: "run",
+      ref: "echo",
+      input: { task: "--input-jsonschema help" },
+    });
+  });
+
   it("supports path refs", () => {
     expect(parseWorkflowArgs("./examples/workflows/echo.workflow.ts hello")).toEqual({
       kind: "run",

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -6,7 +6,10 @@ import { makeTempDir } from "./helpers.js";
 
 type RegisteredTool = {
   name: string;
-  execute: (toolCallId: string, params: { step: string; output: unknown }) => Promise<unknown>;
+  execute: (
+    toolCallId: string,
+    params: { step: string; attempt: string; output: unknown },
+  ) => Promise<unknown>;
 };
 
 type RegisteredCommand = {
@@ -106,9 +109,9 @@ export default defineWorkflow({
   );
 }
 
-function stepIdFromPrompt(prompt: string): string | null {
-  const match = prompt.match(/"step": "([^"]+)"/);
-  return match?.[1] ?? null;
+function stepFromPrompt(prompt: string): { step: string; attempt: string } | null {
+  const match = prompt.match(/"step": "([^"]+)", "attempt": "([^"]+)"/);
+  return match ? { step: match[1] as string, attempt: match[2] as string } : null;
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
@@ -131,9 +134,9 @@ describe("pi-workflows extension", () => {
       const harness = makeHarness({
         cwd,
         respond: (prompt, tool) => {
-          const step = stepIdFromPrompt(prompt);
-          if (step) {
-            void tool.execute("call-1", { step, output: { reply: "hi" } });
+          const contract = stepFromPrompt(prompt);
+          if (contract) {
+            void tool.execute("call-1", { ...contract, output: { reply: "hi" } });
           }
         },
       });
@@ -184,9 +187,9 @@ describe("pi-workflows extension", () => {
   it("rejects tool calls outside a workflow", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const harness = makeHarness({ cwd, respond: () => {} });
-    await expect(harness.tool.execute("call-1", { step: "reply", output: {} })).rejects.toThrow(
-      /No workflow is running/,
-    );
+    await expect(
+      harness.tool.execute("call-1", { step: "reply", attempt: "a1", output: {} }),
+    ).rejects.toThrow(/No workflow is running/);
   });
 
   it("cancels a running workflow", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,229 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import piWorkflows from "../src/extension/index.js";
+import { makeTempDir } from "./helpers.js";
+
+type RegisteredTool = {
+  name: string;
+  execute: (toolCallId: string, params: { step: string; output: unknown }) => Promise<unknown>;
+};
+
+type RegisteredCommand = {
+  handler: (args: string, ctx: FakeContext) => Promise<void>;
+  getArgumentCompletions?: (prefix: string) => Promise<{ value: string; label: string }[] | null>;
+};
+
+type FakeContext = {
+  cwd: string;
+  hasUI: boolean;
+  ui: {
+    notify: (message: string, type?: string) => void;
+    setWidget: (key: string, lines: string[] | undefined) => void;
+  };
+};
+
+/**
+ * Harness that stands in for the pi runtime: it captures the registered
+ * command/tool and plays the model, answering each delivered step prompt by
+ * calling the workflow tool.
+ */
+function makeHarness(options: {
+  cwd: string;
+  respond: (prompt: string, tool: RegisteredTool) => void;
+}) {
+  const notifications: string[] = [];
+  const widgets: (string[] | undefined)[] = [];
+  const listeners = new Map<string, (() => void)[]>();
+  let command: RegisteredCommand | null = null;
+  let tool: RegisteredTool | null = null;
+
+  const ctx: FakeContext = {
+    cwd: options.cwd,
+    hasUI: true,
+    ui: {
+      notify: (message) => notifications.push(message),
+      setWidget: (_key, lines) => widgets.push(lines),
+    },
+  };
+
+  const pi = {
+    registerCommand: (_name: string, spec: RegisteredCommand) => {
+      command = spec;
+    },
+    registerTool: (spec: RegisteredTool) => {
+      tool = spec;
+    },
+    on: (event: string, listener: () => void) => {
+      const queue = listeners.get(event) ?? [];
+      queue.push(listener);
+      listeners.set(event, queue);
+    },
+    sendUserMessage: (prompt: string) => {
+      // Deliver asynchronously like the real runtime would.
+      queueMicrotask(() => options.respond(prompt, tool as RegisteredTool));
+    },
+  };
+
+  piWorkflows(pi as never);
+  if (!command || !tool) {
+    throw new Error("extension did not register command and tool");
+  }
+  return {
+    ctx,
+    notifications,
+    widgets,
+    command: command as RegisteredCommand,
+    tool: tool as RegisteredTool,
+    emit: (event: string) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener();
+      }
+    },
+  };
+}
+
+async function writeEchoWorkflow(cwd: string): Promise<void> {
+  const dir = path.join(cwd, ".pi", "workflows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "mini.workflow.ts"),
+    `import { agent, defineWorkflow } from "pi-workflows";
+
+export default defineWorkflow({
+  name: "mini",
+  startAt: "reply",
+  nodes: {
+    reply: agent({
+      prompt: () => "Say hi.",
+      expectedOutput: '{ "reply": "…" }',
+    }),
+  },
+  edges: [],
+});
+`,
+    "utf8",
+  );
+}
+
+function stepIdFromPrompt(prompt: string): string | null {
+  const match = prompt.match(/"step": "([^"]+)"/);
+  return match?.[1] ?? null;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe("pi-workflows extension", () => {
+  it("runs a workflow end to end through the command and tool", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext");
+    const runsDir = await makeTempDir("pi-workflows-ext-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({
+        cwd,
+        respond: (prompt, tool) => {
+          const step = stepIdFromPrompt(prompt);
+          if (step) {
+            void tool.execute("call-1", { step, output: { reply: "hi" } });
+          }
+        },
+      });
+
+      await harness.command.handler("mini say hi", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
+
+      expect(harness.notifications.some((note) => note.includes("Workflow mini started"))).toBe(
+        true,
+      );
+      expect(harness.notifications.some((note) => note.includes("Workflow mini completed"))).toBe(
+        true,
+      );
+      expect(harness.widgets.length).toBeGreaterThan(0);
+
+      const runDirs = await fs.readdir(runsDir);
+      expect(runDirs).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("lists workflows, rejects bad input, and reports missing cancels", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext");
+    await writeEchoWorkflow(cwd);
+    const harness = makeHarness({ cwd, respond: () => {} });
+
+    await harness.command.handler("", harness.ctx);
+    expect(harness.notifications.at(-1)).toContain("mini (project)");
+
+    await harness.command.handler("cancel", harness.ctx);
+    expect(harness.notifications.at(-1)).toContain("No workflow is running");
+
+    await harness.command.handler("mini --input-json {broken", harness.ctx);
+    expect(harness.notifications.at(-1)).toMatch(/JSON/);
+
+    await harness.command.handler("does-not-exist", harness.ctx);
+    expect(harness.notifications.at(-1)).toContain("Could not start workflow");
+  });
+
+  it("warns when no workflows are discoverable", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext-empty");
+    const harness = makeHarness({ cwd, respond: () => {} });
+    await harness.command.handler("", harness.ctx);
+    expect(harness.notifications.at(-1)).toContain("No workflows found");
+  });
+
+  it("rejects tool calls outside a workflow", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext");
+    const harness = makeHarness({ cwd, respond: () => {} });
+    await expect(harness.tool.execute("call-1", { step: "reply", output: {} })).rejects.toThrow(
+      /No workflow is running/,
+    );
+  });
+
+  it("cancels a running workflow", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext");
+    const runsDir = await makeTempDir("pi-workflows-ext-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      // Never respond, so the step stays pending until cancelled.
+      const harness = makeHarness({ cwd, respond: () => {} });
+
+      await harness.command.handler("mini", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("started")));
+
+      await harness.command.handler("other", harness.ctx);
+      expect(harness.notifications.at(-1)).toContain("already running");
+
+      await harness.command.handler("cancel", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("cancelled")));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("completes workflow names for the command", async () => {
+    const cwd = await makeTempDir("pi-workflows-ext");
+    await writeEchoWorkflow(cwd);
+    const harness = makeHarness({ cwd, respond: () => {} });
+    const originalCwd = process.cwd();
+    process.chdir(cwd);
+    try {
+      const completions = await harness.command.getArgumentCompletions?.("m");
+      expect(completions?.map((item) => item.value)).toContain("mini");
+      const cancelCompletion = await harness.command.getArgumentCompletions?.("can");
+      expect(cancelCompletion?.map((item) => item.value)).toEqual(["cancel"]);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { agent, compute, defineWorkflow } from "../src/workflows/definition.js";
+import {
+  resolveNext,
+  resolveNextForOutcome,
+  validateWorkflowDefinition,
+} from "../src/workflows/graph.js";
+import type { WorkflowEdge, WorkflowNodeResult } from "../src/workflows/types.js";
+
+function makeResult(overrides: Partial<WorkflowNodeResult> = {}): WorkflowNodeResult {
+  return {
+    attemptId: "a1",
+    nodeId: "n1",
+    nodeType: "agent",
+    outcome: "ok",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: 1000,
+    ...overrides,
+  };
+}
+
+const workflowBase = {
+  name: "t",
+  startAt: "a",
+  nodes: {
+    a: compute({ run: () => 1 }),
+    b: compute({ run: () => 2 }),
+  },
+};
+
+describe("validateWorkflowDefinition", () => {
+  it("accepts a valid graph", () => {
+    const workflow = defineWorkflow({ ...workflowBase, edges: [{ from: "a", to: "b" }] });
+    expect(() => validateWorkflowDefinition(workflow)).not.toThrow();
+  });
+
+  it("rejects a missing start node", () => {
+    const workflow = defineWorkflow({ ...workflowBase, edges: [] });
+    expect(() => validateWorkflowDefinition({ ...workflow, startAt: "zzz" })).toThrow(/start node/);
+  });
+
+  it("rejects unknown edge targets", () => {
+    const workflow = defineWorkflow({ ...workflowBase, edges: [{ from: "a", to: "zzz" }] });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/unknown to-node/);
+  });
+
+  it("rejects unknown edge sources", () => {
+    const workflow = defineWorkflow({ ...workflowBase, edges: [{ from: "zzz", to: "a" }] });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/unknown from-node/);
+  });
+
+  it("rejects multiple outgoing edges from one node", () => {
+    const workflow = defineWorkflow({
+      ...workflowBase,
+      edges: [
+        { from: "a", to: "b" },
+        { from: "a", to: "b" },
+      ],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/multiple outgoing edges/);
+  });
+
+  it("rejects switch cases pointing at unknown nodes", () => {
+    const workflow = defineWorkflow({
+      ...workflowBase,
+      edges: [{ from: "a", switch: { on: "$.route", cases: { x: "zzz" } } }],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/unknown to-node/);
+  });
+
+  it("rejects agent nodes without a prompt", () => {
+    expect(() => agent({} as never)).toThrow(/prompt/);
+  });
+});
+
+describe("resolveNext", () => {
+  const switchEdge: WorkflowEdge = {
+    from: "a",
+    switch: { on: "$.route", cases: { yes: "b", no: "c" } },
+  };
+
+  it("returns null when there is no outgoing edge", () => {
+    expect(resolveNext([], "a", {})).toBeNull();
+  });
+
+  it("follows plain edges", () => {
+    expect(resolveNext([{ from: "a", to: "b" }], "a", {})).toBe("b");
+  });
+
+  it("routes switch edges on output paths", () => {
+    expect(resolveNext([switchEdge], "a", { route: "yes" })).toBe("b");
+    expect(resolveNext([switchEdge], "a", { route: "no" })).toBe("c");
+  });
+
+  it("supports $output. prefixed paths", () => {
+    const edge: WorkflowEdge = {
+      from: "a",
+      switch: { on: "$output.deep.route", cases: { "1": "b" } },
+    };
+    expect(resolveNext([edge], "a", { deep: { route: 1 } })).toBe("b");
+  });
+
+  it("supports $result. prefixed paths", () => {
+    const edge: WorkflowEdge = { from: "a", switch: { on: "$result.outcome", cases: { ok: "b" } } };
+    expect(resolveNext([edge], "a", {}, makeResult())).toBe("b");
+  });
+
+  it("throws on non-scalar switch values", () => {
+    expect(() => resolveNext([switchEdge], "a", { route: { nested: true } })).toThrow(/scalar/);
+  });
+
+  it("throws when no case matches", () => {
+    expect(() => resolveNext([switchEdge], "a", { route: "maybe" })).toThrow(
+      /No workflow switch case/,
+    );
+  });
+
+  it("rejects unsupported JSON paths", () => {
+    const edge: WorkflowEdge = { from: "a", switch: { on: "route", cases: { yes: "b" } } };
+    expect(() => resolveNext([edge], "a", { route: "yes" })).toThrow(/Unsupported JSON path/);
+  });
+});
+
+describe("resolveNextForOutcome", () => {
+  it("routes failures through $result. switch edges", () => {
+    const edge: WorkflowEdge = {
+      from: "a",
+      switch: { on: "$result.outcome", cases: { failed: "b", ok: "c" } },
+    };
+    expect(resolveNextForOutcome([edge], "a", makeResult({ outcome: "failed" }))).toBe("b");
+  });
+
+  it("returns null for plain edges and output switches", () => {
+    expect(resolveNextForOutcome([{ from: "a", to: "b" }], "a", makeResult())).toBeNull();
+    const outputEdge: WorkflowEdge = { from: "a", switch: { on: "$.route", cases: { x: "b" } } };
+    expect(resolveNextForOutcome([outputEdge], "a", makeResult())).toBeNull();
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  AgentStepExecutor,
+  AgentStepRequest,
+  AgentStepSubmission,
+} from "../src/workflows/types.js";
+
+export async function makeTempDir(prefix: string): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+export type ScriptedResponse =
+  | { output: unknown }
+  | { error: string }
+  | { hang: true }
+  | ((request: AgentStepRequest) => Promise<AgentStepSubmission> | AgentStepSubmission);
+
+/**
+ * Deterministic executor for engine tests. Responses are keyed by node id;
+ * repeated visits to the same node consume queued responses in order.
+ */
+export class ScriptedExecutor implements AgentStepExecutor {
+  readonly requests: AgentStepRequest[] = [];
+  private readonly responses = new Map<string, ScriptedResponse[]>();
+
+  respond(nodeId: string, ...responses: ScriptedResponse[]): this {
+    const queue = this.responses.get(nodeId) ?? [];
+    queue.push(...responses);
+    this.responses.set(nodeId, queue);
+    return this;
+  }
+
+  async runAgentStep(request: AgentStepRequest, signal: AbortSignal): Promise<AgentStepSubmission> {
+    this.requests.push(request);
+    const queue = this.responses.get(request.contract.nodeId) ?? [];
+    const response = queue.length > 1 ? queue.shift() : queue[0];
+    if (!response) {
+      throw new Error(`No scripted response for node ${request.contract.nodeId}`);
+    }
+    if (typeof response === "function") {
+      return await response(request);
+    }
+    if ("hang" in response) {
+      return await new Promise<AgentStepSubmission>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    }
+    if ("error" in response) {
+      throw new Error(response.error);
+    }
+    const accepted = await request.accept(response.output);
+    if (!accepted.ok) {
+      throw new Error(`Scripted output rejected: ${accepted.error}`);
+    }
+    return { output: accepted.value };
+  }
+}

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { extractJsonValue, parseJsonValue, parseStrictJsonValue } from "../src/workflows/json.js";
+
+describe("parseJsonValue", () => {
+  it("parses direct JSON objects", () => {
+    expect(parseJsonValue(`{"a":1}`)).toEqual({ a: 1 });
+  });
+
+  it("parses direct JSON arrays", () => {
+    expect(parseJsonValue(`[1,2]`)).toEqual([1, 2]);
+  });
+
+  it("throws on empty text", () => {
+    expect(() => parseJsonValue("")).toThrow(/empty text/);
+    expect(() => parseJsonValue("   ")).toThrow(/empty text/);
+  });
+
+  it("parses fenced JSON blocks", () => {
+    const text = 'Here you go:\n```json\n{"route":"y"}\n```\nthanks';
+    expect(parseJsonValue(text, { mode: "fenced" })).toEqual({ route: "y" });
+  });
+
+  it("parses fenced blocks without a language tag", () => {
+    const text = '```\n{"route":"n"}\n```';
+    expect(parseJsonValue(text, { mode: "fenced" })).toEqual({ route: "n" });
+  });
+
+  it("rejects embedded JSON in strict mode", () => {
+    expect(() => parseStrictJsonValue(`prefix {"a":1}`)).toThrow(/Could not parse JSON/);
+  });
+
+  it("rejects fenced JSON in strict mode", () => {
+    expect(() => parseStrictJsonValue("```json\n{}\n```")).toThrow(/Could not parse JSON/);
+  });
+
+  it("extracts balanced embedded objects in compat mode", () => {
+    expect(
+      extractJsonValue(`The answer is {"route":"continue","reason":"clear"} as shown`),
+    ).toEqual({
+      route: "continue",
+      reason: "clear",
+    });
+  });
+
+  it("handles strings containing braces inside embedded JSON", () => {
+    expect(extractJsonValue(`x {"text":"a } inside","n":1} y`)).toEqual({
+      text: "a } inside",
+      n: 1,
+    });
+  });
+
+  it("handles escaped quotes inside strings", () => {
+    expect(extractJsonValue(String.raw`noise {"text":"quote \" and {"} tail`)).toEqual({
+      text: 'quote " and {',
+    });
+  });
+
+  it("skips unbalanced candidates and finds later valid ones", () => {
+    expect(extractJsonValue(`{oops] then {"ok":true}`)).toEqual({ ok: true });
+  });
+
+  it("throws when no JSON can be found", () => {
+    expect(() => extractJsonValue("just prose")).toThrow(/Could not parse JSON/);
+  });
+
+  it("ignores fenced blocks without closing fence", () => {
+    expect(() => parseJsonValue('```json\n{"a":1}', { mode: "fenced" })).toThrow(
+      /Could not parse JSON/,
+    );
+  });
+});

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  discoverWorkflows,
+  loadWorkflowFile,
+  resolveWorkflowRef,
+  workflowFileStem,
+} from "../src/workflows/loader.js";
+import { makeTempDir } from "./helpers.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const ECHO_EXAMPLE = path.join(REPO_ROOT, "examples", "workflows", "echo.workflow.ts");
+
+async function makeSearchDirs() {
+  const cwd = await makeTempDir("pi-workflows-cwd");
+  const homeDir = await makeTempDir("pi-workflows-home");
+  await fs.mkdir(path.join(cwd, ".pi", "workflows"), { recursive: true });
+  await fs.mkdir(path.join(homeDir, ".pi", "agent", "workflows"), { recursive: true });
+  return { cwd, homeDir };
+}
+
+async function copyExample(targetDir: string, fileName: string): Promise<string> {
+  const target = path.join(targetDir, fileName);
+  let source = await fs.readFile(ECHO_EXAMPLE, "utf8");
+  source = source.replace(
+    `from "pi-workflows"`,
+    `from ${JSON.stringify(path.join(REPO_ROOT, "src", "workflows", "index.ts"))}`,
+  );
+  await fs.writeFile(target, source, "utf8");
+  return target;
+}
+
+describe("workflowFileStem", () => {
+  it("strips workflow suffixes", () => {
+    expect(workflowFileStem("/a/b/echo.workflow.ts")).toBe("echo");
+    expect(workflowFileStem("/a/b/echo.workflow.js")).toBe("echo");
+  });
+});
+
+describe("discoverWorkflows", () => {
+  it("finds project and global workflows, project first", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    await copyExample(path.join(cwd, ".pi", "workflows"), "local.workflow.ts");
+    await copyExample(path.join(homeDir, ".pi", "agent", "workflows"), "global.workflow.ts");
+
+    const discovered = await discoverWorkflows({ cwd, homeDir });
+
+    expect(discovered.map((w) => [w.name, w.source])).toEqual([
+      ["local", "project"],
+      ["global", "global"],
+    ]);
+  });
+
+  it("prefers project workflows on name collisions", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    await copyExample(path.join(cwd, ".pi", "workflows"), "same.workflow.ts");
+    await copyExample(path.join(homeDir, ".pi", "agent", "workflows"), "same.workflow.ts");
+
+    const discovered = await discoverWorkflows({ cwd, homeDir });
+
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]?.source).toBe("project");
+  });
+
+  it("returns empty for missing directories", async () => {
+    const cwd = await makeTempDir("pi-workflows-empty");
+    const homeDir = await makeTempDir("pi-workflows-empty-home");
+    expect(await discoverWorkflows({ cwd, homeDir })).toEqual([]);
+  });
+});
+
+describe("loadWorkflowFile", () => {
+  it("loads a workflow module via jiti", async () => {
+    const workflow = await loadWorkflowFile(ECHO_EXAMPLE);
+    expect(workflow.name).toBe("echo");
+    expect(workflow.startAt).toBe("reply");
+  });
+
+  it("rejects modules that do not export defineWorkflow", async () => {
+    const dir = await makeTempDir("pi-workflows-bad");
+    const badPath = path.join(dir, "bad.workflow.ts");
+    await fs.writeFile(badPath, "export default { name: 'nope' };\n", "utf8");
+    await expect(loadWorkflowFile(badPath)).rejects.toThrow(/defineWorkflow/);
+  });
+});
+
+describe("resolveWorkflowRef", () => {
+  it("resolves names to discovered workflows", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    const target = await copyExample(path.join(cwd, ".pi", "workflows"), "mine.workflow.ts");
+
+    const resolved = await resolveWorkflowRef("mine", { cwd, homeDir });
+
+    expect(resolved).toEqual({ path: target, source: "project" });
+  });
+
+  it("resolves direct paths", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    const resolved = await resolveWorkflowRef(ECHO_EXAMPLE, { cwd, homeDir });
+    expect(resolved).toEqual({ path: ECHO_EXAMPLE, source: "path" });
+  });
+
+  it("lists available names for unknown refs", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    await copyExample(path.join(cwd, ".pi", "workflows"), "known.workflow.ts");
+    await expect(resolveWorkflowRef("unknown", { cwd, homeDir })).rejects.toThrow(/known/);
+  });
+});

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { fitWidth, stripAnsi, visibleLength } from "../src/viewer/ansi.js";
 import {
   formatDuration,
+  maxDetailScroll,
   renderRunDetailLines,
   renderRunListLines,
   runElapsedMs,
@@ -142,6 +143,31 @@ describe("renderRunDetailLines", () => {
   it("clips to the viewport height", () => {
     const lines = renderRunDetailLines(makeBundle(), { width: 100, height: 4 }, NOW);
     expect(lines).toHaveLength(4);
+  });
+
+  it("shows the running node's statusDetail", () => {
+    const bundle = makeBundle({
+      currentNode: "two",
+      currentNodeStartedAt: "2026-07-19T00:00:50.000Z",
+      statusDetail: "reviewing",
+    });
+    const text = renderRunDetailLines(bundle, size, NOW).map(stripAnsi).join("\n");
+    expect(text).toContain("◐ two [compute] running 10s · reviewing");
+  });
+
+  it("scrolls the detail view over long content", () => {
+    const bundle = makeBundle();
+    const viewport = { width: 100, height: 4 };
+    const top = renderRunDetailLines(bundle, viewport, NOW, 0).map(stripAnsi);
+    const scrolled = renderRunDetailLines(bundle, viewport, NOW, 2).map(stripAnsi);
+    expect(scrolled[0]).toBe(top[2]);
+    expect(maxDetailScroll(bundle, viewport)).toBeGreaterThan(0);
+    // Scroll beyond the end clamps to the last full viewport.
+    const clamped = renderRunDetailLines(bundle, viewport, NOW, 10_000).map(stripAnsi);
+    expect(clamped).toHaveLength(4);
+    expect(renderRunDetailLines(bundle, viewport, NOW, maxDetailScroll(bundle, viewport))).toEqual(
+      renderRunDetailLines(bundle, viewport, NOW, 10_000),
+    );
   });
 });
 

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { fitWidth, stripAnsi, visibleLength } from "../src/viewer/ansi.js";
+import {
+  formatDuration,
+  renderRunDetailLines,
+  renderRunListLines,
+  runElapsedMs,
+} from "../src/viewer/render.js";
+import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { createDefinitionSnapshot } from "../src/workflows/store.js";
+import type { LoadedRunBundle } from "../src/workflows/store.js";
+import type { WorkflowRunState } from "../src/workflows/types.js";
+
+const NOW = new Date("2026-07-19T00:01:00.000Z");
+
+const workflow = defineWorkflow({
+  name: "demo",
+  startAt: "one",
+  nodes: {
+    one: compute({ run: () => 1 }),
+    two: compute({ run: () => 2 }),
+  },
+  edges: [{ from: "one", to: "two" }],
+});
+
+function makeBundle(overrides: Partial<WorkflowRunState> = {}): LoadedRunBundle {
+  const state: WorkflowRunState = {
+    runId: "run-1",
+    workflowName: "demo",
+    startedAt: "2026-07-19T00:00:00.000Z",
+    updatedAt: "2026-07-19T00:00:30.000Z",
+    status: "running",
+    input: {},
+    outputs: {},
+    results: {},
+    steps: [],
+    ...overrides,
+  };
+  return {
+    runDir: "/tmp/run-1",
+    manifest: {
+      schema: "pi-workflows.run-bundle.v1",
+      runId: state.runId,
+      workflowName: state.workflowName,
+      startedAt: state.startedAt,
+      status: state.status,
+      traceSchema: "pi-workflows.trace-event.v1",
+      paths: { workflow: "workflow.json", state: "state.json", trace: "trace.ndjson" },
+    },
+    state,
+    snapshot: createDefinitionSnapshot(workflow),
+  };
+}
+
+describe("formatDuration", () => {
+  it("formats milliseconds, seconds, and minutes", () => {
+    expect(formatDuration(500)).toBe("500ms");
+    expect(formatDuration(2_500)).toBe("2.5s");
+    expect(formatDuration(30_000)).toBe("30s");
+    expect(formatDuration(95_000)).toBe("1m35s");
+  });
+});
+
+describe("runElapsedMs", () => {
+  it("uses finishedAt when present, otherwise now", () => {
+    const finished = makeBundle({ finishedAt: "2026-07-19T00:00:10.000Z" }).state;
+    expect(runElapsedMs(finished, NOW)).toBe(10_000);
+    expect(runElapsedMs(makeBundle().state, NOW)).toBe(60_000);
+  });
+});
+
+describe("renderRunListLines", () => {
+  const size = { width: 100, height: 20 };
+
+  it("renders an empty message when there are no runs", () => {
+    const lines = renderRunListLines([], 0, size, NOW).map(stripAnsi);
+    expect(lines.at(-1)).toContain("No workflow runs found");
+  });
+
+  it("renders one line per run with a selection marker", () => {
+    const bundles = [makeBundle(), makeBundle({ runId: "run-2", status: "completed" })];
+    const lines = renderRunListLines(bundles, 1, size, NOW).map(stripAnsi);
+    const runLines = lines.filter((line) => line.includes("run-"));
+    expect(runLines).toHaveLength(2);
+    expect(runLines[0]).toMatch(/^ {2}running/);
+    expect(runLines[1]).toMatch(/^› completed/);
+  });
+});
+
+describe("renderRunDetailLines", () => {
+  const size = { width: 100, height: 50 };
+
+  it("renders header, nodes, steps, and final output", () => {
+    const bundle = makeBundle({
+      status: "completed",
+      finishedAt: "2026-07-19T00:00:45.000Z",
+      finalOutput: { done: true },
+      results: {
+        one: {
+          attemptId: "a",
+          nodeId: "one",
+          nodeType: "compute",
+          outcome: "ok",
+          startedAt: "2026-07-19T00:00:00.000Z",
+          finishedAt: "2026-07-19T00:00:01.000Z",
+          durationMs: 1000,
+        },
+      },
+      steps: [
+        {
+          attemptId: "a",
+          nodeId: "one",
+          nodeType: "compute",
+          outcome: "ok",
+          startedAt: "2026-07-19T00:00:00.000Z",
+          finishedAt: "2026-07-19T00:00:01.000Z",
+          promptText: null,
+          output: { value: 1 },
+        },
+      ],
+    });
+    const text = renderRunDetailLines(bundle, size, NOW).map(stripAnsi).join("\n");
+    expect(text).toContain("workflow demo");
+    expect(text).toContain("completed · run run-1 · elapsed 45s");
+    expect(text).toContain("✓ one [compute] 1.0s");
+    expect(text).toContain("· two [compute]");
+    expect(text).toContain(`{"value":1}`);
+    expect(text).toContain(`output {"done":true}`);
+  });
+
+  it("renders running node elapsed time and errors", () => {
+    const bundle = makeBundle({
+      currentNode: "two",
+      currentNodeStartedAt: "2026-07-19T00:00:50.000Z",
+      error: "exploded",
+    });
+    const text = renderRunDetailLines(bundle, size, NOW).map(stripAnsi).join("\n");
+    expect(text).toContain("◐ two [compute] running 10s");
+    expect(text).toContain("error: exploded");
+  });
+
+  it("clips to the viewport height", () => {
+    const lines = renderRunDetailLines(makeBundle(), { width: 100, height: 4 }, NOW);
+    expect(lines).toHaveLength(4);
+  });
+});
+
+describe("ansi helpers", () => {
+  it("strips ANSI and measures visible length", () => {
+    const styled = "\u001b[32mgreen\u001b[0m";
+    expect(stripAnsi(styled)).toBe("green");
+    expect(visibleLength(styled)).toBe(5);
+  });
+
+  it("fits lines to a width", () => {
+    expect(fitWidth("short", 10)).toBe("short");
+    expect(stripAnsi(fitWidth("a".repeat(20), 10))).toBe(`${"a".repeat(9)}…`);
+  });
+});

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { ConversationStepExecutor, type PromptDelivery } from "../src/extension/executor.js";
 import { sanitizeText } from "../src/viewer/ansi.js";
@@ -5,6 +6,7 @@ import { renderRunDetailLines } from "../src/viewer/render.js";
 import { agent, compute, defineWorkflow, shell } from "../src/workflows/definition.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import { validateWorkflowDefinition } from "../src/workflows/graph.js";
+import { extractJsonValue } from "../src/workflows/json.js";
 import { runShellAction } from "../src/workflows/shell.js";
 import { createDefinitionSnapshot } from "../src/workflows/store.js";
 import type { AgentStepRequest } from "../src/workflows/types.js";
@@ -471,6 +473,55 @@ describe("failure metadata retention", () => {
   });
 });
 
+describe("shell robustness", () => {
+  it("survives a child that exits without consuming stdin", async () => {
+    // 1 MiB of stdin against a child that closes stdin immediately (EPIPE).
+    const result = await runShellAction({
+      command: "sh",
+      args: ["-c", "exec 0<&-; printf ok"],
+      stdin: "x".repeat(1_048_576),
+      allowNonZeroExit: true,
+    });
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("refuses to spawn when the signal is already aborted", async () => {
+    const abort = new AbortController();
+    abort.abort();
+    const marker = `${Date.now()}-no-spawn`;
+    await expect(
+      runShellAction({ command: "sh", args: ["-c", `touch /tmp/${marker}`] }, abort.signal),
+    ).rejects.toThrow(/cancelled/i);
+    await expect(fs.access(`/tmp/${marker}`)).rejects.toThrow();
+  });
+
+  it("keeps the shell receipt when the node-level timeout kills the command", async () => {
+    const workflow = defineWorkflow({
+      name: "receipt-on-timeout",
+      startAt: "sleepy",
+      nodes: {
+        sleepy: shell({ timeoutMs: 150, exec: () => ({ command: "sleep", args: ["10"] }) }),
+      },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("timed_out");
+    expect(state.steps.at(-1)?.action).toMatchObject({ actionType: "shell", command: "sleep" });
+  });
+});
+
+describe("embedded JSON extraction bounds", () => {
+  it("stays fast on pathological brace floods", () => {
+    const started = Date.now();
+    expect(() => extractJsonValue("{".repeat(20_000))).toThrow(/Could not parse/);
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it("still finds JSON embedded in chatty text", () => {
+    expect(extractJsonValue('Sure! Here you go: {"route":"y"} — done.')).toEqual({ route: "y" });
+  });
+});
+
 describe("bounded shell output", () => {
   it("truncates output beyond maxOutputChars", async () => {
     const result = await runShellAction({
@@ -487,6 +538,10 @@ describe("terminal output sanitization", () => {
   it("strips ANSI and control characters from untrusted text", () => {
     expect(sanitizeText("\u001b[2Jwiped\u0007bell")).toBe("wipedbell");
     expect(sanitizeText("plain text")).toBe("plain text");
+  });
+
+  it("collapses line breaks and tabs so one value stays one line", () => {
+    expect(sanitizeText("line1\nline2\r\n\tline3")).toBe("line1 line2 line3");
   });
 
   it("keeps model-controlled escape sequences out of rendered runs", async () => {

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { ConversationStepExecutor, type PromptDelivery } from "../src/extension/executor.js";
+import { sanitizeText } from "../src/viewer/ansi.js";
+import { renderRunDetailLines } from "../src/viewer/render.js";
+import { agent, compute, defineWorkflow, shell } from "../src/workflows/definition.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { runShellAction } from "../src/workflows/shell.js";
+import { createDefinitionSnapshot } from "../src/workflows/store.js";
+import type { AgentStepRequest } from "../src/workflows/types.js";
+import { ScriptedExecutor, makeTempDir } from "./helpers.js";
+
+async function makeEngine(options: { executor?: ScriptedExecutor } = {}) {
+  const outputRoot = await makeTempDir("pi-workflows-fixes");
+  return new WorkflowEngine({ executor: options.executor ?? new ScriptedExecutor(), outputRoot });
+}
+
+describe("timeouts and cancellation for local nodes", () => {
+  it("times out a compute node that never settles", async () => {
+    const workflow = defineWorkflow({
+      name: "hung-compute",
+      startAt: "spin",
+      nodes: { spin: compute({ timeoutMs: 100, run: () => new Promise(() => {}) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("timed_out");
+    expect(state.results.spin?.outcome).toBe("timed_out");
+  });
+
+  it("cancels a compute node that never settles", async () => {
+    const workflow = defineWorkflow({
+      name: "cancel-compute",
+      startAt: "spin",
+      nodes: { spin: compute({ run: () => new Promise(() => {}) }) },
+      edges: [],
+    });
+    const engine = await makeEngine();
+    const runPromise = engine.run(workflow, {});
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    engine.cancel();
+    const { state } = await runPromise;
+    expect(state.status).toBe("cancelled");
+  });
+
+  it("kills a shell action without its own timeout when the node times out", async () => {
+    const workflow = defineWorkflow({
+      name: "hung-shell",
+      startAt: "sleepy",
+      nodes: {
+        sleepy: shell({ timeoutMs: 150, exec: () => ({ command: "sleep", args: ["10"] }) }),
+      },
+      edges: [],
+    });
+    const started = Date.now();
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("timed_out");
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+});
+
+describe("abort-like errors from callbacks", () => {
+  it("marks the run cancelled when a node throws an AbortError", async () => {
+    const workflow = defineWorkflow({
+      name: "abortish",
+      startAt: "boom",
+      nodes: {
+        boom: compute({
+          run: () => {
+            const error = new Error("aborted externally");
+            error.name = "AbortError";
+            throw error;
+          },
+        }),
+      },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.results.boom?.outcome).toBe("cancelled");
+    expect(state.status).toBe("cancelled");
+  });
+});
+
+describe("unserializable node outputs", () => {
+  it("fails the node instead of corrupting the persisted state", async () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const workflow = defineWorkflow({
+      name: "cyclic-output",
+      startAt: "bad",
+      nodes: { bad: compute({ run: () => cyclic }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("failed");
+    expect(state.error).toMatch(/non-JSON-serializable/);
+    expect(() => JSON.stringify(state)).not.toThrow();
+  });
+});
+
+describe("shell output capture", () => {
+  it("waits for stdio to close so backgrounded writers are captured", async () => {
+    const result = await runShellAction({
+      command: "sh",
+      args: ["-c", "(sleep 0.1; printf late) & printf early"],
+    });
+    expect(result.stdout).toBe("earlylate");
+  });
+});
+
+describe("stale submissions after a step is replaced", () => {
+  it("does not clear a newer pending step", async () => {
+    const sent: PromptDelivery[] = [];
+    const executor = new ConversationStepExecutor({ sendPrompt: (d) => sent.push(d) });
+
+    let releaseAccept: (() => void) | undefined;
+    const slowRequest: AgentStepRequest = {
+      contract: { runId: "r", workflowName: "w", nodeId: "first", attemptId: "a1" },
+      prompt: "first",
+      accept: () =>
+        new Promise((resolve) => {
+          releaseAccept = () => resolve({ ok: true, value: { late: true } });
+        }),
+    };
+
+    const firstAbort = new AbortController();
+    const firstStep = executor.runAgentStep(slowRequest, firstAbort.signal);
+    const staleSubmission = executor.submit("first", {});
+
+    // The step times out while validation is still pending, and the engine
+    // moves on to a new step.
+    firstAbort.abort(new Error("timed out"));
+    await expect(firstStep).rejects.toThrow(/timed out/);
+
+    const secondRequest: AgentStepRequest = {
+      contract: { runId: "r", workflowName: "w", nodeId: "first", attemptId: "a2" },
+      prompt: "retry",
+      accept: async (output) => ({ ok: true, value: output }),
+    };
+    const secondStep = executor.runAgentStep(secondRequest, new AbortController().signal);
+
+    releaseAccept?.();
+    const stale = await staleSubmission;
+    expect(stale.accepted).toBe(false);
+    expect(stale.message).toMatch(/no longer awaiting/);
+
+    // The newer step is still submittable.
+    const fresh = await executor.submit("first", { ok: 1 });
+    expect(fresh.accepted).toBe(true);
+    await expect(secondStep).resolves.toEqual({ output: { ok: 1 } });
+  });
+});
+
+describe("terminal output sanitization", () => {
+  it("strips ANSI and control characters from untrusted text", () => {
+    expect(sanitizeText("\u001b[2Jwiped\u0007bell")).toBe("wipedbell");
+    expect(sanitizeText("plain text")).toBe("plain text");
+  });
+
+  it("keeps model-controlled escape sequences out of rendered runs", async () => {
+    const workflow = defineWorkflow({
+      name: "hostile",
+      startAt: "reply",
+      nodes: { reply: agent({ prompt: () => "?" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("reply", {
+      output: { text: "\u001b[2J\u001b[H cleared" },
+    });
+    const engine = await makeEngine({ executor });
+    const { state, runDir } = await engine.run(workflow, {});
+    const lines = renderRunDetailLines(
+      { runDir, manifest: null as never, state, snapshot: createDefinitionSnapshot(workflow) },
+      { width: 120, height: 100 },
+    );
+    const joined = lines.join("\n");
+    expect(joined).toContain("cleared");
+    expect(joined).not.toContain("\u001b[2J");
+  });
+});

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -582,6 +582,70 @@ describe("shell robustness", () => {
   });
 });
 
+describe("observer isolation", () => {
+  it("completes the run even when onEvent throws", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-observer");
+    const engine = new WorkflowEngine({
+      executor: new ScriptedExecutor(),
+      outputRoot,
+      onEvent: () => {
+        throw new Error("UI exploded");
+      },
+    });
+    const workflow = defineWorkflow({
+      name: "observed",
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => "done" }) },
+      edges: [],
+    });
+    const { state } = await engine.run(workflow, {});
+    expect(state.status).toBe("completed");
+  });
+});
+
+describe("nudge delivery failures", () => {
+  it("fails the pending step promptly when the reminder cannot be sent", async () => {
+    let sends = 0;
+    const executor = new ConversationStepExecutor({
+      sendPrompt: () => {
+        sends += 1;
+        if (sends > 1) {
+          throw new Error("reminder delivery failed");
+        }
+      },
+    });
+    const request: AgentStepRequest = {
+      contract: { runId: "r", workflowName: "w", nodeId: "step", attemptId: "a1" },
+      prompt: "step",
+      accept: async (output) => ({ ok: true, value: output }),
+    };
+    const stepPromise = executor.runAgentStep(request, new AbortController().signal);
+    expect(executor.handleAgentSettled()).toBe(false);
+    await expect(stepPromise).rejects.toThrow(/reminder delivery failed/);
+    expect(executor.pendingStepId).toBeNull();
+  });
+});
+
+describe("spawn failure receipts", () => {
+  it("records a receipt when the executable does not exist", async () => {
+    const workflow = defineWorkflow({
+      name: "no-such-binary",
+      startAt: "ghost",
+      nodes: {
+        ghost: shell({ exec: () => ({ command: "definitely-not-a-real-binary-xyz" }) }),
+      },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("failed");
+    expect(state.steps.at(-1)?.action).toMatchObject({
+      actionType: "shell",
+      command: "definitely-not-a-real-binary-xyz",
+      exitCode: null,
+    });
+  });
+});
+
 describe("embedded JSON extraction bounds", () => {
   it("stays fast on pathological brace floods", () => {
     const started = Date.now();

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -340,6 +340,78 @@ describe("prompt delivery failures", () => {
   });
 });
 
+describe("hung validation after the step is cleared", () => {
+  it("unblocks the submit call when the step times out mid-validation", async () => {
+    const executor = new ConversationStepExecutor({ sendPrompt: () => {} });
+    const request: AgentStepRequest = {
+      contract: { runId: "r", workflowName: "w", nodeId: "step", attemptId: "a1" },
+      prompt: "step",
+      accept: () => new Promise(() => {}), // validation never settles
+    };
+    const abort = new AbortController();
+    const stepPromise = executor.runAgentStep(request, abort.signal);
+    const submission = executor.submit("step", "a1", {});
+
+    abort.abort(new Error("timed out"));
+    await expect(stepPromise).rejects.toThrow(/timed out/);
+
+    // Without the cleared-race, this await would hang forever and block pi's
+    // tool execution.
+    const result = await submission;
+    expect(result.accepted).toBe(false);
+    expect(result.message).toMatch(/no longer awaiting/);
+  });
+});
+
+describe("checkpoint edges", () => {
+  it("rejects outgoing edges from checkpoint nodes", async () => {
+    const { checkpoint } = await import("../src/workflows/definition.js");
+    const workflow = defineWorkflow({
+      name: "checkpoint-edge",
+      startAt: "pause",
+      nodes: { pause: checkpoint({}), after: compute({ run: () => 1 }) },
+      edges: [{ from: "pause", to: "after" }],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(
+      /checkpoint node must not declare an outgoing edge/,
+    );
+  });
+});
+
+describe("late prompt continuations", () => {
+  it("does not persist agent_prompt_sent after the node timed out", async () => {
+    let resolvePrompt: ((value: string) => void) | undefined;
+    const workflow = defineWorkflow({
+      name: "slow-prompt",
+      startAt: "ask",
+      nodes: {
+        ask: agent({
+          timeoutMs: 100,
+          prompt: () =>
+            new Promise<string>((resolve) => {
+              resolvePrompt = resolve;
+            }),
+        }),
+      },
+      edges: [],
+    });
+    const { state, runDir } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("timed_out");
+
+    // The stale continuation resolves after the run is terminal.
+    resolvePrompt?.("late prompt");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const trace = await fs.readFile(`${runDir}/trace.ndjson`, "utf8");
+    const types = trace
+      .trim()
+      .split("\n")
+      .map((line) => (JSON.parse(line) as { type: string }).type);
+    expect(types).not.toContain("agent_prompt_sent");
+    expect(types.at(-1)).toBe("run_timed_out");
+  });
+});
+
 describe("stale submissions after a step is replaced", () => {
   it("does not clear a newer pending step", async () => {
     const sent: PromptDelivery[] = [];

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -218,6 +218,61 @@ describe("stale outputs on repeated attempts", () => {
   });
 });
 
+describe("run input validation", () => {
+  it("rejects non-round-tripping input before any bundle is written", async () => {
+    const engine = await makeEngine();
+    const workflow = defineWorkflow({
+      name: "input-check",
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => 1 }) },
+      edges: [],
+    });
+    await expect(engine.run(workflow, { when: new Date() })).rejects.toThrow(/round-trip/);
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    await expect(engine.run(workflow, cyclic)).rejects.toThrow(/non-JSON-serializable/);
+  });
+
+  it("normalizes undefined input to null", async () => {
+    const workflow = defineWorkflow({
+      name: "input-null",
+      startAt: "echo",
+      nodes: { echo: compute({ run: ({ input }) => ({ input }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, undefined);
+    expect(state.status).toBe("completed");
+    expect(state.input).toBeNull();
+  });
+});
+
+describe("unreachable nodes", () => {
+  it("rejects a workflow with a node no path can reach", async () => {
+    const workflow = defineWorkflow({
+      name: "island",
+      startAt: "a",
+      nodes: { a: compute({ run: () => 1 }), b: compute({ run: () => 2 }) },
+      edges: [],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/unreachable nodes: b/);
+  });
+});
+
+describe("reserved node ids", () => {
+  it("rejects node ids that shadow Object prototype members", () => {
+    for (const nodeId of ["__proto__", "constructor", "toString"]) {
+      expect(() =>
+        defineWorkflow({
+          name: "reserved",
+          startAt: nodeId,
+          nodes: { [nodeId]: compute({ run: () => 1 }) },
+          edges: [],
+        }),
+      ).toThrow(/shadows an Object prototype member|must match/);
+    }
+  });
+});
+
 describe("prototype-polluting node ids", () => {
   it("rejects a start node that only exists on Object.prototype", () => {
     const workflow = defineWorkflow({
@@ -276,7 +331,9 @@ describe("prompt delivery failures", () => {
     );
     expect(executor.pendingStepId).toBeNull();
     const second = executor.runAgentStep(request("b"), new AbortController().signal);
-    await expect(executor.submit("b", { done: true })).resolves.toMatchObject({ accepted: true });
+    await expect(executor.submit("b", "b", { done: true })).resolves.toMatchObject({
+      accepted: true,
+    });
     await expect(second).resolves.toEqual({ output: { done: true } });
   });
 });
@@ -298,7 +355,7 @@ describe("stale submissions after a step is replaced", () => {
 
     const firstAbort = new AbortController();
     const firstStep = executor.runAgentStep(slowRequest, firstAbort.signal);
-    const staleSubmission = executor.submit("first", {});
+    const staleSubmission = executor.submit("first", "a1", {});
 
     // The step times out while validation is still pending, and the engine
     // moves on to a new step.
@@ -318,7 +375,7 @@ describe("stale submissions after a step is replaced", () => {
     expect(stale.message).toMatch(/no longer awaiting/);
 
     // The newer step is still submittable.
-    const fresh = await executor.submit("first", { ok: 1 });
+    const fresh = await executor.submit("first", "a2", { ok: 1 });
     expect(fresh.accepted).toBe(true);
     await expect(secondStep).resolves.toEqual({ output: { ok: 1 } });
   });

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -95,6 +95,31 @@ describe("unserializable node outputs", () => {
     expect(state.error).toMatch(/non-JSON-serializable/);
     expect(() => JSON.stringify(state)).not.toThrow();
   });
+
+  it("rejects values that stringify but do not round-trip", async () => {
+    for (const value of [Number.NaN, () => 1, { when: new Date() }, { drop: undefined, keep: 1 }]) {
+      const workflow = defineWorkflow({
+        name: "lossy-output",
+        startAt: "bad",
+        nodes: { bad: compute({ run: () => value }) },
+        edges: [],
+      });
+      const { state } = await (await makeEngine()).run(workflow, {});
+      expect(state.status).toBe("failed");
+      expect(state.error).toMatch(/round-trip|non-JSON/);
+    }
+  });
+
+  it("accepts plain JSON values", async () => {
+    const workflow = defineWorkflow({
+      name: "clean-output",
+      startAt: "good",
+      nodes: { good: compute({ run: () => ({ list: [1, "two", null, { nested: true }] }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("completed");
+  });
 });
 
 describe("shell output capture", () => {
@@ -104,6 +129,54 @@ describe("shell output capture", () => {
       args: ["-c", "(sleep 0.1; printf late) & printf early"],
     });
     expect(result.stdout).toBe("earlylate");
+  });
+
+  it("kills the whole process tree on timeout", async () => {
+    const started = Date.now();
+    await expect(
+      runShellAction({
+        command: "sh",
+        args: ["-c", "(sleep 5; printf late) & sleep 5"],
+        timeoutMs: 150,
+      }),
+    ).rejects.toThrow(/Timed out/);
+    // With only the direct child killed, the backgrounded descendant would
+    // hold the stdio pipes open for the full 5 seconds.
+    expect(Date.now() - started).toBeLessThan(3_000);
+  });
+});
+
+describe("stale outputs on repeated attempts", () => {
+  it("removes a previous success from outputs when the retry fails", async () => {
+    let calls = 0;
+    const workflow = defineWorkflow({
+      name: "flaky-loop",
+      startAt: "work",
+      nodes: {
+        work: compute({
+          run: () => {
+            calls += 1;
+            if (calls > 1) {
+              throw new Error("second attempt failed");
+            }
+            return { attempt: calls };
+          },
+        }),
+        again: compute({ run: () => "loop" }),
+        recover: compute({ run: ({ outputs }) => ({ sawStaleOutput: "work" in outputs }) }),
+      },
+      edges: [
+        {
+          from: "work",
+          switch: { on: "$result.outcome", cases: { ok: "again", failed: "recover" } },
+        },
+        { from: "again", to: "work" },
+      ],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("completed");
+    expect(state.finalOutput).toEqual({ sawStaleOutput: false });
+    expect(state.outputs).not.toHaveProperty("work");
   });
 });
 

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -381,6 +381,108 @@ describe("stale submissions after a step is replaced", () => {
   });
 });
 
+describe("switch path validation", () => {
+  it("rejects unsupported switch paths at definition time", () => {
+    expect(() =>
+      defineWorkflow({
+        name: "bad-path",
+        startAt: "a",
+        nodes: { a: compute({ run: () => 1 }), b: compute({ run: () => 2 }) },
+        edges: [{ from: "a", switch: { on: "route", cases: { x: "b" } } }],
+      }),
+    ).toThrow(/switch\.on must start with/);
+  });
+});
+
+describe("hung title resolution", () => {
+  it("can be cancelled before any node runs", async () => {
+    const workflow = defineWorkflow({
+      name: "hung-title",
+      title: () => new Promise<string>(() => {}),
+      startAt: "noop",
+      nodes: { noop: compute({ run: () => 1 }) },
+      edges: [],
+    });
+    const engine = await makeEngine();
+    const runPromise = engine.run(workflow, {});
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    engine.cancel();
+    await expect(runPromise).rejects.toThrow(/cancelled/i);
+  });
+});
+
+describe("validator results that are not JSON", () => {
+  it("returns a retryable validation error instead of accepting", async () => {
+    const attempts: unknown[] = [];
+    const workflow = defineWorkflow({
+      name: "bad-validator",
+      startAt: "step",
+      nodes: {
+        step: agent({
+          prompt: () => "?",
+          validate: (output) =>
+            (output as { fix?: boolean }).fix ? { fixed: true } : { when: new Date() },
+        }),
+      },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("step", async (request) => {
+      const first = await request.accept({ fix: false });
+      attempts.push(first);
+      const second = await request.accept({ fix: true });
+      if (!second.ok) {
+        throw new Error("expected the corrected output to be accepted");
+      }
+      return { output: second.value };
+    });
+    const { state } = await (await makeEngine({ executor })).run(workflow, {});
+    expect(state.status).toBe("completed");
+    expect(attempts[0]).toMatchObject({ ok: false });
+    expect((attempts[0] as { error: string }).error).toMatch(/round-trip/);
+  });
+});
+
+describe("failure metadata retention", () => {
+  it("keeps the shell action receipt when the command fails", async () => {
+    const workflow = defineWorkflow({
+      name: "failing-shell",
+      startAt: "boom",
+      nodes: { boom: shell({ exec: () => ({ command: "sh", args: ["-c", "exit 7"] }) }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("failed");
+    const step = state.steps.at(-1);
+    expect(step?.action).toMatchObject({ actionType: "shell", exitCode: 7 });
+    expect(step).toHaveProperty("output", null);
+  });
+
+  it("keeps the agent prompt when the step fails after delivery", async () => {
+    const workflow = defineWorkflow({
+      name: "failing-agent",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "Please answer" }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { error: "executor gave up" });
+    const { state } = await (await makeEngine({ executor })).run(workflow, {});
+    expect(state.status).toBe("failed");
+    expect(state.steps.at(-1)?.promptText).toContain("Please answer");
+  });
+});
+
+describe("bounded shell output", () => {
+  it("truncates output beyond maxOutputChars", async () => {
+    const result = await runShellAction({
+      command: "sh",
+      args: ["-c", "yes x | head -c 100000"],
+      maxOutputChars: 1_000,
+    });
+    expect(result.stdout.length).toBeLessThan(1_100);
+    expect(result.stdout).toContain("[output truncated]");
+  });
+});
+
 describe("terminal output sanitization", () => {
   it("strips ANSI and control characters from untrusted text", () => {
     expect(sanitizeText("\u001b[2Jwiped\u0007bell")).toBe("wipedbell");

--- a/test/review-fixes.test.ts
+++ b/test/review-fixes.test.ts
@@ -4,6 +4,7 @@ import { sanitizeText } from "../src/viewer/ansi.js";
 import { renderRunDetailLines } from "../src/viewer/render.js";
 import { agent, compute, defineWorkflow, shell } from "../src/workflows/definition.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
+import { validateWorkflowDefinition } from "../src/workflows/graph.js";
 import { runShellAction } from "../src/workflows/shell.js";
 import { createDefinitionSnapshot } from "../src/workflows/store.js";
 import type { AgentStepRequest } from "../src/workflows/types.js";
@@ -40,6 +41,30 @@ describe("timeouts and cancellation for local nodes", () => {
     engine.cancel();
     const { state } = await runPromise;
     expect(state.status).toBe("cancelled");
+  });
+
+  it("exposes an abort signal that fires when the node times out", async () => {
+    let sawAbort = false;
+    const workflow = defineWorkflow({
+      name: "cooperative",
+      startAt: "spin",
+      nodes: {
+        spin: compute({
+          timeoutMs: 100,
+          run: ({ signal }) =>
+            new Promise((_resolve, reject) => {
+              signal.addEventListener("abort", () => {
+                sawAbort = true;
+                reject(signal.reason);
+              });
+            }),
+        }),
+      },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("timed_out");
+    expect(sawAbort).toBe(true);
   });
 
   it("kills a shell action without its own timeout when the node times out", async () => {
@@ -120,6 +145,19 @@ describe("unserializable node outputs", () => {
     const { state } = await (await makeEngine()).run(workflow, {});
     expect(state.status).toBe("completed");
   });
+
+  it("normalizes an undefined output to null", async () => {
+    const workflow = defineWorkflow({
+      name: "void-output",
+      startAt: "quiet",
+      nodes: { quiet: compute({ run: () => undefined }) },
+      edges: [],
+    });
+    const { state } = await (await makeEngine()).run(workflow, {});
+    expect(state.status).toBe("completed");
+    expect(state.outputs.quiet).toBeNull();
+    expect(JSON.parse(JSON.stringify(state)).outputs).toHaveProperty("quiet");
+  });
 });
 
 describe("shell output capture", () => {
@@ -177,6 +215,69 @@ describe("stale outputs on repeated attempts", () => {
     expect(state.status).toBe("completed");
     expect(state.finalOutput).toEqual({ sawStaleOutput: false });
     expect(state.outputs).not.toHaveProperty("work");
+  });
+});
+
+describe("prototype-polluting node ids", () => {
+  it("rejects a start node that only exists on Object.prototype", () => {
+    const workflow = defineWorkflow({
+      name: "proto-start",
+      startAt: "toString",
+      nodes: { real: compute({ run: () => 1 }) },
+      edges: [],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/start node is missing: toString/);
+  });
+
+  it("rejects an edge target that only exists on Object.prototype", () => {
+    const workflow = defineWorkflow({
+      name: "proto-edge",
+      startAt: "real",
+      nodes: { real: compute({ run: () => 1 }) },
+      edges: [{ from: "real", to: "hasOwnProperty" }],
+    });
+    expect(() => validateWorkflowDefinition(workflow)).toThrow(/unknown to-node: hasOwnProperty/);
+  });
+});
+
+describe("non-finite timeouts", () => {
+  it("rejects NaN and Infinity timeouts at definition time", () => {
+    for (const timeoutMs of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        defineWorkflow({
+          name: "bad-timeout",
+          startAt: "spin",
+          nodes: { spin: compute({ timeoutMs, run: () => 1 }) },
+          edges: [],
+        }),
+      ).toThrow(/finite positive number/);
+    }
+  });
+});
+
+describe("prompt delivery failures", () => {
+  it("clears the pending step so a recovery step can run", async () => {
+    let failFirst = true;
+    const executor = new ConversationStepExecutor({
+      sendPrompt: () => {
+        if (failFirst) {
+          failFirst = false;
+          throw new Error("delivery failed");
+        }
+      },
+    });
+    const request = (nodeId: string): AgentStepRequest => ({
+      contract: { runId: "r", workflowName: "w", nodeId, attemptId: nodeId },
+      prompt: nodeId,
+      accept: async (output) => ({ ok: true, value: output }),
+    });
+    await expect(executor.runAgentStep(request("a"), new AbortController().signal)).rejects.toThrow(
+      /delivery failed/,
+    );
+    expect(executor.pendingStepId).toBeNull();
+    const second = executor.runAgentStep(request("b"), new AbortController().signal);
+    await expect(executor.submit("b", { done: true })).resolves.toMatchObject({ accepted: true });
+    await expect(second).resolves.toEqual({ output: { done: true } });
   });
 });
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  action,
+  agent,
+  checkpoint,
+  compute,
+  defineWorkflow,
+  isWorkflowDefinition,
+  shell,
+} from "../src/workflows/definition.js";
+import {
+  CancelledError,
+  TimeoutError,
+  errorMessage,
+  isAbortLikeError,
+} from "../src/workflows/errors.js";
+import {
+  createDefinitionSnapshot,
+  readRunBundle,
+  workflowRunsBaseDir,
+} from "../src/workflows/store.js";
+import type { WorkflowDefinition, WorkflowEdge } from "../src/workflows/types.js";
+import { makeTempDir } from "./helpers.js";
+
+const validNodes = { start: compute({ run: () => 1 }) };
+
+function define(overrides: Partial<WorkflowDefinition>): WorkflowDefinition {
+  return defineWorkflow({
+    name: "valid",
+    startAt: "start",
+    nodes: validNodes,
+    edges: [],
+    ...overrides,
+  } as WorkflowDefinition);
+}
+
+describe("defineWorkflow validation", () => {
+  it("accepts a valid workflow and brands it once", () => {
+    const workflow = define({});
+    expect(isWorkflowDefinition(workflow)).toBe(true);
+    expect(defineWorkflow(workflow)).toBe(workflow);
+  });
+
+  it("rejects missing or invalid top-level fields", () => {
+    expect(() => define({ name: "" })).toThrow(/requires a name/);
+    expect(() => define({ startAt: "" })).toThrow(/requires startAt/);
+    expect(() => define({ title: 5 as never })).toThrow(/title must be a string or function/);
+    expect(() => define({ maxSteps: 0 })).toThrow(/maxSteps must be a positive integer/);
+    expect(() => define({ maxSteps: 1.5 })).toThrow(/maxSteps must be a positive integer/);
+    expect(() => define({ nodes: {} })).toThrow(/at least one node/);
+    expect(() => define({ nodes: [] as never })).toThrow(/must be an object/);
+    expect(() => define({ edges: {} as never })).toThrow(/edges must be an array/);
+  });
+
+  it("rejects bad node ids and unknown node types", () => {
+    expect(() => define({ nodes: { "bad id!": compute({ run: () => 1 }) } })).toThrow(/must match/);
+    expect(() => define({ nodes: { x: { nodeType: "mystery" } as never } })).toThrow(
+      /unknown nodeType/,
+    );
+  });
+
+  it("rejects malformed edges", () => {
+    const edge = (value: unknown) => define({ edges: [value as WorkflowEdge] });
+    expect(() => edge({ to: "start" })).toThrow(/requires a from/);
+    expect(() => edge({ from: "start", to: "" })).toThrow(/requires a to/);
+    expect(() => edge({ from: "start", switch: { on: "", cases: { a: "start" } } })).toThrow(
+      /switch\.on/,
+    );
+    expect(() => edge({ from: "start", switch: { on: "$.x", cases: {} } })).toThrow(
+      /must not be empty/,
+    );
+    expect(() => edge({ from: "start", switch: { on: "$.x", cases: { a: 1 } } })).toThrow(
+      /must map to a node id/,
+    );
+  });
+});
+
+describe("node constructors", () => {
+  it("validates agent nodes", () => {
+    expect(() => agent({ prompt: "nope" as never })).toThrow(/requires a prompt function/);
+    expect(() => agent({ prompt: () => "p", expectedOutput: 5 as never })).toThrow(
+      /expectedOutput/,
+    );
+    expect(() => agent({ prompt: () => "p", validate: "x" as never })).toThrow(/validate/);
+    expect(() => agent({ prompt: () => "p", timeoutMs: -1 })).toThrow(/timeoutMs/);
+    expect(() => agent({ prompt: () => "p", statusDetail: 1 as never })).toThrow(/statusDetail/);
+    expect(agent({ prompt: () => "p" }).nodeType).toBe("agent");
+  });
+
+  it("validates compute nodes", () => {
+    expect(() => compute({ run: "nope" as never })).toThrow(/requires a run function/);
+  });
+
+  it("validates action nodes", () => {
+    expect(() => action({} as never)).toThrow(/exactly one of run or exec/);
+    expect(() => action({ run: () => 1, exec: () => ({ command: "x" }) } as never)).toThrow(
+      /exactly one of run or exec/,
+    );
+    expect(() => action({ exec: () => ({ command: "x" }), parse: "y" as never })).toThrow(/parse/);
+    expect(action({ run: () => 1 }).nodeType).toBe("action");
+    expect(action({ exec: () => ({ command: "x" }) }).nodeType).toBe("action");
+  });
+
+  it("validates shell nodes", () => {
+    expect(() => shell({ exec: undefined as never })).toThrow(/requires an exec function/);
+    expect(() => shell({ exec: () => ({ command: "x" }), parse: 1 as never })).toThrow(/parse/);
+    expect(shell({ exec: () => ({ command: "x" }) }).nodeType).toBe("action");
+  });
+
+  it("validates checkpoint nodes", () => {
+    expect(() => checkpoint({ summary: 1 as never })).toThrow(/summary/);
+    expect(() => checkpoint({ run: "x" as never })).toThrow(/run/);
+    expect(checkpoint().nodeType).toBe("checkpoint");
+  });
+});
+
+describe("errors helpers", () => {
+  it("describes timeouts and cancellations", () => {
+    const timeout = new TimeoutError(1500);
+    expect(timeout.message).toBe("Timed out after 1500ms");
+    expect(timeout.timeoutMs).toBe(1500);
+    expect(new CancelledError().message).toContain("cancelled");
+  });
+
+  it("detects abort-like errors", () => {
+    expect(isAbortLikeError(new CancelledError())).toBe(true);
+    const abort = new Error("aborted");
+    abort.name = "AbortError";
+    expect(isAbortLikeError(abort)).toBe(true);
+    expect(isAbortLikeError(new Error("other"))).toBe(false);
+    expect(isAbortLikeError("nope")).toBe(false);
+  });
+
+  it("stringifies unknown error values", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+    expect(errorMessage("plain")).toBe("plain");
+    expect(errorMessage(42)).toBe("42");
+  });
+});
+
+describe("definition snapshots", () => {
+  it("captures per-node metadata for every node type", () => {
+    const workflow = define({
+      nodes: {
+        start: agent({
+          prompt: () => "p",
+          expectedOutput: "{}",
+          timeoutMs: 1000,
+          statusDetail: "thinking",
+        }),
+        act: shell({ exec: () => ({ command: "true" }) }),
+        fn: action({ run: () => 1 }),
+        stop: checkpoint({ summary: "pause here" }),
+      },
+      edges: [
+        { from: "start", to: "act" },
+        { from: "act", to: "fn" },
+        { from: "fn", to: "stop" },
+      ],
+    });
+    const snapshot = createDefinitionSnapshot(workflow);
+    expect(snapshot.nodes.start).toEqual({
+      nodeType: "agent",
+      expectedOutput: "{}",
+      timeoutMs: 1000,
+      statusDetail: "thinking",
+    });
+    expect(snapshot.nodes.act).toEqual({ nodeType: "action", actionExecution: "shell" });
+    expect(snapshot.nodes.fn).toEqual({ nodeType: "action", actionExecution: "function" });
+    expect(snapshot.nodes.stop).toEqual({ nodeType: "checkpoint", summary: "pause here" });
+  });
+});
+
+describe("store misc", () => {
+  it("honors the PI_WORKFLOWS_RUNS_DIR override", () => {
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", "/tmp/custom-runs");
+    try {
+      expect(workflowRunsBaseDir()).toBe("/tmp/custom-runs");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("returns null for unreadable bundles", async () => {
+    const dir = await makeTempDir("pi-workflows-junk");
+    expect(await readRunBundle(dir)).toBeNull();
+  });
+});

--- a/test/shell.test.ts
+++ b/test/shell.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { TimeoutError } from "../src/workflows/errors.js";
+import { renderShellCommand, runShellAction } from "../src/workflows/shell.js";
+
+describe("renderShellCommand", () => {
+  it("renders commands with quoted args", () => {
+    expect(renderShellCommand("git", ["status", "--short"])).toBe('git "status" "--short"');
+    expect(renderShellCommand("ls", [])).toBe("ls");
+  });
+});
+
+describe("runShellAction", () => {
+  it("captures stdout, stderr, and exit code", async () => {
+    const result = await runShellAction({
+      command: "sh",
+      args: ["-c", "printf out; printf err >&2"],
+    });
+    expect(result.stdout).toBe("out");
+    expect(result.stderr).toBe("err");
+    expect(result.exitCode).toBe(0);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("passes stdin, env, and cwd", async () => {
+    const result = await runShellAction({
+      command: "sh",
+      args: ["-c", 'cat; printf %s "$MARKER"; pwd'],
+      stdin: "piped|",
+      env: { MARKER: "-mark-" },
+      cwd: "/tmp",
+    });
+    expect(result.stdout).toContain("piped|-mark-");
+    expect(result.stdout.trimEnd().endsWith("/tmp")).toBe(true);
+  });
+
+  it("rejects on non-zero exit unless allowed", async () => {
+    await expect(runShellAction({ command: "sh", args: ["-c", "exit 3"] })).rejects.toThrow(
+      /exit 3/,
+    );
+    const tolerated = await runShellAction({
+      command: "sh",
+      args: ["-c", "exit 3"],
+      allowNonZeroExit: true,
+    });
+    expect(tolerated.exitCode).toBe(3);
+  });
+
+  it("times out long-running commands", async () => {
+    await expect(runShellAction({ command: "sleep", args: ["5"], timeoutMs: 100 })).rejects.toThrow(
+      TimeoutError,
+    );
+  });
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import {
+  WorkflowRunStore,
+  createDefinitionSnapshot,
+  createRunId,
+  listRunBundles,
+  readRunBundle,
+  workflowRunsBaseDir,
+} from "../src/workflows/store.js";
+import type { WorkflowRunState } from "../src/workflows/types.js";
+import { makeTempDir } from "./helpers.js";
+
+function makeState(overrides: Partial<WorkflowRunState> = {}): WorkflowRunState {
+  const now = new Date().toISOString();
+  return {
+    runId: createRunId("demo"),
+    workflowName: "demo",
+    startedAt: now,
+    updatedAt: now,
+    status: "running",
+    input: { task: "t" },
+    outputs: {},
+    results: {},
+    steps: [],
+    ...overrides,
+  };
+}
+
+const workflow = defineWorkflow({
+  name: "demo",
+  startAt: "one",
+  nodes: { one: compute({ run: () => 1 }) },
+  edges: [],
+});
+
+describe("createRunId", () => {
+  it("slugifies the workflow name with a timestamp and suffix", () => {
+    const runId = createRunId("My Workflow!", new Date("2026-07-19T01:02:03.456Z"));
+    expect(runId).toMatch(/^20260719T010203Z-my-workflow-[0-9a-f]{8}$/);
+  });
+});
+
+describe("workflowRunsBaseDir", () => {
+  it("lives under the pi agent directory", () => {
+    expect(workflowRunsBaseDir("/home/x")).toBe(
+      path.join("/home/x", ".pi", "agent", "workflows", "runs"),
+    );
+  });
+});
+
+describe("WorkflowRunStore", () => {
+  it("initializes and updates a run bundle", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-store");
+    const store = new WorkflowRunStore(outputRoot);
+    const state = makeState();
+
+    const runDir = await store.initializeRunBundle(workflow, state);
+    expect(runDir).toBe(path.join(outputRoot, state.runId));
+
+    state.status = "completed";
+    state.finishedAt = new Date().toISOString();
+    await store.writeSnapshot(runDir, state, { scope: "run", type: "run_completed", payload: {} });
+
+    const bundle = await readRunBundle(runDir);
+    expect(bundle?.manifest.status).toBe("completed");
+    expect(bundle?.state.status).toBe("completed");
+    expect(bundle?.snapshot?.schema).toBe("pi-workflows.definition-snapshot.v1");
+
+    const trace = await fs.readFile(path.join(runDir, "trace.ndjson"), "utf8");
+    const events = trace
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { seq: number; type: string });
+    expect(events.map((event) => event.type)).toEqual(["run_completed"]);
+  });
+
+  it("assigns monotonic trace sequence numbers", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-store");
+    const store = new WorkflowRunStore(outputRoot);
+    const state = makeState();
+    const runDir = await store.initializeRunBundle(workflow, state);
+
+    await Promise.all([
+      store.appendTrace(runDir, state, { scope: "node", type: "a", payload: {} }),
+      store.appendTrace(runDir, state, { scope: "node", type: "b", payload: {} }),
+      store.appendTrace(runDir, state, { scope: "node", type: "c", payload: {} }),
+    ]);
+
+    const trace = await fs.readFile(path.join(runDir, "trace.ndjson"), "utf8");
+    const seqs = trace
+      .trim()
+      .split("\n")
+      .map((line) => (JSON.parse(line) as { seq: number }).seq);
+    expect([...seqs].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("listRunBundles", () => {
+  it("lists bundles most recent first and skips junk", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-list");
+    const store = new WorkflowRunStore(outputRoot);
+    const older = makeState({ startedAt: "2026-01-01T00:00:00.000Z" });
+    const newer = makeState({ startedAt: "2026-06-01T00:00:00.000Z" });
+    await store.initializeRunBundle(workflow, older);
+    await store.initializeRunBundle(workflow, newer);
+    await fs.mkdir(path.join(outputRoot, "not-a-bundle"));
+
+    const bundles = await listRunBundles(outputRoot);
+
+    expect(bundles.map((bundle) => bundle.state.runId)).toEqual([newer.runId, older.runId]);
+  });
+
+  it("returns empty for a missing directory", async () => {
+    expect(await listRunBundles("/nonexistent/definitely/missing")).toEqual([]);
+  });
+});
+
+describe("createDefinitionSnapshot", () => {
+  it("captures node metadata without functions", () => {
+    const snapshot = createDefinitionSnapshot(workflow);
+    expect(snapshot.name).toBe("demo");
+    expect(snapshot.nodes.one).toEqual({ nodeType: "compute" });
+    expect(JSON.stringify(snapshot)).not.toContain("=>");
+  });
+});

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { watchRunsDir } from "../src/viewer/watch.js";
+import { makeTempDir } from "./helpers.js";
+
+function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const timer = setInterval(() => {
+      if (predicate()) {
+        clearInterval(timer);
+        resolve();
+      } else if (Date.now() > deadline) {
+        clearInterval(timer);
+        reject(new Error("Timed out waiting for change event"));
+      }
+    }, 10);
+  });
+}
+
+describe("watchRunsDir", () => {
+  it("fires on file changes and debounces bursts", async () => {
+    const dir = await makeTempDir("pi-workflows-watch");
+    let changes = 0;
+    const unsubscribe = watchRunsDir(
+      dir,
+      () => {
+        changes += 1;
+      },
+      { pollMs: 60_000, debounceMs: 20 },
+    );
+    try {
+      await fs.writeFile(path.join(dir, "a.json"), "{}", "utf8");
+      await fs.writeFile(path.join(dir, "b.json"), "{}", "utf8");
+      await waitFor(() => changes >= 1);
+      expect(changes).toBeGreaterThanOrEqual(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("falls back to polling when the directory cannot be watched", async () => {
+    let changes = 0;
+    const unsubscribe = watchRunsDir(
+      "/nonexistent/pi-workflows",
+      () => {
+        changes += 1;
+      },
+      { pollMs: 20, debounceMs: 5 },
+    );
+    try {
+      await waitFor(() => changes >= 1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("stops firing after unsubscribe", async () => {
+    const dir = await makeTempDir("pi-workflows-watch");
+    let changes = 0;
+    const unsubscribe = watchRunsDir(
+      dir,
+      () => {
+        changes += 1;
+      },
+      { pollMs: 20, debounceMs: 5 },
+    );
+    await waitFor(() => changes >= 1);
+    unsubscribe();
+    const settled = changes;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(changes).toBe(settled);
+  });
+});

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -98,4 +98,24 @@ describe("buildWidgetLines", () => {
     );
     expect(waiting.at(-1)).toContain("waiting on checkpoint: third");
   });
+
+  it("sanitizes titles, status details, and errors", () => {
+    const lines = buildWidgetLines(
+      makeState({
+        runTitle: "evil\u001b[2J\ntitle",
+        currentNode: "second",
+        statusDetail: "phase\tone\u0007",
+        error: "boom\nline2",
+        status: "failed",
+      }),
+      snapshot,
+    );
+    const joined = lines.join("|");
+    expect(joined).not.toContain("\u001b");
+    expect(joined).not.toContain("\u0007");
+    expect(joined).not.toContain("\n");
+    expect(lines[0]).toContain("evil title");
+    expect(joined).toContain("(phase one)");
+    expect(joined).toContain("error: boom line2");
+  });
 });

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { buildWidgetLines, displayNodeIds, nodeGlyph } from "../src/extension/widget.js";
+import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { createDefinitionSnapshot } from "../src/workflows/store.js";
+import type { WorkflowNodeResult, WorkflowRunState } from "../src/workflows/types.js";
+
+const workflow = defineWorkflow({
+  name: "demo",
+  startAt: "first",
+  nodes: {
+    first: compute({ run: () => 1 }),
+    second: compute({ run: () => 2 }),
+    third: compute({ run: () => 3 }),
+  },
+  edges: [
+    { from: "first", to: "second" },
+    { from: "second", to: "third" },
+  ],
+});
+const snapshot = createDefinitionSnapshot(workflow);
+
+function makeResult(nodeId: string, outcome: WorkflowNodeResult["outcome"]): WorkflowNodeResult {
+  return {
+    attemptId: "a",
+    nodeId,
+    nodeType: "compute",
+    outcome,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:00:01.000Z",
+    durationMs: 1000,
+  };
+}
+
+function makeState(overrides: Partial<WorkflowRunState> = {}): WorkflowRunState {
+  return {
+    runId: "r1",
+    workflowName: "demo",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    status: "running",
+    input: {},
+    outputs: {},
+    results: {},
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe("displayNodeIds", () => {
+  it("returns nodes in definition order", () => {
+    expect(displayNodeIds(snapshot)).toEqual(["first", "second", "third"]);
+  });
+});
+
+describe("nodeGlyph", () => {
+  it("marks the current node as running", () => {
+    expect(nodeGlyph(makeState({ currentNode: "second" }), "second")).toBe("◐");
+  });
+
+  it("marks finished, failed, waiting, and pending nodes", () => {
+    const state = makeState({
+      results: { first: makeResult("first", "ok"), second: makeResult("second", "failed") },
+      waitingOn: "third",
+    });
+    state.results.third = makeResult("third", "ok");
+    expect(nodeGlyph(state, "first")).toBe("✓");
+    expect(nodeGlyph(state, "second")).toBe("✗");
+    expect(nodeGlyph(state, "third")).toBe("⏸");
+    expect(nodeGlyph(makeState(), "first")).toBe("·");
+  });
+});
+
+describe("buildWidgetLines", () => {
+  it("renders a header and node markers", () => {
+    const state = makeState({
+      currentNode: "second",
+      statusDetail: "verifying",
+      results: { first: makeResult("first", "ok") },
+      runTitle: "demo run",
+    });
+    const lines = buildWidgetLines(state, snapshot);
+    expect(lines[0]).toContain("workflow demo — demo run [running]");
+    expect(lines[1]).toContain("✓ first");
+    expect(lines[1]).toContain("◐ second (verifying)");
+    expect(lines[1]).toContain("· third");
+  });
+
+  it("shows errors and waiting checkpoints", () => {
+    const failed = buildWidgetLines(
+      makeState({ status: "failed", error: "x".repeat(200) }),
+      snapshot,
+    );
+    expect(failed.at(-1)).toMatch(/error: x+…$/);
+
+    const waiting = buildWidgetLines(
+      makeState({ status: "waiting", waitingOn: "third" }),
+      snapshot,
+    );
+    expect(waiting.at(-1)).toContain("waiting on checkpoint: third");
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "paths": {
+      "pi-workflows": ["./src/workflows/index.ts"],
+      "pi-workflows/extension": ["./src/extension/index.ts"]
+    }
+  },
+  "include": ["src", "test", "examples", "scripts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "pi-workflows": new URL("./src/workflows/index.ts", import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ["test/**/*.test.ts"],
+    exclude: ["test/e2e/**", "node_modules/**"],
+    coverage: {
+      // istanbul instruments through the vitest transform pipeline only, so
+      // jiti-compiled copies of workflow modules don't pollute the report.
+      provider: "istanbul",
+      include: ["src/**"],
+      exclude: ["src/viewer/tui.ts"],
+      thresholds: {
+        lines: 85,
+        functions: 85,
+        branches: 85,
+        statements: 85,
+      },
+    },
+  },
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "pi-workflows": new URL("./src/workflows/index.ts", import.meta.url).pathname,
+    },
+  },
+  test: {
+    include: ["test/e2e/**/*.e2e.test.ts"],
+    testTimeout: 120_000,
+    hookTimeout: 60_000,
+    coverage: { enabled: false },
+  },
+});


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

pi had no way to run a structured multi-step agent workflow inside a conversation.
This change brings the acpx flows model into pi: you define a workflow as a TypeScript graph, trigger it at any point in a conversation with `/workflow`, and the model completes each step by calling a JSON `workflow` tool.
Runs persist to disk as they execute, and a standalone terminal viewer (`pi-workflows view`) shows progress live.
The flagship examples are `elegant-solution` (propose, holy grail, y/n compare, then implement or reconcile) and `autoimplement` (implement, verify, review loop until clean).

## What Changed

The package has three layers with enforced dependency boundaries.

- `src/workflows/` is the pi-agnostic engine: `defineWorkflow` with `agent`/`compute`/`action`/`shell`/`checkpoint` nodes and `decision`/`decisionEdge` sugar, graph validation, switch-edge routing on JSON paths (`$.field`, `$result.outcome`), timeouts, a `maxSteps` loop guard, and run-bundle persistence (atomic `state.json`, append-only `trace.ndjson`, versioned schemas).
- `src/extension/` embeds the engine in pi: the `/workflow` command (list, run by name or path, cancel, autocomplete), the `workflow` tool the model calls with `{step, output}` (invalid submissions are rejected with a reason so the model retries), a nudge policy when the model settles without submitting, and a live progress widget.
- `src/viewer/` is a self-contained ANSI TUI that tails the runs directory and re-renders on change, with `--once` snapshot output for scripts.

Workflows are discovered from `.pi/workflows/` and `~/.pi/agent/workflows/` and loaded with jiti, so plain TypeScript files work without a build step.
Six example workflows mirror the acpx set, and docs cover authoring (`docs/workflows.md`), the on-disk format (`docs/run-bundles.md`), and contributor standards (`docs/development.md`).

## Testing

Everything runs locally and non-destructively; no real model is called and nothing is written outside temp directories.

- `npm run check` — oxfmt, oxlint, tsc strict, build, and 145 unit tests with istanbul coverage at 96.6% statements / 90.6% branches (85% thresholds enforced).
- `npm run test:e2e` — spawns the real `pi` CLI in RPC mode with a mock OpenAI-compatible provider whose scripted "model" answers each step contract via the `workflow` tool, drives `/workflow` end to end, and asserts on the resulting run bundle and viewer output.
- `npx slophammer-ts dry .` and dependency-boundary checks pass.

Not tested locally: behavior against a real hosted model, and the interactive TUI input loop (`src/viewer/tui.ts`, excluded from coverage; its rendering is unit-tested through `render.ts`).

## Risks

This is a new package, so there is no existing behavior to break.
The main risk is model compliance: a model may ignore the step contract, which the nudge policy (two reminders, then step failure) and per-node timeouts bound.
Shell actions execute whatever the workflow author wrote; that is by design and documented, and the E2E suite keeps everything in temp dirs.

Made with [Cursor](https://cursor.com)