### PR TITLE
ci(release): publish crate from GitHub releases

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,119 @@
+name: Publish crates.io package
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: publish-crate-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
+    runs-on: ubuntu-24.04
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Validate release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          metadata="$(cargo metadata --manifest-path tui/Cargo.toml --no-deps --format-version 1)"
+          package_name="$(jq -r '.packages[0].name' <<<"$metadata")"
+          version="$(jq -r '.packages[0].version' <<<"$metadata")"
+          expected_tag="v${version}"
+
+          if [[ "$package_name" != "pi-workflows" ]]; then
+            echo "Cargo package is $package_name, expected pi-workflows." >&2
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            echo "The release tag $RELEASE_TAG does not match Cargo version $version (expected $expected_tag)." >&2
+            exit 1
+          fi
+
+          git fetch origin "$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor HEAD "origin/$DEFAULT_BRANCH"; then
+            echo "The release commit is not on origin/$DEFAULT_BRANCH." >&2
+            exit 1
+          fi
+
+          registry_status="$(
+            curl \
+              --silent \
+              --show-error \
+              --retry 3 \
+              --retry-all-errors \
+              --output /tmp/crates-io-version.json \
+              --write-out '%{http_code}' \
+              --user-agent 'pi-workflows-release-workflow (https://github.com/osolmaz/pi-workflows)' \
+              "https://crates.io/api/v1/crates/${package_name}/${version}"
+          )"
+          case "$registry_status" in
+            404) ;;
+            200)
+              echo "${package_name} ${version} is already published." >&2
+              exit 1
+              ;;
+            *)
+              echo "crates.io version lookup returned HTTP ${registry_status}." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Check package
+        run: |
+          cargo fmt --manifest-path tui/Cargo.toml -- --check
+          cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings
+          cargo test --manifest-path tui/Cargo.toml
+          cargo publish --manifest-path tui/Cargo.toml --dry-run
+
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        run: cargo publish --manifest-path tui/Cargo.toml
+
+      - name: Verify registry
+        run: |
+          set -euo pipefail
+          version="$(cargo metadata --manifest-path tui/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          for attempt in {1..12}; do
+            status="$(
+              curl \
+                --silent \
+                --show-error \
+                --output /tmp/crates-io-version.json \
+                --write-out '%{http_code}' \
+                --user-agent 'pi-workflows-release-workflow (https://github.com/osolmaz/pi-workflows)' \
+                "https://crates.io/api/v1/crates/pi-workflows/${version}"
+            )"
+            if [[ "$status" == "200" ]]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "crates.io did not report pi-workflows ${version} after publication." >&2
+          exit 1

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,29 +118,30 @@ Nothing outside the temp directories is touched, and no real model is called.
 
 ## Publishing
 
-The npm package is `@osolmaz/pi-workflows`. The first version must be published
-locally because npm cannot configure a trusted publisher until the package
-exists:
+The npm package is `@osolmaz/pi-workflows`. The crates.io package is
+`pi-workflows`, and it installs the `piw` executable. Keep both package versions
+in sync so one GitHub Release can publish both artifacts.
 
-```bash
-npm publish --access public
-```
+Trusted publishing uses separate GitHub environments and workflows. Neither
+workflow stores a long-lived registry token:
 
-After that first publish, configure npm trusted publishing for the
-`osolmaz/pi-workflows` repository, `.github/workflows/publish.yml`, and the
-`npm` GitHub environment. The workflow does not use a stored npm token.
+- npm: repository `osolmaz/pi-workflows`, workflow
+  `.github/workflows/publish.yml`, environment `npm`;
+- crates.io: repository owner `osolmaz`, repository `pi-workflows`, workflow
+  `publish-crate.yml`, environment `crates-io`.
 
 For later versions:
 
-1. Update `version` in `package.json` and `package-lock.json`, then merge that
-   change into the default branch.
+1. Update `version` in `package.json`, `package-lock.json`, `tui/Cargo.toml`,
+   and `tui/Cargo.lock`, then merge that change into the default branch.
 2. Publish a GitHub Release whose tag is `v<version>`, such as `v0.2.0`.
-3. Wait for the **Publish npm package** workflow to finish and verify the new
-   version on npm.
+3. Wait for the **Publish npm package** and **Publish crates.io package**
+   workflows to finish.
+4. Verify the version on both npm and crates.io.
 
-The workflow rejects mismatched tags, commits outside the default branch, and
-versions already present on npm. It runs the full checks and end-to-end tests
-before `npm publish --provenance`.
+Both workflows reject mismatched tags, commits outside the default branch, and
+versions already present in their registry. They run their package checks
+before publishing.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Future GitHub Releases currently publish the npm package but not the Rust viewer.
This change adds a separate trusted-publishing workflow for the crates.io package `pi-workflows`, which installs the `piw` command.
It validates the release, tests the packaged crate, publishes with a short-lived crates.io token, and verifies the registry afterward.

## What Changed

One GitHub Release can now publish the synchronized npm and Cargo versions.
The Cargo workflow has its own GitHub environment and does not store a long-lived crates.io token.

- Added the **Publish crates.io package** workflow at `.github/workflows/publish-crate.yml`.
- Triggered it only for published, non-draft, non-prerelease GitHub Releases.
- Required the release tag to match `tui/Cargo.toml` and the release commit to belong to the default branch.
- Rejected versions already present on crates.io.
- Ran formatting, clippy, tests, and `cargo publish --dry-run` before authentication.
- Used `rust-lang/crates-io-auth-action@v1` for crates.io trusted publishing.
- Verified the published version through the crates.io API.
- Documented synchronized npm/Cargo versioning and the exact trusted-publisher identity.

## Testing

The workflow syntax and shell expressions pass actionlint, and the existing crate still passes Cargo's publication verification.
The full TypeScript, Rust, parity, and real-Pi end-to-end checks also pass.

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yml`
- `cargo publish --manifest-path tui/Cargo.toml --dry-run --allow-dirty`
- `npm run check`
- `npm run test:e2e`
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`

## Risks

The workflow cannot authenticate until the crate owner configures the matching crates.io trusted publisher.
The required identity is owner `osolmaz`, repository `pi-workflows`, workflow `publish-crate.yml`, and environment `crates-io`.
No package version or GitHub Release is created by this change.
