### PR TITLE
chore(tui): prepare crates.io package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ Or try the npm package without installing it:
 pi -e npm:@osolmaz/pi-workflows
 ```
 
-The `pi-workflows` viewer binary is part of the same package. To get it on
-your PATH, clone the repo and run `npm install && npm run build && npm link`,
+Install the interactive terminal viewer separately from crates.io. The crate
+is named `pi-workflows`; its command is `piw`:
+
+```bash
+cargo install pi-workflows
+piw
+```
+
+The npm package also includes the simpler `pi-workflows` snapshot viewer. To
+link that command from a clone, run `npm install && npm run build && npm link`,
 or run it in place with `npx tsx src/viewer/cli.ts`.
 
 ## Quick start

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -5,6 +5,15 @@ the same graph as the bundled TypeScript viewer, pinned by the golden fixtures
 under `fixtures/layout/`, and adds live following, replay, detailed inspection,
 a recorded Pi conversation, themes, and remote viewing.
 
+## Install
+
+The crates.io package uses the project name and installs the shorter `piw`
+command:
+
+```bash
+cargo install pi-workflows
+```
+
 ## Modes
 
 - `piw` browses the local runs directory (`PI_WORKFLOWS_RUNS_DIR` or

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1251,13 +1251,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "piw"
+name = "pi-workflows"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -1278,6 +1272,12 @@ dependencies = [
  "toml_edit",
  "unicode-width",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,9 +1,19 @@
 [package]
-name = "piw"
+name = "pi-workflows"
 version = "0.1.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"
+readme = "README.md"
+repository = "https://github.com/osolmaz/pi-workflows"
+homepage = "https://github.com/osolmaz/pi-workflows"
+documentation = "https://docs.rs/pi-workflows"
+keywords = ["workflow", "terminal", "replay", "pi"]
+categories = ["command-line-utilities", "development-tools"]
+
+[lib]
+name = "piw"
+path = "src/lib.rs"
 
 [[bin]]
 name = "piw"

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,41 @@
+# piw
+
+piw is the terminal viewer for [pi-workflows](https://github.com/osolmaz/pi-workflows).
+It browses saved workflow runs, follows active runs, and replays recorded workflow and Pi conversation events without rerunning models or tools.
+
+## Install
+
+Install the `pi-workflows` crate to get the `piw` command:
+
+```bash
+cargo install pi-workflows
+```
+
+## Use
+
+Open the default run directory:
+
+```bash
+piw
+```
+
+Open another run directory or one specific run bundle:
+
+```bash
+piw /path/to/runs
+piw /path/to/one-run
+```
+
+Serve local runs over the live replay protocol:
+
+```bash
+piw serve
+```
+
+Connect another viewer to that server:
+
+```bash
+piw connect ws://127.0.0.1:9377/ws
+```
+
+See the [piw viewer guide](https://github.com/osolmaz/pi-workflows/blob/main/docs/tui-viewer.md) for controls, themes, replay behavior, and remote viewing.


### PR DESCRIPTION
## Summary

The Rust viewer was packaged as `piw`, which did not match the project name used on GitHub and npm.
This change prepares it for an independent crates.io publication as `pi-workflows` while keeping the installed command named `piw`.
It adds the registry metadata and user documentation needed for `cargo install pi-workflows`.

## What Changed

The package name now matches the project without changing the executable or internal Rust library name.
Existing source imports and the `piw` command continue to work.

- Renamed the Cargo package from `piw` to `pi-workflows`.
- Kept the library and binary targets explicitly named `piw`.
- Added repository, homepage, documentation, keyword, category, and README metadata for crates.io.
- Added a crate-specific README with installation and basic usage.
- Updated the main README and viewer guide to document `cargo install pi-workflows`.

## Testing

The exact crate archive passes Cargo's publication verification and installs a working `piw` executable.
The full TypeScript, Rust, parity, and real-Pi end-to-end checks also pass.

- `cargo publish --manifest-path tui/Cargo.toml --dry-run --allow-dirty`
- `cargo install --path tui --root /tmp/pi-workflows-cargo-install`
- `/tmp/pi-workflows-cargo-install/bin/piw --version`
- `npm run check`
- `npm run test:e2e`
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`

## Risks

This changes the Cargo package name used for installation and publication.
The `piw` binary, Rust library target, runtime behavior, and persisted formats are unchanged.
Nothing has been published to crates.io by this change.
