### PR TITLE
fix(viewer): align card surfaces and live action

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ pi-workflows view --once   # print a snapshot and exit (good for scripts)
 
 The run detail view draws the workflow as a boxed graph, like the acpx replay
 viewer. Every card has a centered step-name header and a divider above its
-structured metadata. Node type, status, attempts, and timing use compact symbol
-rows; start and terminal markers sit outside the card. Node types have distinct
+structured metadata. Border characters keep the graph background, the body
+surface begins inside the border, and the header interior uses a separate
+surface. Node type, status, attempts, and timing use compact symbol rows; start
+and terminal markers sit outside the card. Node types have distinct
 semantic colors, active cards use a heavy border, branches carry their case
 labels, the taken path is highlighted, and loops route through a gutter on the
 right back into their target from above. `←/→` scrubs

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -40,8 +40,11 @@ the browser.
   pair a type badge with status (`●` agent, `ƒ` compute, `⚙` action, `◆`
   checkpoint), then attempts (`↻`) with elapsed time (`◷`). Branch labels use
   `◇`; the final reserved row carries a short detail while unbounded content
-  stays in the inspector. Type badges and header dividers have distinct
-  semantic colors. Updates fill reserved rows without moving nodes or edges.
+  stays in the inspector. The outer border and header divider share the node's
+  state color on the graph background. The body background starts inside that
+  border, while the header interior uses a separate panel surface. Type badges
+  keep their semantic colors. Updates fill reserved rows without moving nodes
+  or edges.
   Narrow terminals pan over the fixed graph. Compact line nodes remain
   available with `z`. Start `▶` and terminal `■` markers sit outside the card.
   Branch labels remain on edges and loops use a right-hand gutter.
@@ -144,9 +147,10 @@ events retain step-based replay.
 
 Playback uses event timestamps at 1x, 2x, 5x, or 10x and breaks timestamp ties
 by event sequence. Step-only runs use the 700 ms base interval. Seeking
-backward detaches from live; selecting Live or pressing `G`, `L`, or End
-rejoins it and enables graph follow. A viewer already at latest follows newly
-appended events. A detached viewer stays at its chosen position. Rewinding
+backward detaches from live. Active runs show a Live button that rejoins the
+latest event and enables graph follow. Finished runs omit that button; End
+jumps to their latest event. A viewer already at latest follows newly appended
+events. A detached viewer stays at its chosen position. Rewinding
 never changes graph geometry because card size and layout depend only on the
 persisted definition snapshot.
 
@@ -154,14 +158,14 @@ Graph follow is on by default and is shown as `FOLLOW` in the graph title. It
 centers the running node, the waiting checkpoint, or the selected replay step,
 including nodes at the graph edges and graphs smaller than the viewport. `f`
 toggles follow. Keyboard or mouse panning turns it off; `f`, `0`, or returning
-to Live turns it back on.
+to the latest position turns it back on.
 
 The conversation folds `session/events.ndjson` through the temporal cursor.
 Unsealed messages stay visible as partial output. A settled `message_finished`
 with `entryId` switches that message to the matching verbatim record from
 `session/entries.ndjson`. Capture failures, sequence gaps, count mismatches,
-and reconciliation diagnostics remain visible. Live auto-follow stays at the
-bottom until the user moves to an older message and returns with End.
+and reconciliation diagnostics remain visible. Conversation auto-follow stays
+at the bottom until the user moves to an older message and returns with End.
 
 ## Remote behavior
 
@@ -176,8 +180,9 @@ symlink, and 4 MiB limits.
 
 ## Interaction
 
-- Replay: `[`/`]` previous/next, Space play/pause, Home or `g` to start, End,
-  `G`, or `L` to live, and `{`/`}` to change speed.
+- Replay: `[`/`]` previous/next, Space play/pause, Home or `g` to start, End
+  to jump to latest, and `{`/`}` to change speed. Active runs also show Live;
+  `G` and `L` are its keyboard shortcuts.
 - Focus: Tab cycles Runs → Graph → Inspector. Click the full `[symbol Tab]`
   buttons, or use `t` or `1`–`4`, to change inspector tabs.
 - Graph: arrows or `hjkl` pan, `0` resets, `f` toggles centered follow, and

--- a/src/render/graph-render.ts
+++ b/src/render/graph-render.ts
@@ -671,11 +671,11 @@ function drawNodes(
       if (nodeStyle === "box") {
         drawNodeBox(canvas, startX, rank.y, rendered, status);
       } else {
-        if (rendered.isStart) canvas.put(startX - 2, rank.y, "▶", nodeTypeStyle(rendered.nodeType));
+        if (rendered.isStart) canvas.put(startX - 2, rank.y, "▶", STATUS_STYLES[status]);
         canvas.put(startX, rank.y, STATUS_GLYPHS[status], STATUS_STYLES[status]);
         canvas.text(startX + 2, rank.y, rendered.text, status === "queued" ? "dim" : "plain");
         if (rendered.isEnd) {
-          canvas.put(startX + rendered.width + 1, rank.y, "■", nodeTypeStyle(rendered.nodeType));
+          canvas.put(startX + rendered.width + 1, rank.y, "■", STATUS_STYLES[status]);
         }
       }
     }
@@ -723,7 +723,7 @@ function drawNodeBox(
   canvas.text(startX, y, `${chars.tl}${horizontal}${chars.tr}`, borderStyle);
   rowBorder(y + 1);
   canvas.text(startX + 1, y + 1, centeredText(rendered.nodeId, innerWidth), contentStyle);
-  canvas.text(startX, y + 2, `${chars.ml}${horizontal}${chars.mr}`, typeStyle);
+  canvas.text(startX, y + 2, `${chars.ml}${horizontal}${chars.mr}`, borderStyle);
   pairedRow(
     y + 3,
     nodeTypeBadge(rendered.nodeType),
@@ -748,8 +748,8 @@ function drawNodeBox(
     );
   }
   canvas.text(startX, y + height - 1, `${chars.bl}${horizontal}${chars.br}`, borderStyle);
-  if (rendered.isStart) canvas.put(startX - 2, y + 1, "▶", typeStyle);
-  if (rendered.isEnd) canvas.put(startX + rendered.width + 1, y + 1, "■", typeStyle);
+  if (rendered.isStart) canvas.put(startX - 2, y + 1, "▶", borderStyle);
+  if (rendered.isEnd) canvas.put(startX + rendered.width + 1, y + 1, "■", borderStyle);
 }
 
 function edgeStyle(

--- a/tui/src/canvas.rs
+++ b/tui/src/canvas.rs
@@ -13,6 +13,15 @@ pub enum CanvasStyle {
     NodeText,
     NodeDim,
     NodeFocusText,
+    NodeHeader,
+    NodeBorderDim,
+    NodeBorderActive,
+    NodeBorderReplay,
+    NodeBorderOk,
+    NodeBorderFail,
+    NodeBorderTimedOut,
+    NodeBorderWarn,
+    NodeBorderCancelled,
     Active,
     Replay,
     Ok,
@@ -21,10 +30,15 @@ pub enum CanvasStyle {
     Warn,
     Cancelled,
     Branch,
+    BranchFocus,
     Agent,
+    AgentFocus,
     Compute,
+    ComputeFocus,
     Action,
+    ActionFocus,
     Checkpoint,
+    CheckpointFocus,
 }
 
 impl CanvasStyle {
@@ -36,15 +50,32 @@ impl CanvasStyle {
             CanvasStyle::Back => 2,
             CanvasStyle::Taken => 3,
             CanvasStyle::ActiveEdge => 4,
-            CanvasStyle::NodeText | CanvasStyle::NodeDim | CanvasStyle::NodeFocusText => 5,
-            CanvasStyle::Warn | CanvasStyle::Cancelled => 6,
+            CanvasStyle::NodeText
+            | CanvasStyle::NodeDim
+            | CanvasStyle::NodeFocusText
+            | CanvasStyle::NodeHeader => 5,
+            CanvasStyle::NodeBorderDim
+            | CanvasStyle::NodeBorderActive
+            | CanvasStyle::NodeBorderReplay
+            | CanvasStyle::NodeBorderOk
+            | CanvasStyle::NodeBorderFail
+            | CanvasStyle::NodeBorderTimedOut
+            | CanvasStyle::NodeBorderWarn
+            | CanvasStyle::NodeBorderCancelled
+            | CanvasStyle::Warn
+            | CanvasStyle::Cancelled => 6,
             CanvasStyle::Ok => 7,
             CanvasStyle::Fail | CanvasStyle::TimedOut => 8,
             CanvasStyle::Branch
+            | CanvasStyle::BranchFocus
             | CanvasStyle::Agent
+            | CanvasStyle::AgentFocus
             | CanvasStyle::Compute
+            | CanvasStyle::ComputeFocus
             | CanvasStyle::Action
-            | CanvasStyle::Checkpoint => 9,
+            | CanvasStyle::ActionFocus
+            | CanvasStyle::Checkpoint
+            | CanvasStyle::CheckpointFocus => 9,
             CanvasStyle::Replay => 10,
             CanvasStyle::Active => 11,
         }

--- a/tui/src/render.rs
+++ b/tui/src/render.rs
@@ -71,6 +71,19 @@ impl NodeStatus {
         }
     }
 
+    fn border_style(self) -> CanvasStyle {
+        match self {
+            NodeStatus::Completed => CanvasStyle::NodeBorderOk,
+            NodeStatus::Failed => CanvasStyle::NodeBorderFail,
+            NodeStatus::TimedOut => CanvasStyle::NodeBorderTimedOut,
+            NodeStatus::Active => CanvasStyle::NodeBorderActive,
+            NodeStatus::ReplayFocus => CanvasStyle::NodeBorderReplay,
+            NodeStatus::Waiting => CanvasStyle::NodeBorderWarn,
+            NodeStatus::Cancelled => CanvasStyle::NodeBorderCancelled,
+            NodeStatus::Queued => CanvasStyle::NodeBorderDim,
+        }
+    }
+
     fn is_focused(self) -> bool {
         matches!(self, NodeStatus::Active | NodeStatus::ReplayFocus)
     }
@@ -92,13 +105,18 @@ fn node_type_glyph(node_type: &str) -> char {
     }
 }
 
-fn node_type_style(node_type: &str) -> CanvasStyle {
-    match node_type {
-        "agent" => CanvasStyle::Agent,
-        "compute" => CanvasStyle::Compute,
-        "action" => CanvasStyle::Action,
-        "checkpoint" => CanvasStyle::Checkpoint,
-        _ => CanvasStyle::NodeDim,
+fn node_type_style(node_type: &str, focused: bool) -> CanvasStyle {
+    match (node_type, focused) {
+        ("agent", false) => CanvasStyle::Agent,
+        ("agent", true) => CanvasStyle::AgentFocus,
+        ("compute", false) => CanvasStyle::Compute,
+        ("compute", true) => CanvasStyle::ComputeFocus,
+        ("action", false) => CanvasStyle::Action,
+        ("action", true) => CanvasStyle::ActionFocus,
+        ("checkpoint", false) => CanvasStyle::Checkpoint,
+        ("checkpoint", true) => CanvasStyle::CheckpointFocus,
+        (_, false) => CanvasStyle::NodeDim,
+        (_, true) => CanvasStyle::NodeFocusText,
     }
 }
 
@@ -941,14 +959,9 @@ fn draw_nodes(
                         draw_node_box(canvas, start_x, rank.y, rendered, status);
                     } else {
                         if rendered.is_start {
-                            canvas.put(
-                                start_x - 2,
-                                rank.y,
-                                '▶',
-                                node_type_style(&rendered.node_type),
-                            );
+                            canvas.put(start_x - 2, rank.y, '▶', status.border_style());
                         }
-                        canvas.put(start_x, rank.y, status.glyph(), status.style());
+                        canvas.put(start_x, rank.y, status.glyph(), status.border_style());
                         canvas.text(
                             start_x + 2,
                             rank.y,
@@ -964,7 +977,7 @@ fn draw_nodes(
                                 start_x + rendered.width + 1,
                                 rank.y,
                                 '■',
-                                node_type_style(&rendered.node_type),
+                                status.border_style(),
                             );
                         }
                     }
@@ -987,8 +1000,14 @@ fn draw_node_box(
     } else {
         &BOX_LIGHT
     };
-    let border_style = status.style();
-    let type_style = node_type_style(&rendered.node_type);
+    let border_style = status.border_style();
+    let status_style = status.style();
+    let type_style = node_type_style(&rendered.node_type, status.is_focused());
+    let branch_style = if status.is_focused() {
+        CanvasStyle::BranchFocus
+    } else {
+        CanvasStyle::Branch
+    };
     let content_style = if status.is_focused() {
         CanvasStyle::NodeFocusText
     } else if status == NodeStatus::Queued {
@@ -999,7 +1018,20 @@ fn draw_node_box(
     let height = 7 + rendered.branch_lines.len() as i64;
     let inner_width = (rendered.width - 2) as usize;
     let right_x = start_x + rendered.width - 1;
-    canvas.fill_rect(start_x, y, rendered.width, height, content_style);
+    canvas.fill_rect(
+        start_x + 1,
+        y + 1,
+        rendered.width - 2,
+        1,
+        CanvasStyle::NodeHeader,
+    );
+    canvas.fill_rect(
+        start_x + 1,
+        y + 3,
+        rendered.width - 2,
+        height - 4,
+        content_style,
+    );
     let horizontal: String = std::iter::repeat_n(chars.h, inner_width).collect();
 
     canvas.text(
@@ -1014,13 +1046,13 @@ fn draw_node_box(
         start_x + 1,
         y + 1,
         &centered_text(&rendered.node_id, inner_width),
-        content_style,
+        CanvasStyle::NodeHeader,
     );
     canvas.text(
         start_x,
         y + 2,
         &format!("{}{horizontal}{}", chars.ml, chars.mr),
-        type_style,
+        border_style,
     );
 
     let type_badge = fit_text(&node_type_badge(&rendered.node_type), inner_width - 2);
@@ -1035,7 +1067,7 @@ fn draw_node_box(
         right_x - 1 - status_badge.chars().count() as i64,
         y + 3,
         &status_badge,
-        border_style,
+        status_style,
     );
 
     let attempts = format!("↻ {}", rendered.attempts);
@@ -1058,7 +1090,7 @@ fn draw_node_box(
             start_x + 2,
             row,
             &fit_text(branch, inner_width - 2),
-            CanvasStyle::Branch,
+            branch_style,
         );
     }
     let detail_row = y + 5 + rendered.branch_lines.len() as i64;
@@ -1079,10 +1111,10 @@ fn draw_node_box(
         border_style,
     );
     if rendered.is_start {
-        canvas.put(start_x - 2, y + 1, '▶', type_style);
+        canvas.put(start_x - 2, y + 1, '▶', border_style);
     }
     if rendered.is_end {
-        canvas.put(start_x + rendered.width + 1, y + 1, '■', type_style);
+        canvas.put(start_x + rendered.width + 1, y + 1, '■', border_style);
     }
 }
 

--- a/tui/src/ui/graph.rs
+++ b/tui/src/ui/graph.rs
@@ -18,6 +18,28 @@ pub fn style_for(style: CanvasStyle, palette: &Palette) -> Style {
         CanvasStyle::NodeText => Style::default().fg(palette.text).bg(palette.node_bg),
         CanvasStyle::NodeDim => Style::default().fg(palette.muted).bg(palette.node_bg),
         CanvasStyle::NodeFocusText => Style::default().fg(palette.text).bg(palette.node_focus_bg),
+        CanvasStyle::NodeHeader => Style::default()
+            .fg(palette.text)
+            .bg(palette.panel_bg)
+            .add_modifier(Modifier::BOLD),
+        CanvasStyle::NodeBorderDim => Style::default().fg(palette.muted).bg(palette.canvas_bg),
+        CanvasStyle::NodeBorderActive => Style::default()
+            .fg(palette.running)
+            .bg(palette.canvas_bg)
+            .add_modifier(Modifier::BOLD),
+        CanvasStyle::NodeBorderReplay => Style::default()
+            .fg(palette.replay_focus)
+            .bg(palette.canvas_bg)
+            .add_modifier(Modifier::BOLD),
+        CanvasStyle::NodeBorderOk => Style::default().fg(palette.success).bg(palette.canvas_bg),
+        CanvasStyle::NodeBorderFail => Style::default().fg(palette.error).bg(palette.canvas_bg),
+        CanvasStyle::NodeBorderTimedOut => {
+            Style::default().fg(palette.timed_out).bg(palette.canvas_bg)
+        }
+        CanvasStyle::NodeBorderWarn => Style::default().fg(palette.warning).bg(palette.canvas_bg),
+        CanvasStyle::NodeBorderCancelled => {
+            Style::default().fg(palette.cancelled).bg(palette.canvas_bg)
+        }
         CanvasStyle::Active => Style::default()
             .fg(palette.running)
             .bg(palette.node_focus_bg)
@@ -32,21 +54,40 @@ pub fn style_for(style: CanvasStyle, palette: &Palette) -> Style {
         CanvasStyle::Warn => Style::default().fg(palette.warning).bg(palette.node_bg),
         CanvasStyle::Cancelled => Style::default().fg(palette.cancelled).bg(palette.node_bg),
         CanvasStyle::Branch => Style::default().fg(palette.branch).bg(palette.node_bg),
+        CanvasStyle::BranchFocus => Style::default()
+            .fg(palette.branch)
+            .bg(palette.node_focus_bg),
         CanvasStyle::Agent => Style::default()
             .fg(palette.assistant)
             .bg(palette.node_bg)
+            .add_modifier(Modifier::BOLD),
+        CanvasStyle::AgentFocus => Style::default()
+            .fg(palette.assistant)
+            .bg(palette.node_focus_bg)
             .add_modifier(Modifier::BOLD),
         CanvasStyle::Compute => Style::default()
             .fg(palette.accent)
             .bg(palette.node_bg)
             .add_modifier(Modifier::BOLD),
+        CanvasStyle::ComputeFocus => Style::default()
+            .fg(palette.accent)
+            .bg(palette.node_focus_bg)
+            .add_modifier(Modifier::BOLD),
         CanvasStyle::Action => Style::default()
             .fg(palette.tool)
             .bg(palette.node_bg)
             .add_modifier(Modifier::BOLD),
+        CanvasStyle::ActionFocus => Style::default()
+            .fg(palette.tool)
+            .bg(palette.node_focus_bg)
+            .add_modifier(Modifier::BOLD),
         CanvasStyle::Checkpoint => Style::default()
             .fg(palette.replay_focus)
             .bg(palette.node_bg)
+            .add_modifier(Modifier::BOLD),
+        CanvasStyle::CheckpointFocus => Style::default()
+            .fg(palette.replay_focus)
+            .bg(palette.node_focus_bg)
             .add_modifier(Modifier::BOLD),
     }
 }
@@ -119,6 +160,20 @@ mod tests {
             style_for(CanvasStyle::NodeFocusText, &palette).bg,
             Some(palette.node_focus_bg)
         );
+        assert_eq!(
+            style_for(CanvasStyle::NodeHeader, &palette).bg,
+            Some(palette.panel_bg)
+        );
+        assert_eq!(
+            style_for(CanvasStyle::NodeBorderActive, &palette).bg,
+            Some(palette.canvas_bg)
+        );
+        assert_eq!(
+            style_for(CanvasStyle::AgentFocus, &palette).bg,
+            Some(palette.node_focus_bg)
+        );
+        assert_ne!(palette.panel_bg, palette.node_bg);
+        assert_ne!(palette.panel_bg, palette.node_focus_bg);
     }
 
     #[test]

--- a/tui/src/ui/timeline.rs
+++ b/tui/src/ui/timeline.rs
@@ -87,7 +87,7 @@ pub fn render(
     render_track(frame, top[1], &view, palette);
     render_position(frame, top[2], &view, palette);
 
-    let specs = [
+    let mut specs = vec![
         (
             TimelineAction::Start,
             controls::button_label("⌂", "Home"),
@@ -111,11 +111,15 @@ pub fn render(
             controls::button_label("→", "Next"),
             false,
         ),
-        (
+    ];
+    if view.status == RunStatus::Running {
+        specs.push((
             TimelineAction::Live,
             controls::button_label("●", "Live"),
             view.at_latest,
-        ),
+        ));
+    }
+    specs.extend([
         (
             TimelineAction::Slower,
             controls::button_label("−", "Slow"),
@@ -126,7 +130,7 @@ pub fn render(
             controls::button_label("+", "Fast"),
             false,
         ),
-    ];
+    ]);
     let button_count = specs.len();
     let mut constraints: Vec<Constraint> = specs
         .iter()
@@ -409,5 +413,47 @@ mod tests {
         for pair in geometry.hits.windows(2) {
             assert_eq!(pair[1].rect.x, pair[0].rect.right() + 1);
         }
+    }
+
+    #[test]
+    fn finished_runs_do_not_render_a_live_action() {
+        let backend = TestBackend::new(120, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut geometry = TimelineGeometry::default();
+        terminal
+            .draw(|frame| {
+                geometry = render(
+                    frame,
+                    frame.area(),
+                    Some(TimelineView {
+                        status: RunStatus::Completed,
+                        paused: false,
+                        elapsed: "1s",
+                        steps: 8,
+                        position: 3,
+                        temporal: true,
+                        at_latest: false,
+                        live: false,
+                        playing: false,
+                        speed: 1,
+                        diagnostic: None,
+                    }),
+                    &Palette::catppuccin(),
+                );
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(!rendered.contains("[● Live]"));
+        assert_eq!(geometry.hits.len(), 6);
+        assert!(geometry
+            .hits
+            .iter()
+            .all(|hit| hit.action != TimelineAction::Live));
     }
 }


### PR DESCRIPTION
## Summary

Selected workflow cards mixed focus and node-type colors across their borders and surfaces.
This change gives each card a consistent selected state, keeps border backgrounds aligned with the graph canvas, and gives the header its own interior surface.
Finished runs also stop showing a Live action that cannot follow new events.

## What Changed

Card colors now describe one clear state without bleeding into the surrounding canvas.
The TypeScript and Rust renderers still produce identical graph geometry and text.

- Added separate styles for card borders, headers, body content, focused type labels, and focused branch labels.
- Applied the node state color to the full outer border and header divider.
- Kept border and endpoint-marker backgrounds on the graph canvas.
- Filled only card interiors, with separate header and body surfaces.
- Hid the Live action and its mouse hitbox for terminal runs.
- Updated the viewer documentation and README.

## Testing

The full repository checks pass, including the real Pi end-to-end test and TypeScript/Rust renderer parity.
The installed `piw` binary was also checked interactively against a completed temporal run, both at latest and in replay history.

- `npm run check`
- `npm run test:e2e`
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- Markdown link validation

## Risks

The change is limited to viewer presentation and timeline controls.
It does not change persisted data, workflow execution, replay state, card geometry, or graph layout.
Custom themes continue to use the existing canvas, panel, node, and focus palette fields.
