### PR TITLE
feat: add agent-managed monitor workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ limit. Its input supports `task`, `everyMinutes`, `reportWhen`, `stopWhen`, and
 by using the same file name.
 
 A monitor occupies the session's one active workflow slot. If its Pi runner
-stops during the shell sleep, the run parks and repeats that sleep node when a
+stops during the shell wait, the run parks and repeats that wait node when a
 runner resumes it.
 
 Because the workflow runs in your current conversation, you can have a long

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ you have taken the conversation back; `/workflow resume` re-delivers the
 pending step prompt. `/workflow cancel` stops the active run; if the last run
 already ended (for example parked at a checkpoint), it clears the leftover
 widget instead. Trailing text becomes `{ task: "..." }`; pass arbitrary input
-with `--input-json {"key": "value"}`. The names `cancel`, `list`, `pause`,
-and `resume` are reserved and rejected as workflow names.
+with `--input-json {"key": "value"}`. The names `answer`, `cancel`, `list`, `pause`, `resume`, and `status` are
+reserved and rejected as workflow names.
 
 While a run is on screen, the footer status bar shows a compact
 `wf <name> [status] <node>` indicator alongside the widget.
@@ -89,6 +89,26 @@ While a run is on screen, the footer status bar shows a compact
 structured run ends to request one normal, human-readable assistant response.
 Workflows without it remain silent after their final structured output, which
 keeps shell-only and machine-consumed workflows model-free.
+
+## Agent-managed workflows
+
+The model can use the same `workflow` tool to list, start, inspect, pause,
+resume, cancel, and answer workflows. Step contracts use the tool's `submit`
+action. Slash commands and model actions share one lifecycle implementation.
+
+Pi Workflows includes a `monitor` workflow for plain-language requests such as:
+
+> Monitor PR 123 every 30 minutes. Report failed checks. Stop when it is merged or closed.
+
+The monitor checks immediately, reports only the states requested by the user,
+waits with a normal shell action, and loops until its stop condition or check
+limit. Its input supports `task`, `everyMinutes`, `reportWhen`, `stopWhen`, and
+`maxChecks`. Project and global workflows can replace the built-in `monitor`
+by using the same file name.
+
+A monitor occupies the session's one active workflow slot. If its Pi runner
+stops during the shell sleep, the run parks and repeats that sleep node when a
+runner resumes it.
 
 Because the workflow runs in your current conversation, you can have a long
 discussion first and then trigger a workflow that builds on it. The

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@ authoring workflows, see [workflows.md](workflows.md).
 
 ```
 src/workflows/   finite graph engine: definitions, execution, bundles, loader
+src/builtins/    default workflows shipped at lowest discovery precedence
 src/controllers/ durable resources, queue, reconciliation, effects, child runs
 src/extension/   pi integration: commands, workflow tool, controller host, widget
 src/viewer/      standalone read-only views over runs and controller resources

--- a/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
+++ b/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
@@ -14,7 +14,7 @@ A monitor is one Pi Workflows graph. It checks the target, reports a meaningful 
 
 ## Shipped design
 
-The implementation follows this plan. The built-in monitor defaults to 1,000 checks, caps the interval at 24 hours, and uses a 5,010-step engine limit as a second guard. The normal Pi extension exposes all workflow tool actions. The headless RPC bridge exposes only `submit`. A real-Pi end-to-end test proves that a normal model turn can start the built-in monitor and complete its first check. The automated test inspects the exact 30-minute `sleep 1800` command and both timeout margins instead of making the test suite wait for 30 minutes.
+The implementation follows this plan. The built-in monitor defaults to 1,000 checks, caps the interval at 24 hours, and uses a 5,010-step engine limit as a second guard. The normal Pi extension exposes all workflow tool actions. The headless RPC bridge exposes only `submit`. A real-Pi end-to-end test proves that a normal model turn can start the built-in monitor and complete its first check. The automated test inspects the exact 30-minute Node timer command and both timeout margins instead of making the test suite wait for 30 minutes. The Node timer keeps the shell action portable across Pi's supported platforms.
 
 ## User experience
 
@@ -116,7 +116,7 @@ prepare -> guard -> check
 
 The report nodes write a normal assistant message and then submit an acknowledgement. Keeping reporting after accepted check output prevents the agent from showing a report before the structured result passes validation. The final presentation reports why the monitor stopped without repeating a report that the user already saw.
 
-The sleep node uses the existing Pi Workflows shell action and the system `sleep` command. Set the node timeout above the largest supported interval because the engine default is 15 minutes. Set the shell execution timeout above the requested sleep by a small fixed margin. Cancellation aborts the sleep immediately.
+The sleep node uses the existing Pi Workflows shell action to launch the current Node executable with a timer. Set the node timeout above the largest supported interval because the engine default is 15 minutes. Set the shell execution timeout above the requested wait by a small fixed margin. Cancellation aborts the timer process immediately.
 
 If the Pi TUI or standalone workflow host stops during sleep, Pi Workflows parks the run and kills the shell child. Resuming the run starts that sleep node again from the beginning. This is existing workflow behavior and is acceptable for this feature. No special timer persistence is added.
 

--- a/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
+++ b/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
@@ -1,0 +1,184 @@
+---
+title: Let agents run and manage monitor workflows
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-10
+updated: 2026-08-10
+status: implemented
+---
+
+# Agent-managed monitor workflows plan
+
+The user should be able to tell an agent, "Monitor this every 30 minutes," and have the agent start the right workflow. The user must not write controller records or JSON. The existing `workflow` model tool should manage workflows instead of serving only as a step-submission tool.
+
+A monitor is one Pi Workflows graph. It checks the target, reports a meaningful change, sleeps for the requested interval with the existing shell node, and loops. This plan does not use controllers, Unified Exec, a new wait node, or a second scheduler.
+
+## Shipped design
+
+The implementation follows this plan. The built-in monitor defaults to 1,000 checks, caps the interval at 24 hours, and uses a 5,010-step engine limit as a second guard. The normal Pi extension exposes all workflow tool actions. The headless RPC bridge exposes only `submit`. A real-Pi end-to-end test proves that a normal model turn can start the built-in monitor and complete its first check. The automated test inspects the exact 30-minute `sleep 1800` command and both timeout margins instead of making the test suite wait for 30 minutes.
+
+## User experience
+
+A normal request looks like this:
+
+> Monitor PR 123 every 30 minutes. Tell me when checks fail. Stop when it is merged or closed.
+
+The agent recognizes repeated monitoring from the `workflow` tool description and starts the built-in `monitor` workflow. The tool call contains the structured input, but the user does not write it.
+
+The monitor checks immediately, then waits between later checks. It writes a normal assistant message only when the requested report condition is met. It stops when the requested stop condition is met, when it reaches its safety limit, or when the user or agent cancels it.
+
+Existing controls remain available:
+
+```text
+/workflow pause
+/workflow resume
+/workflow cancel
+```
+
+The same operations become available to the model through the `workflow` tool. One active workflow per Pi session remains the rule. A long monitor therefore occupies that session's workflow slot.
+
+## Workflow tool
+
+Replace the current submit-only schema with one discriminated tool schema. Use Pi's documented `registerTool` API and `StringEnum` helper.
+
+The tool supports these actions:
+
+- `list`: list discovered workflows and their source.
+- `start`: start a workflow by name or path with structured input.
+- `status`: return a bounded summary of the active or named run.
+- `pause`: pause the active run at its next node boundary.
+- `resume`: resume the active paused run.
+- `cancel`: cancel the active run.
+- `answer`: answer a waiting checkpoint, with an optional run ID.
+- `submit`: submit the result required by the current workflow step contract.
+
+The `submit` form becomes:
+
+```json
+{
+  "action": "submit",
+  "step": "check",
+  "attempt": "attempt-id",
+  "output": {}
+}
+```
+
+Update workflow step prompts and reminders to include `action: "submit"`. Do not retain the old submit shape as a compatibility alias.
+
+Slash commands and tool actions must call the same internal lifecycle functions. This avoids separate behavior for humans and models. Tool results must be structured and bounded. Errors must state whether the operation failed because no run exists, a run is already active, a checkpoint is not waiting, or the requested workflow cannot be found.
+
+A tool call happens during an agent turn. The `start` action must validate and queue the launch, then deliver the first workflow prompt after the initiating turn settles. This prevents the new run from treating the initiating turn as a failed workflow step. It also prevents a workflow prompt from being injected in the middle of the tool call.
+
+The headless RPC bridge keeps a submit-only version of the tool. Headless workflow children must not start or control other workflows. Its submit schema and parser still change to require `action: "submit"`.
+
+## Agent guidance
+
+The tool description must tell the model when to use the built-in workflow:
+
+- Use `start` with workflow `monitor` when the user asks to watch, monitor, poll, or check something repeatedly.
+- Start directly when the task and interval are clear.
+- Ask one short question when the target or interval is missing.
+- Use observation-only behavior unless the user explicitly authorizes a mutation.
+- Do not create repeated work without a user request or an existing workflow instruction that authorizes it.
+
+The `list` result identifies `monitor` as a built-in workflow and gives a short description. This keeps discovery inside the tool instead of adding a skill or a system-prompt injection.
+
+## Built-in monitor workflow
+
+Ship `monitor` as a built-in workflow in the Pi Workflows package. Built-ins have the lowest discovery precedence:
+
+1. Project workflows under `.pi/workflows/`
+2. Global workflows under `~/.pi/agent/workflows/`
+3. Workflows bundled with Pi Workflows
+
+A project or global `monitor.workflow.ts` can therefore replace the default. The built-in remains a real workflow file so run bundles can record its path and source hash with the existing rules.
+
+The workflow input contains:
+
+- `task`: what to inspect.
+- `everyMinutes`: the interval between checks.
+- `reportWhen`: changes or states that deserve a user message.
+- `stopWhen`: the condition that ends monitoring.
+- `maxChecks`: a hard safety limit.
+
+The model supplies these fields from the user's request. The workflow validates the input and applies documented bounds. The first release supports intervals from 1 minute through 24 hours. It defaults `maxChecks` to a documented finite value when the request gives no end limit.
+
+The graph is:
+
+```text
+prepare -> guard -> check
+                    | continue quietly -> sleep -> guard
+                    | continue and report -> report -> sleep -> guard
+                    | stop quietly -> finish
+                    | stop and report -> report-final -> finish
+```
+
+`prepare` validates and normalizes the input. `guard` enforces `maxChecks`. `check` is an agent node that performs one observation and returns a validated route, a bounded observation, and an optional report. The next `check` can read the previous accepted `check` output, which Pi Workflows already keeps for looped nodes.
+
+The report nodes write a normal assistant message and then submit an acknowledgement. Keeping reporting after accepted check output prevents the agent from showing a report before the structured result passes validation. The final presentation reports why the monitor stopped without repeating a report that the user already saw.
+
+The sleep node uses the existing Pi Workflows shell action and the system `sleep` command. Set the node timeout above the largest supported interval because the engine default is 15 minutes. Set the shell execution timeout above the requested sleep by a small fixed margin. Cancellation aborts the sleep immediately.
+
+If the Pi TUI or standalone workflow host stops during sleep, Pi Workflows parks the run and kills the shell child. Resuming the run starts that sleep node again from the beginning. This is existing workflow behavior and is acceptable for this feature. No special timer persistence is added.
+
+The workflow uses a high but finite `maxSteps` value as a second safety guard. Check and report values have explicit size limits so a long run cannot grow its bundle without bound.
+
+## Repository changes
+
+Make the feature in `osolmaz/pi-workflows`:
+
+- Refactor workflow lifecycle operations out of the slash-command handler.
+- Expand the normal Pi `workflow` tool and update its tests.
+- Update the RPC bridge submit contract.
+- Add built-in workflow discovery with project and global override precedence.
+- Add the built-in monitor workflow and focused tests.
+- Update `README.md` and `docs/workflows.md`.
+
+After the upstream change is complete, update the pinned Pi Workflows commit in OnurPi's thin `packages/workflows` wrapper. Do not add a new OnurPi extension or copy a monitor file into live global state.
+
+## State and API impact
+
+- **Session state:** Normal workflow prompts, model replies, tool calls, and monitor reports are appended through Pi's normal session behavior.
+- **Other persistent data:** No new data model. The feature uses existing run bundles and the existing workflow run queue.
+- **Pi internals:** None.
+- **Pi public API:** `registerTool`, `registerCommand`, `sendUserMessage`, and documented agent and session lifecycle events.
+- **Pi Workflows API:** The workflow definition and run-state models do not change. The model-facing `workflow` tool contract changes, and discovery gains a lowest-priority built-in source.
+
+## Non-goals
+
+This work does not add cron expressions, calendar schedules, a background service, controller resources, OS notifications, concurrent workflows in one session, resumable shell processes, or guaranteed wall-clock wake times across runner shutdowns. It does not let headless child agents recursively start workflows.
+
+## Acceptance criteria
+
+- A user can ask for repeated monitoring in plain language, and the agent starts `monitor` through the existing `workflow` tool.
+- The user does not type JSON or a slash command to start the monitor.
+- The monitor checks immediately, sleeps for the requested interval, and checks again.
+- An unchanged observation produces no normal assistant report.
+- A matching report condition produces one concise assistant report.
+- A matching stop condition reports as requested and ends the run.
+- The safety limit ends a monitor that never reaches its stop condition.
+- The model can list, start, inspect, pause, resume, cancel, answer, and submit through one tool.
+- Slash commands and tool actions use the same lifecycle code.
+- Starting from a model tool call does not cause an early nudge or record the initiating turn as the first workflow attempt.
+- A 30-minute sleep is not stopped by the default 15-minute node timeout.
+- Cancelling during sleep stops the shell child and ends the workflow.
+- Project and global workflows override the built-in `monitor` name.
+- Existing workflow, controller, host, viewer, and run-bundle tests continue to pass.
+- OnurPi loads the updated wrapper and Pi starts successfully.
+
+## Verification
+
+Add unit and integration coverage for tool action validation, lifecycle dispatch, deferred model-start launches, built-in discovery precedence, monitor routing, quiet checks, reports, stop conditions, safety limits, cancellation during sleep, and the headless submit bridge.
+
+Run:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+```
+
+Test the extension from the Pi Workflows checkout with `pi -e src/extension/index.ts`. Use a short test interval in a controlled fixture, then perform one manual 30-minute monitor run to confirm that the configured node timeout does not stop it. Test plain-language startup with the normal model, then test list, status, pause, resume, cancel, and checkpoint answer actions.
+
+After updating OnurPi, run its full checks and start Pi with the installed OnurPi package. Confirm that the model sees one `workflow` tool, discovers `monitor`, and can start it from a plain-language request.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -289,11 +289,12 @@ Intervals must be whole minutes from 1 through 1,440. `maxChecks` defaults to
 1,000 and cannot exceed 1,000. The workflow also has a finite step limit and
 bounded observation and report sizes.
 
-The interval uses the existing shell action with `sleep`. The node and command
-timeouts are higher than the maximum interval. Cancelling the workflow aborts
-the sleep immediately. If the owning Pi process or standalone host stops during
-the sleep, normal parking rules abort the shell node and resume later by running
-that sleep again from the beginning.
+The interval uses the existing shell action to launch the current Node
+executable with a timer. This works on every platform supported by Pi. The node
+and command timeouts are higher than the maximum interval. Cancelling the
+workflow aborts the timer process immediately. If the owning Pi process or
+standalone host stops during the wait, normal parking rules abort the shell node
+and resume later by running that wait again from the beginning.
 
 A monitor uses the session's single active workflow slot. It does not provide
 cron syntax, calendar scheduling, OS notifications, or a background service.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -9,10 +9,14 @@ model sees, and how runs behave at runtime. For the on-disk run format, see
 
 A workflow is a TypeScript module whose default export is `defineWorkflow(...)`.
 Files are discovered by suffix (`.workflow.ts`, `.workflow.js`, `.workflow.mts`,
-`.workflow.mjs`) from two directories, in precedence order:
+`.workflow.mjs`) from these sources, in precedence order:
 
 1. `.pi/workflows/` in the project (highest precedence on name collisions)
 2. `~/.pi/agent/workflows/` globally
+3. Workflows built into Pi Workflows
+
+Pi Workflows includes a built-in `monitor` workflow. A project or global file
+named `monitor.workflow.ts` replaces it.
 
 The workflow's command name is the file stem, so `.pi/workflows/triage.workflow.ts`
 runs as `/workflow triage`. A direct path also works: `/workflow ./somewhere/x.workflow.ts`.
@@ -44,7 +48,7 @@ Top-level fields:
 
 | Field                | Type                   | Notes                                                                                                                                                                                                              |
 | -------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`               | `string`               | Required. Used in run ids and the step contract. `cancel`, `list`, `pause`, and `resume` are reserved for `/workflow` subcommands.                                                                                 |
+| `name`               | `string`               | Required. Used in run ids and the step contract. `answer`, `cancel`, `list`, `pause`, `resume`, and `status` are reserved for `/workflow` subcommands.                                                             |
 | `title`              | `string` or function   | Optional run title, resolved once at start from `{ input, workflowName }`. Async resolution is bounded (30s) and cancellable.                                                                                      |
 | `presentationPrompt` | `string` or function   | Optional instructions for a normal assistant response after the run. A function receives `{ state, finalOutput, signal }` and may return a prompt or `undefined`. See [Result presentation](#result-presentation). |
 | `startAt`            | `string`               | Required. Id of the first node.                                                                                                                                                                                    |
@@ -244,6 +248,56 @@ A missing case for the resolved value fails the run with a routing error. A
 node with no outgoing edge (or no matching failure route) ends the run:
 `completed` on success, `failed`/`timed_out`/`cancelled` otherwise.
 
+## Model workflow control
+
+The model sees one `workflow` tool. Its `action` field supports:
+
+- `list` for discovered workflow names and sources.
+- `start` with a workflow name or path and structured input.
+- `status` for the active run or a supplied run ID.
+- `pause`, `resume`, and `cancel` for the active run.
+- `answer` with checkpoint input and an optional run ID.
+- `submit` for the current workflow step contract.
+
+A model-started run is queued until the model's current turn settles. The first
+workflow prompt then starts a new turn. This keeps the requesting turn outside
+the workflow's first attempt and prevents an early missing-submission reminder.
+The normal extension offers all actions. The headless RPC bridge offers only
+`submit`, so a workflow child cannot recursively control other runs.
+
+### Built-in monitor
+
+The built-in `monitor` workflow turns a plain request for repeated checks into
+one looping workflow run. Its input is:
+
+```json
+{
+  "task": "Check pull request 123",
+  "everyMinutes": 30,
+  "reportWhen": "Checks fail or the state changes materially",
+  "stopWhen": "The pull request is merged or closed",
+  "maxChecks": 1000
+}
+```
+
+The first check runs immediately. Each accepted check records a bounded current
+observation and chooses whether to continue, report, or stop. A report uses a
+separate agent node so its structured check result is validated before the user
+sees the message. The next check can read the previous accepted observation.
+
+Intervals must be whole minutes from 1 through 1,440. `maxChecks` defaults to
+1,000 and cannot exceed 1,000. The workflow also has a finite step limit and
+bounded observation and report sizes.
+
+The interval uses the existing shell action with `sleep`. The node and command
+timeouts are higher than the maximum interval. Cancelling the workflow aborts
+the sleep immediately. If the owning Pi process or standalone host stops during
+the sleep, normal parking rules abort the shell node and resume later by running
+that sleep again from the beginning.
+
+A monitor uses the session's single active workflow slot. It does not provide
+cron syntax, calendar scheduling, OS notifications, or a background service.
+
 ## The step contract
 
 Every `agent` prompt ends with a step contract block naming the workflow, the
@@ -254,16 +308,17 @@ step id, the attempt id, and the expected output shape:
 Workflow step contract (workflow: autoimplement, step: review, attempt: 6f9d…)
 
 Complete this step by calling the `workflow` tool exactly once with:
-{"step": "review", "attempt": "6f9d…", "output": <your result>}
+{"action": "submit", "step": "review", "attempt": "6f9d…", "output": <your result>}
 Expected output: { "route": "clean" | "issues_found", "reason": "short justification" }
 The step is complete only after the workflow tool accepts the output.
 If the tool reports a validation error, correct the output and call it again.
 ```
 
-The `workflow` tool takes `{ step, attempt, output }`. Submissions are
-rejected (with a reason the model sees) when no step is pending, the step id
-is wrong, the attempt id belongs to an earlier attempt of the same node (loops
-revisit node ids, so each attempt gets a fresh id), or `validate` throws.
+The `workflow` tool uses `{ action: "submit", step, attempt, output }` for step
+results. Submissions are rejected (with a reason the model sees) when no step
+is pending, the step id is wrong, the attempt id belongs to an earlier attempt
+of the same node (loops revisit node ids, so each attempt gets a fresh id), or
+`validate` throws.
 Acceptance resolves the step and the engine advances; the next agent prompt
 arrives as a new user message in the same conversation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "pi-workflows": "dist/viewer/cli.js"
       },
       "devDependencies": {
+        "@earendil-works/pi-ai": "^0.80.10",
         "@earendil-works/pi-coding-agent": "^0.80.10",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.1",
@@ -31,8 +32,489 @@
         "node": ">=22"
       },
       "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
         "typebox": "*"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
+      "integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -254,6 +736,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -302,6 +794,39 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.1.38"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
       "version": "0.80.10",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
@@ -338,468 +863,6 @@
         "@mariozechner/clipboard": "0.3.9"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
-      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-node": "^3.972.42",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.19",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
-      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
-      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
-      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
-      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-login": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
-      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
-      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.37",
-        "@aws-sdk/credential-provider-http": "^3.972.39",
-        "@aws-sdk/credential-provider-ini": "^3.972.41",
-        "@aws-sdk/credential-provider-process": "^3.972.37",
-        "@aws-sdk/credential-provider-sso": "^3.972.41",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
-      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
-      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/token-providers": "3.1048.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
-      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
-      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
-      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1048.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
-      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.11",
-        "@aws-sdk/nested-clients": "^3.997.9",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.80.10",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
@@ -810,31 +873,6 @@
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
-        "@smithy/node-http-handler": "4.7.3",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -851,31 +889,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
@@ -1068,281 +1081,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -1353,44 +1097,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -1404,13 +1110,6 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
       "version": "5.6.2",
@@ -1440,34 +1139,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -1476,129 +1147,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
@@ -1632,34 +1180,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1690,34 +1210,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -1744,60 +1236,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
       "version": "11.4.0",
@@ -1846,119 +1284,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
@@ -2010,61 +1335,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2108,33 +1378,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
@@ -2150,23 +1393,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
@@ -2185,44 +1411,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -2237,26 +1425,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2735,6 +1903,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -2795,6 +1988,27 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -2812,6 +2026,26 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3470,6 +2704,72 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -3734,6 +3034,134 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3796,6 +3224,13 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
@@ -4275,6 +3710,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4284,6 +3729,27 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -4309,6 +3775,23 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.6",
@@ -4343,6 +3826,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
@@ -4382,6 +3872,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4408,6 +3908,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4496,6 +4006,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4514,6 +4031,43 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4529,6 +4083,36 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4537,6 +4121,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/has-flag": {
@@ -4555,6 +4167,34 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4617,6 +4257,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4628,6 +4292,29 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lightningcss": {
@@ -4891,6 +4578,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4974,6 +4668,46 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -4996,6 +4730,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/oxfmt": {
@@ -5099,6 +4855,27 @@
         }
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5155,6 +4932,40 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -5188,6 +4999,27 @@
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -5300,13 +5132,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.23.1",
@@ -5575,6 +5413,16 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -5592,12 +5440,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jiti": "^2.7.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "^0.80.10",
     "@earendil-works/pi-coding-agent": "^0.80.10",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.1",
@@ -73,6 +74,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
     "typebox": "*"
   },

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -229,8 +229,8 @@ export default defineWorkflow({
         const config = configFrom(outputs);
         const sleepMs = config.everyMinutes * 60_000;
         return {
-          command: "sleep",
-          args: [String(config.everyMinutes * 60)],
+          command: process.execPath,
+          args: ["-e", "setTimeout(() => {}, Number(process.argv[1]))", String(sleepMs)],
           timeoutMs: sleepMs + SLEEP_TIMEOUT_MARGIN_MS,
           maxOutputChars: 1_024,
         };

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -1,0 +1,278 @@
+import { agent, compute, defineWorkflow, shell } from "../workflows/index.js";
+import type { WorkflowNodeContext } from "../workflows/types.js";
+
+const MIN_INTERVAL_MINUTES = 1;
+const MAX_INTERVAL_MINUTES = 24 * 60;
+const DEFAULT_MAX_CHECKS = 1_000;
+const MAX_CHECKS = 1_000;
+const MAX_OBSERVATION_CHARS = 8_000;
+const MAX_REPORT_CHARS = 4_000;
+const MAX_REASON_CHARS = 2_000;
+const SLEEP_TIMEOUT_MARGIN_MS = 60_000;
+const NODE_TIMEOUT_MARGIN_MS = 2 * 60_000;
+
+type MonitorInput = {
+  task: string;
+  everyMinutes: number;
+  reportWhen?: string;
+  stopWhen?: string;
+  maxChecks?: number;
+};
+
+type MonitorConfig = {
+  task: string;
+  everyMinutes: number;
+  reportWhen: string;
+  stopWhen: string;
+  maxChecks: number;
+};
+
+type MonitorRoute = "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report";
+
+type MonitorCheck = {
+  route: MonitorRoute;
+  observation: string;
+  report?: string;
+  reason: string;
+};
+
+const MONITOR_ROUTES = new Set<MonitorRoute>([
+  "continue_quiet",
+  "continue_report",
+  "stop_quiet",
+  "stop_report",
+]);
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireBoundedString(value: unknown, label: string, maxChars: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+  if (trimmed.length > maxChars) {
+    throw new Error(`${label} must be at most ${maxChars} characters`);
+  }
+  return trimmed;
+}
+
+function prepareInput(input: unknown): MonitorConfig {
+  const value = requireRecord(input, "monitor input") as Partial<MonitorInput>;
+  const task = requireBoundedString(value.task, "task", 8_000);
+  if (
+    typeof value.everyMinutes !== "number" ||
+    !Number.isInteger(value.everyMinutes) ||
+    value.everyMinutes < MIN_INTERVAL_MINUTES ||
+    value.everyMinutes > MAX_INTERVAL_MINUTES
+  ) {
+    throw new Error(
+      `everyMinutes must be an integer from ${MIN_INTERVAL_MINUTES} through ${MAX_INTERVAL_MINUTES}`,
+    );
+  }
+  const maxChecks = value.maxChecks ?? DEFAULT_MAX_CHECKS;
+  if (!Number.isInteger(maxChecks) || maxChecks <= 0 || maxChecks > MAX_CHECKS) {
+    throw new Error(`maxChecks must be an integer from 1 through ${MAX_CHECKS}`);
+  }
+  return {
+    task,
+    everyMinutes: value.everyMinutes,
+    reportWhen:
+      value.reportWhen === undefined
+        ? "The observed state changes materially or needs the user's attention."
+        : requireBoundedString(value.reportWhen, "reportWhen", 4_000),
+    stopWhen:
+      value.stopWhen === undefined
+        ? "The user cancels the monitor or it reaches its maximum check count."
+        : requireBoundedString(value.stopWhen, "stopWhen", 4_000),
+    maxChecks,
+  };
+}
+
+function configFrom(outputs: Record<string, unknown>): MonitorConfig {
+  return outputs.prepare as MonitorConfig;
+}
+
+function completedChecks(context: WorkflowNodeContext): number {
+  return context.state.steps.filter((step) => step.nodeId === "check" && step.outcome === "ok")
+    .length;
+}
+
+function validateCheck(output: unknown): MonitorCheck {
+  const value = requireRecord(output, "monitor check output");
+  if (typeof value.route !== "string" || !MONITOR_ROUTES.has(value.route as MonitorRoute)) {
+    throw new Error(`route must be one of ${[...MONITOR_ROUTES].join(", ")}`);
+  }
+  const route = value.route as MonitorRoute;
+  const observation = requireBoundedString(value.observation, "observation", MAX_OBSERVATION_CHARS);
+  const reason = requireBoundedString(value.reason, "reason", MAX_REASON_CHARS);
+  const reports = route === "continue_report" || route === "stop_report";
+  const report =
+    value.report === undefined
+      ? undefined
+      : requireBoundedString(value.report, "report", MAX_REPORT_CHARS);
+  if (reports && report === undefined) {
+    throw new Error(`route ${route} requires a report`);
+  }
+  return {
+    route,
+    observation,
+    ...(report !== undefined ? { report } : {}),
+    reason,
+  };
+}
+
+function validateReportAck(output: unknown): { reported: true } {
+  const value = requireRecord(output, "report acknowledgement");
+  if (value.reported !== true) {
+    throw new Error("report acknowledgement must set reported to true");
+  }
+  return { reported: true };
+}
+
+function reportPrompt(outputs: Record<string, unknown>): string {
+  const check = outputs.check as MonitorCheck;
+  return [
+    "Write one concise normal assistant message to the user with this monitoring update:",
+    check.report ?? check.observation,
+    "Do not add unrelated detail.",
+    "After writing the update, submit the acknowledgement required by the workflow step contract.",
+  ].join("\n\n");
+}
+
+export default defineWorkflow({
+  name: "monitor",
+  title: ({ input }) => {
+    try {
+      const task = prepareInput(input).task;
+      return `monitor: ${task.slice(0, 80)}`;
+    } catch {
+      return "monitor";
+    }
+  },
+  presentationPrompt: ({ finalOutput }) => {
+    const result = requireRecord(finalOutput, "monitor result");
+    if (result.reported === true) {
+      return undefined;
+    }
+    return `Tell the user concisely why this monitor stopped: ${String(result.reason ?? "monitor ended")}`;
+  },
+  startAt: "prepare",
+  maxSteps: 5_010,
+  nodes: {
+    prepare: compute({
+      run: ({ input }) => prepareInput(input),
+    }),
+    guard: compute({
+      run: (context) => {
+        const config = configFrom(context.outputs);
+        const checks = completedChecks(context);
+        return checks >= config.maxChecks
+          ? { route: "stop", checks, reason: `Reached the ${config.maxChecks}-check limit.` }
+          : { route: "check", checks };
+      },
+    }),
+    continue_guard: compute({
+      run: (context) => {
+        const config = configFrom(context.outputs);
+        const checks = completedChecks(context);
+        return checks >= config.maxChecks
+          ? { route: "stop", checks, reason: `Reached the ${config.maxChecks}-check limit.` }
+          : { route: "sleep", checks };
+      },
+    }),
+    check: agent({
+      statusDetail: "checking monitored target",
+      prompt: (context) => {
+        const config = configFrom(context.outputs);
+        const previous = context.outputs.check as MonitorCheck | undefined;
+        const checkNumber = completedChecks(context) + 1;
+        return [
+          `Perform monitoring check ${checkNumber} of at most ${config.maxChecks}.`,
+          `Task: ${config.task}`,
+          `Report when: ${config.reportWhen}`,
+          `Stop when: ${config.stopWhen}`,
+          previous === undefined
+            ? "There is no previous observation. Report the initial state only when the report condition calls for it."
+            : `Previous accepted observation: ${previous.observation}`,
+          "Use available tools to inspect the current state. Observe only unless the task explicitly authorizes a mutation.",
+          "Choose continue_quiet, continue_report, stop_quiet, or stop_report. A report route requires concise report text.",
+        ].join("\n\n");
+      },
+      expectedOutput:
+        '{ "route": "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report", "observation": "current factual state", "report": "required for report routes", "reason": "short reason" }',
+      validate: (output) => validateCheck(output),
+    }),
+    report_continue: agent({
+      statusDetail: "reporting monitor update",
+      prompt: ({ outputs }) => reportPrompt(outputs),
+      expectedOutput: '{ "reported": true }',
+      validate: (output) => validateReportAck(output),
+    }),
+    report_stop: agent({
+      statusDetail: "reporting final monitor update",
+      prompt: ({ outputs }) => reportPrompt(outputs),
+      expectedOutput: '{ "reported": true }',
+      validate: (output) => validateReportAck(output),
+    }),
+    sleep: shell({
+      statusDetail: "waiting for next monitor check",
+      timeoutMs: MAX_INTERVAL_MINUTES * 60_000 + NODE_TIMEOUT_MARGIN_MS,
+      exec: ({ outputs }) => {
+        const config = configFrom(outputs);
+        const sleepMs = config.everyMinutes * 60_000;
+        return {
+          command: "sleep",
+          args: [String(config.everyMinutes * 60)],
+          timeoutMs: sleepMs + SLEEP_TIMEOUT_MARGIN_MS,
+          maxOutputChars: 1_024,
+        };
+      },
+      parse: (_result, { outputs }) => ({ waitedMinutes: configFrom(outputs).everyMinutes }),
+    }),
+    finish: compute({
+      run: ({ outputs }) => {
+        const check = outputs.check as MonitorCheck | undefined;
+        const guard = outputs.guard as { reason?: string } | undefined;
+        const continueGuard = outputs.continue_guard as { reason?: string } | undefined;
+        return {
+          reason: continueGuard?.reason ?? guard?.reason ?? check?.reason ?? "Monitor finished.",
+          observation: check?.observation ?? null,
+          reported:
+            outputs.report_stop !== undefined ||
+            (check !== undefined && check.route === "stop_report"),
+        };
+      },
+    }),
+  },
+  edges: [
+    { from: "prepare", to: "guard" },
+    { from: "guard", switch: { on: "$.route", cases: { check: "check", stop: "finish" } } },
+    {
+      from: "check",
+      switch: {
+        on: "$.route",
+        cases: {
+          continue_quiet: "continue_guard",
+          continue_report: "report_continue",
+          stop_quiet: "finish",
+          stop_report: "report_stop",
+        },
+      },
+    },
+    { from: "report_continue", to: "continue_guard" },
+    { from: "report_stop", to: "finish" },
+    {
+      from: "continue_guard",
+      switch: { on: "$.route", cases: { sleep: "sleep", stop: "finish" } },
+    },
+    { from: "sleep", to: "guard" },
+  ],
+});

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -255,7 +255,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
         prompt: [
           `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
           "Complete it by calling the `workflow` tool with:",
-          `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
+          `{"action": "submit", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
           `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
         ].join("\n"),
         streaming: this.streaming,

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,10 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type {
-  ExtensionAPI,
-  ExtensionCommandContext,
-  ExtensionContext,
-} from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   projectControllerStorePath,
   type RunEventRecord,
@@ -42,6 +37,7 @@ import {
 import { ConversationStepExecutor } from "./executor.js";
 import { SessionRecorder } from "./recorder.js";
 import { buildWidgetView } from "./widget.js";
+import { WorkflowToolParameters, type WorkflowToolInput } from "./workflow-tool.js";
 
 const RUN_CLAIM_LEASE_MS = 30_000;
 const RUN_CLAIM_RENEW_MS = 10_000;
@@ -103,6 +99,7 @@ export type ParsedWorkflowArgs =
   | { kind: "cancel" }
   | { kind: "pause" }
   | { kind: "resume" }
+  | { kind: "status"; runId?: string }
   | { kind: "answer"; input: unknown; runId?: string | undefined }
   | { kind: "run"; ref: string; input: unknown };
 
@@ -114,6 +111,16 @@ export function parseWorkflowArgs(args: string): ParsedWorkflowArgs {
   }
   if (trimmed === "cancel" || trimmed === "pause" || trimmed === "resume") {
     return { kind: trimmed };
+  }
+  if (trimmed === "status") {
+    return { kind: "status" };
+  }
+  if (trimmed.startsWith("status ")) {
+    const runId = trimmed.slice("status".length).trim();
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/.test(runId)) {
+      throw new Error("status requires one valid run id");
+    }
+    return { kind: "status", runId };
   }
   if (trimmed === "answer" || trimmed.startsWith("answer ")) {
     let rest = trimmed === "answer" ? "" : trimmed.slice("answer".length).trim();
@@ -165,6 +172,21 @@ export function parseWorkflowArgs(args: string): ParsedWorkflowArgs {
     return { kind: "run", ref, input: JSON.parse(json) as unknown };
   }
   return { kind: "run", ref, input: rest.length > 0 ? { task: rest } : {} };
+}
+
+function workflowStateSummary(state: WorkflowRunState): JsonObject {
+  return {
+    active: state.status === "running",
+    runId: state.runId,
+    workflowName: state.workflowName,
+    status: state.status,
+    steps: state.steps.length,
+    ...(state.currentNode !== undefined ? { currentNode: state.currentNode } : {}),
+    ...(state.waitingOn !== undefined ? { waitingOn: state.waitingOn } : {}),
+    ...(state.startedAt !== undefined ? { startedAt: state.startedAt } : {}),
+    ...(state.finishedAt !== undefined ? { finishedAt: state.finishedAt } : {}),
+    ...(state.error !== undefined ? { error: state.error } : {}),
+  };
 }
 
 type WidgetSource = {
@@ -317,6 +339,12 @@ export default function piWorkflows(pi: ExtensionAPI) {
     runSyncTimer.unref?.();
   };
   let activeRun: ActiveRun | null = null;
+  let pendingToolLaunch: {
+    ctx: ExtensionContext;
+    ref: string;
+    input: unknown;
+    options?: StartRunOptions;
+  } | null = null;
   // The interactive run currently parked at a checkpoint, if any.
   let lastWaitingRunId: string | null = null;
   let widgetTimer: NodeJS.Timeout | null = null;
@@ -1004,27 +1032,307 @@ export default function piWorkflows(pi: ExtensionAPI) {
     return controllerHost;
   };
 
-  const listWorkflows = async (ctx: ExtensionCommandContext) => {
+  type WorkflowControlResult = {
+    message: string;
+    details: JsonObject;
+    level?: "info" | "warning" | "error";
+  };
+
+  const listWorkflowControl = async (ctx: ExtensionContext): Promise<WorkflowControlResult> => {
     const discovered = await discoverWorkflows({ cwd: ctx.cwd });
     if (discovered.length === 0) {
-      notify(
-        ctx,
-        "No workflows found. Put *.workflow.ts files in .pi/workflows/ or ~/.pi/agent/workflows/, or pass a path.",
-        "warning",
-      );
-      return;
+      return {
+        message:
+          "No workflows found. Put *.workflow.ts files in .pi/workflows/ or ~/.pi/agent/workflows/, or pass a path.",
+        details: { workflows: [] },
+        level: "warning",
+      };
     }
     const names = discovered.map((workflow) => `${workflow.name} (${workflow.source})`).join(", ");
-    notify(ctx, `Workflows: ${names}. Run one with /workflow <name> [task].`);
+    return {
+      message: `Workflows: ${names}. Run one with /workflow <name> [task].`,
+      details: {
+        workflows: discovered.map((workflow) => ({
+          name: workflow.name,
+          source: workflow.source,
+          ...(workflow.name === "monitor"
+            ? {
+                description:
+                  "Repeatedly check a target, report requested changes, and stop on a condition.",
+              }
+            : {}),
+        })),
+      },
+    };
+  };
+
+  const listWorkflows = async (ctx: ExtensionContext) => {
+    const result = await listWorkflowControl(ctx);
+    notify(ctx, result.message, result.level);
+  };
+
+  const cancelWorkflowControl = (ctx: ExtensionContext): WorkflowControlResult => {
+    if (activeRun) {
+      const workflowName = activeRun.workflowName;
+      const runId = activeRun.runId;
+      activeRun.engine.cancel();
+      return {
+        message: `Cancelling workflow ${workflowName}…`,
+        details: { action: "cancel", workflowName, runId },
+      };
+    }
+    if (pendingToolLaunch !== null) {
+      const ref = pendingToolLaunch.ref;
+      pendingToolLaunch = null;
+      return {
+        message: `Cancelled the queued workflow launch for ${ref}.`,
+        details: { action: "cancel", workflow: ref, queued: false },
+      };
+    }
+    if (widgetSource) {
+      const { state } = widgetSource;
+      clearWidgetTimer();
+      clearWidget(ctx);
+      const detail =
+        state.status === "waiting" && state.waitingOn
+          ? `already ended at checkpoint ${state.waitingOn}`
+          : `already ${state.status}`;
+      return {
+        message: `Workflow ${state.workflowName} ${detail}; cleared its widget.`,
+        details: { action: "clear", workflowName: state.workflowName, runId: state.runId },
+      };
+    }
+    return {
+      message: "No workflow is running.",
+      details: { action: "cancel", active: false },
+      level: "warning",
+    };
+  };
+
+  const pauseWorkflowControl = (ctx: ExtensionContext): WorkflowControlResult => {
+    if (!activeRun) {
+      return {
+        message: "No workflow is running.",
+        details: { action: "pause", active: false },
+        level: "warning",
+      };
+    }
+    if (runHeld()) {
+      return {
+        message: `Workflow ${activeRun.workflowName} is already pausing or paused.`,
+        details: {
+          action: "pause",
+          workflowName: activeRun.workflowName,
+          runId: activeRun.runId,
+          paused: true,
+        },
+      };
+    }
+    activeRun.engine.pause();
+    renderWidget(ctx);
+    return {
+      message: `Pausing workflow ${activeRun.workflowName}; the current step will finish before the run holds.`,
+      details: {
+        action: "pause",
+        workflowName: activeRun.workflowName,
+        runId: activeRun.runId,
+        paused: true,
+      },
+    };
+  };
+
+  const resumeWorkflowControl = (ctx: ExtensionContext): WorkflowControlResult => {
+    if (!activeRun) {
+      return {
+        message: "No workflow is running.",
+        details: { action: "resume", active: false },
+        level: "warning",
+      };
+    }
+    if (!runHeld()) {
+      return {
+        message: `Workflow ${activeRun.workflowName} is not paused.`,
+        details: {
+          action: "resume",
+          workflowName: activeRun.workflowName,
+          runId: activeRun.runId,
+          paused: false,
+        },
+        level: "warning",
+      };
+    }
+    activeRun.engine.resume();
+    activeRun.executor.release();
+    renderWidget(ctx);
+    return {
+      message: `Workflow ${activeRun.workflowName} resumed.`,
+      details: {
+        action: "resume",
+        workflowName: activeRun.workflowName,
+        runId: activeRun.runId,
+        paused: false,
+      },
+    };
+  };
+
+  const statusWorkflowControl = async (
+    ctx: ExtensionContext,
+    runId?: string,
+  ): Promise<WorkflowControlResult> => {
+    if (runId !== undefined) {
+      const bundle = await readRunBundle(new WorkflowRunStore().runDirFor(runId));
+      if (bundle === null) {
+        throw new Error(`Workflow run not found: ${runId}`);
+      }
+      const { state } = bundle;
+      return {
+        message: `Workflow ${state.workflowName} is ${state.status} (run ${state.runId}).`,
+        details: workflowStateSummary(state),
+      };
+    }
+    const state = activeRun?.lastState ?? widgetSource?.state;
+    if ((state === undefined || state === null) && pendingToolLaunch !== null) {
+      return {
+        message: `Workflow ${pendingToolLaunch.ref} is queued until the current turn finishes.`,
+        details: { active: false, queued: true, workflow: pendingToolLaunch.ref },
+      };
+    }
+    if (state === undefined || state === null) {
+      return {
+        message: "No workflow run is active or displayed.",
+        details: { active: false },
+        level: "warning",
+      };
+    }
+    return {
+      message: `Workflow ${state.workflowName} is ${state.status} (run ${state.runId}).`,
+      details: workflowStateSummary(state),
+    };
+  };
+
+  const resolveWaitingWorkflow = async (
+    ctx: ExtensionContext,
+    requestedRunId?: string,
+  ): Promise<{ parentRunId: string; workflowPath: string }> => {
+    let parentRunId = requestedRunId ?? lastWaitingRunId;
+    if (parentRunId === null) {
+      const rows = ensureRunQueueStore(ctx.cwd).listWorkflowRuns();
+      const known = new Set(rows.map((row) => row.runId));
+      const continued = new Set(
+        rows.map((row) => row.parentRunId).filter((parent): parent is string => parent !== null),
+      );
+      const bundles = await listRunBundles(new WorkflowRunStore().outputRoot);
+      parentRunId =
+        bundles.find(
+          (bundle) =>
+            bundle.state.status === "waiting" &&
+            known.has(bundle.state.runId) &&
+            !continued.has(bundle.state.runId),
+        )?.state.runId ?? null;
+    }
+    if (parentRunId === null) {
+      throw new Error("No workflow is waiting for an answer.");
+    }
+    const parent = await readRunBundle(new WorkflowRunStore().runDirFor(parentRunId));
+    if (
+      parent === null ||
+      parent.state.status !== "waiting" ||
+      parent.state.workflowPath === undefined
+    ) {
+      if (parentRunId === lastWaitingRunId) {
+        lastWaitingRunId = null;
+      }
+      throw new Error(`Workflow run ${parentRunId} is no longer waiting.`);
+    }
+    return { parentRunId, workflowPath: parent.state.workflowPath };
+  };
+
+  const answerWorkflowControl = async (
+    ctx: ExtensionContext,
+    input: unknown,
+    requestedRunId?: string,
+  ): Promise<WorkflowControlResult> => {
+    const waiting = await resolveWaitingWorkflow(ctx, requestedRunId);
+    const continued = await startRun(ctx, waiting.workflowPath, input, {
+      parentRunId: waiting.parentRunId,
+    });
+    if (continued === undefined) {
+      throw new Error("Could not start the checkpoint continuation.");
+    }
+    lastWaitingRunId = null;
+    return {
+      message: `Answered checkpoint ${waiting.parentRunId}; continuation ${continued} started.`,
+      details: {
+        action: "answer",
+        parentRunId: waiting.parentRunId,
+        runId: continued,
+      },
+    };
+  };
+
+  const startWorkflowControl = async (
+    ctx: ExtensionContext,
+    ref: string,
+    input: unknown,
+  ): Promise<WorkflowControlResult> => {
+    if (activeRun !== null) {
+      throw new Error(`A workflow is already running: ${activeRun.workflowName}.`);
+    }
+    if (pendingToolLaunch !== null) {
+      throw new Error("A workflow launch is already waiting for the current turn to finish.");
+    }
+    if (presentationPending !== null) {
+      throw new Error("The previous workflow result is still being presented.");
+    }
+    const runId = await startRun(ctx, ref, input);
+    if (runId === undefined) {
+      throw new Error("The workflow could not start.");
+    }
+    return {
+      message: `Workflow ${ref} started (run ${runId}).`,
+      details: { action: "start", workflow: ref, runId },
+    };
+  };
+
+  const queueToolLaunch = async (
+    ctx: ExtensionContext,
+    ref: string,
+    input: unknown,
+    options: StartRunOptions = {},
+  ): Promise<WorkflowControlResult> => {
+    if (activeRun !== null) {
+      throw new Error(
+        `A workflow is already running: ${activeRun.workflowName}. Cancel it before starting another.`,
+      );
+    }
+    if (pendingToolLaunch !== null) {
+      throw new Error("A workflow launch is already waiting for the current turn to finish.");
+    }
+    if (presentationPending !== null) {
+      throw new Error("The previous workflow result is still being presented.");
+    }
+    const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd });
+    const workflow = await loadWorkflowFile(resolved.path);
+    pendingToolLaunch = { ctx, ref, input, options };
+    return {
+      message: `Workflow ${workflow.name} will start after this turn finishes.`,
+      details: {
+        action: "start",
+        workflow: workflow.name,
+        source: resolved.source,
+        queued: true,
+      },
+    };
   };
 
   pi.registerCommand("workflow", {
     description:
-      "Run a workflow: /workflow <name-or-path> [task | --input-json {…}]; also: pause, resume, cancel, answer",
+      "Run or manage a workflow: /workflow <name-or-path> [task | --input-json {…}]; also: status, pause, resume, cancel, answer",
     getArgumentCompletions: async (prefix: string) => {
       const discovered = await discoverWorkflows({ cwd: process.cwd() });
       const items = [
         ...discovered.map((workflow) => ({ value: workflow.name, label: workflow.name })),
+        { value: "status", label: "status" },
         { value: "pause", label: "pause" },
         { value: "resume", label: "resume" },
         { value: "cancel", label: "cancel" },
@@ -1045,113 +1353,39 @@ export default function piWorkflows(pi: ExtensionAPI) {
         return;
       }
       if (parsed.kind === "cancel") {
-        if (activeRun) {
-          activeRun.engine.cancel();
-          notify(ctx, `Cancelling workflow ${activeRun.workflowName}…`);
-          return;
-        }
-        // No live run, but a parked (waiting) or recently finished run may
-        // still occupy the widget; cancel clears it.
-        if (widgetSource) {
-          const { state } = widgetSource;
-          clearWidgetTimer();
-          clearWidget(ctx);
-          const detail =
-            state.status === "waiting" && state.waitingOn
-              ? `already ended at checkpoint ${state.waitingOn}`
-              : `already ${state.status}`;
-          notify(ctx, `Workflow ${state.workflowName} ${detail}; cleared its widget.`);
-          return;
-        }
-        notify(ctx, "No workflow is running.", "warning");
+        const result = cancelWorkflowControl(ctx);
+        notify(ctx, result.message, result.level);
         return;
       }
       if (parsed.kind === "pause") {
-        if (!activeRun) {
-          notify(ctx, "No workflow is running.", "warning");
-          return;
-        }
-        if (runHeld()) {
-          notify(ctx, `Workflow ${activeRun.workflowName} is already pausing or paused.`);
-          return;
-        }
-        activeRun.engine.pause();
-        renderWidget(ctx);
-        notify(
-          ctx,
-          `Pausing workflow ${activeRun.workflowName} — the current step finishes, then the run holds. /workflow resume to continue.`,
-        );
+        const result = pauseWorkflowControl(ctx);
+        notify(ctx, result.message, result.level);
         return;
       }
       if (parsed.kind === "resume") {
-        if (!activeRun) {
-          notify(ctx, "No workflow is running.", "warning");
-          return;
+        const result = resumeWorkflowControl(ctx);
+        notify(ctx, result.message, result.level);
+        return;
+      }
+      if (parsed.kind === "status") {
+        try {
+          const result = await statusWorkflowControl(ctx, parsed.runId);
+          notify(ctx, result.message, result.level);
+        } catch (error) {
+          notify(ctx, errorMessage(error), "error");
         }
-        if (!runHeld()) {
-          notify(ctx, `Workflow ${activeRun.workflowName} is not paused.`);
-          return;
-        }
-        activeRun.engine.resume();
-        activeRun.executor.release();
-        renderWidget(ctx);
-        notify(ctx, `Workflow ${activeRun.workflowName} resumed.`);
         return;
       }
       if (parsed.kind === "answer") {
-        // Resolve the waiting run durably: this session's own checkpoint if
-        // there is one, an explicit run id, or the most recent waiting bundle
-        // on disk (restart- and host-safe).
-        let parentRunId = parsed.runId ?? lastWaitingRunId;
-        if (parentRunId === null) {
-          // Discover from durable state, scoped to this project's queue: a
-          // bare answer targets the newest waiting run this project started
-          // that has not already been continued.
-          const rows = ensureRunQueueStore(ctx.cwd).listWorkflowRuns();
-          const known = new Set(rows.map((row) => row.runId));
-          const continued = new Set(
-            rows
-              .map((row) => row.parentRunId)
-              .filter((parent): parent is string => parent !== null),
-          );
-          const bundles = await listRunBundles(new WorkflowRunStore().outputRoot);
-          parentRunId =
-            bundles.find(
-              (bundle) =>
-                bundle.state.status === "waiting" &&
-                known.has(bundle.state.runId) &&
-                !continued.has(bundle.state.runId),
-            )?.state.runId ?? null;
-        }
-        if (parentRunId === null) {
-          notify(ctx, "No workflow is waiting for an answer.", "warning");
-          return;
-        }
-        const parent = await readRunBundle(new WorkflowRunStore().runDirFor(parentRunId));
-        if (
-          parent === null ||
-          parent.state.status !== "waiting" ||
-          parent.state.workflowPath === undefined
-        ) {
-          notify(ctx, `Workflow run ${parentRunId} is no longer waiting.`, "warning");
-          if (parentRunId === lastWaitingRunId) {
-            lastWaitingRunId = null;
-          }
-          return;
-        }
         try {
-          const continued = await startRun(ctx, parent.state.workflowPath, parsed.input, {
-            parentRunId,
-          });
-          if (continued !== undefined) {
-            lastWaitingRunId = null;
-          }
+          const result = await answerWorkflowControl(ctx, parsed.input, parsed.runId);
+          notify(ctx, result.message, result.level);
         } catch (error) {
           const message = errorMessage(error);
           notify(
             ctx,
             /workflow_run_queue_parent/.test(message)
-              ? `Checkpoint ${parentRunId} was already answered; see its continuation run.`
+              ? "That checkpoint was already answered; see its continuation run."
               : `Could not continue workflow: ${message}`,
             "error",
           );
@@ -1159,7 +1393,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
         return;
       }
       try {
-        await startRun(ctx, parsed.ref, parsed.input);
+        const result = await startWorkflowControl(ctx, parsed.ref, parsed.input);
+        notify(ctx, result.message, result.level);
       } catch (error) {
         notify(ctx, `Could not start workflow: ${errorMessage(error)}`, "error");
       }
@@ -1239,37 +1474,65 @@ export default function piWorkflows(pi: ExtensionAPI) {
     name: "workflow",
     label: "Workflow",
     description: [
-      "Submit the output for the pending workflow step.",
-      "Only call this tool when a workflow step contract in the conversation asks you to.",
-      "Pass the exact step id from the contract and your result as the output.",
+      "List, start, inspect, pause, resume, cancel, answer, or complete Pi Workflows runs.",
+      "When the user asks to monitor, watch, poll, or check something repeatedly, start the built-in monitor workflow with input keys task, everyMinutes, reportWhen, stopWhen, and optional maxChecks.",
+      "Use submit only when a workflow step contract asks for it, and pass the exact step and attempt ids.",
+      "Do not start repeated work without the user's request, and keep monitoring observation-only unless the user authorizes mutations.",
     ].join(" "),
-    parameters: Type.Object({
-      step: Type.String({ description: "The step id from the workflow step contract" }),
-      attempt: Type.String({ description: "The attempt id from the workflow step contract" }),
-      output: Type.Unknown({ description: "The step output, matching the expected output shape" }),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (!activeRun) {
-        throw new Error(
-          "No workflow is running. Do not call the workflow tool outside a workflow.",
-        );
-      }
-      // Flush the conversation into the bundle before accepting, so the
-      // attempt's recorded range includes the assistant message that carries
-      // this submission. Pi guarantees ctx.sessionManager is synchronized
-      // through the current assistant tool-calling message before tool_call
-      // dispatch, which precedes tool execution (docs/extensions.md, "Tool
-      // Events"). The tool result of this call itself lands after the range
-      // by design: it is the submission receipt, not the submission.
-      await activeRun.recorder?.record(ctx).catch(() => undefined);
-      await activeRun.recorder?.synchronize(ctx).catch(() => undefined);
-      const result = await activeRun.executor.submit(params.step, params.attempt, params.output);
-      if (!result.accepted) {
-        throw new Error(result.message);
+    parameters: WorkflowToolParameters,
+    async execute(_toolCallId, params: WorkflowToolInput, _signal, _onUpdate, ctx) {
+      let control: WorkflowControlResult;
+      switch (params.action) {
+        case "list":
+          control = await listWorkflowControl(ctx);
+          break;
+        case "start":
+          control = await queueToolLaunch(ctx, params.workflow, params.input ?? {});
+          break;
+        case "status":
+          control = await statusWorkflowControl(ctx, params.runId);
+          break;
+        case "pause":
+          control = pauseWorkflowControl(ctx);
+          break;
+        case "resume":
+          control = resumeWorkflowControl(ctx);
+          break;
+        case "cancel":
+          control = cancelWorkflowControl(ctx);
+          break;
+        case "answer": {
+          const waiting = await resolveWaitingWorkflow(ctx, params.runId);
+          control = await queueToolLaunch(ctx, waiting.workflowPath, params.input, {
+            parentRunId: waiting.parentRunId,
+          });
+          break;
+        }
+        case "submit": {
+          if (!activeRun) {
+            throw new Error("No workflow step is waiting for output.");
+          }
+          // Flush the conversation into the bundle before accepting, so the
+          // attempt range includes the assistant message carrying this call.
+          await activeRun.recorder?.record(ctx).catch(() => undefined);
+          await activeRun.recorder?.synchronize(ctx).catch(() => undefined);
+          const result = await activeRun.executor.submit(
+            params.step,
+            params.attempt,
+            params.output,
+          );
+          if (!result.accepted) {
+            throw new Error(result.message);
+          }
+          return {
+            content: [{ type: "text", text: result.message }],
+            details: { action: "submit", step: params.step, accepted: true },
+          };
+        }
       }
       return {
-        content: [{ type: "text", text: result.message }],
-        details: { step: params.step, accepted: true },
+        content: [{ type: "text", text: control.message }],
+        details: control.details,
       };
     },
   });
@@ -1375,6 +1638,21 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", async (_event, ctx) => {
+    if (activeRun === null && pendingToolLaunch !== null) {
+      const launch = pendingToolLaunch;
+      pendingToolLaunch = null;
+      try {
+        const runId = await startRun(launch.ctx, launch.ref, launch.input, launch.options);
+        if (runId === undefined) {
+          notify(launch.ctx, "The queued workflow could not start.", "error");
+        } else if (launch.options?.parentRunId !== undefined) {
+          lastWaitingRunId = null;
+        }
+      } catch (error) {
+        notify(launch.ctx, `Could not start queued workflow: ${errorMessage(error)}`, "error");
+      }
+      return;
+    }
     const run = activeRun;
     if (!run) {
       presentationPending = null;
@@ -1400,6 +1678,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     await run?.recorder?.stop().catch(() => undefined);
     await run?.completion?.catch(() => undefined);
     activeRun = null;
+    pendingToolLaunch = null;
     lastWaitingRunId = null;
     if (runSyncTimer !== null) {
       clearInterval(runSyncTimer);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -47,6 +47,7 @@ const PRESENTATION_MESSAGE_TYPE = "pi-workflows-presentation";
 const FINAL_WIDGET_TTL_MS = 60_000;
 const WIDGET_SCROLL_STEP = 3;
 const MAX_PRESENTATION_RESULT_CHARS = 50_000;
+const MAX_STATUS_ERROR_CHARS = 4_000;
 const PRESENTATION_TIMEOUT_MS = 30_000;
 
 class PresentationSupersededError extends Error {}
@@ -175,6 +176,12 @@ export function parseWorkflowArgs(args: string): ParsedWorkflowArgs {
 }
 
 function workflowStateSummary(state: WorkflowRunState): JsonObject {
+  const error =
+    state.error === undefined
+      ? undefined
+      : state.error.length <= MAX_STATUS_ERROR_CHARS
+        ? state.error
+        : `${state.error.slice(0, MAX_STATUS_ERROR_CHARS)}\n… [error truncated]`;
   return {
     active: state.status === "running",
     runId: state.runId,
@@ -185,7 +192,7 @@ function workflowStateSummary(state: WorkflowRunState): JsonObject {
     ...(state.waitingOn !== undefined ? { waitingOn: state.waitingOn } : {}),
     ...(state.startedAt !== undefined ? { startedAt: state.startedAt } : {}),
     ...(state.finishedAt !== undefined ? { finishedAt: state.finishedAt } : {}),
-    ...(state.error !== undefined ? { error: state.error } : {}),
+    ...(error !== undefined ? { error } : {}),
   };
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -48,6 +48,8 @@ const FINAL_WIDGET_TTL_MS = 60_000;
 const WIDGET_SCROLL_STEP = 3;
 const MAX_PRESENTATION_RESULT_CHARS = 50_000;
 const MAX_STATUS_ERROR_CHARS = 4_000;
+const MAX_WORKFLOW_LIST_ITEMS = 50;
+const MAX_WORKFLOW_LIST_NAME_CHARS = 3_500;
 const PRESENTATION_TIMEOUT_MS = 30_000;
 
 class PresentationSupersededError extends Error {}
@@ -1045,21 +1047,50 @@ export default function piWorkflows(pi: ExtensionAPI) {
     level?: "info" | "warning" | "error";
   };
 
-  const listWorkflowControl = async (ctx: ExtensionContext): Promise<WorkflowControlResult> => {
+  const listWorkflowControl = async (
+    ctx: ExtensionContext,
+    offset = 0,
+  ): Promise<WorkflowControlResult> => {
     const discovered = await discoverWorkflows({ cwd: ctx.cwd });
     if (discovered.length === 0) {
       return {
         message:
           "No workflows found. Put *.workflow.ts files in .pi/workflows/ or ~/.pi/agent/workflows/, or pass a path.",
-        details: { workflows: [] },
+        details: { workflows: [], total: 0, offset: 0 },
         level: "warning",
       };
     }
-    const names = discovered.map((workflow) => `${workflow.name} (${workflow.source})`).join(", ");
+    if (!Number.isInteger(offset) || offset < 0 || offset > discovered.length) {
+      throw new Error(
+        `Workflow list offset must be an integer from 0 through ${discovered.length}.`,
+      );
+    }
+    const page = [];
+    let nameChars = 0;
+    for (const workflow of discovered.slice(offset)) {
+      const renderedName = `${workflow.name} (${workflow.source})`;
+      if (
+        page.length >= MAX_WORKFLOW_LIST_ITEMS ||
+        nameChars + renderedName.length > MAX_WORKFLOW_LIST_NAME_CHARS
+      ) {
+        break;
+      }
+      page.push(workflow);
+      nameChars += renderedName.length;
+    }
+    const names = page.map((workflow) => `${workflow.name} (${workflow.source})`).join(", ");
+    const nextOffset = offset + page.length;
+    const omitted = discovered.length - nextOffset;
     return {
-      message: `Workflows: ${names}. Run one with /workflow <name> [task].`,
+      message: [
+        `Workflows: ${names}.`,
+        omitted > 0 ? `${omitted} more omitted; list again with offset ${nextOffset}.` : "",
+        "Run one with /workflow <name> [task].",
+      ]
+        .filter(Boolean)
+        .join(" "),
       details: {
-        workflows: discovered.map((workflow) => ({
+        workflows: page.map((workflow) => ({
           name: workflow.name,
           source: workflow.source,
           ...(workflow.name === "monitor"
@@ -1069,6 +1100,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
               }
             : {}),
         })),
+        total: discovered.length,
+        offset,
+        omitted,
+        ...(omitted > 0 ? { nextOffset } : {}),
       },
     };
   };
@@ -1318,18 +1353,29 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (presentationPending !== null) {
       throw new Error("The previous workflow result is still being presented.");
     }
-    const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd });
-    const workflow = await loadWorkflowFile(resolved.path);
-    pendingToolLaunch = { ctx, ref, input, options };
-    return {
-      message: `Workflow ${workflow.name} will start after this turn finishes.`,
-      details: {
-        action: "start",
-        workflow: workflow.name,
-        source: resolved.source,
-        queued: true,
-      },
-    };
+    const reservation = { ctx, ref, input, options };
+    pendingToolLaunch = reservation;
+    try {
+      const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd });
+      const workflow = await loadWorkflowFile(resolved.path);
+      if (pendingToolLaunch !== reservation) {
+        throw new Error("The queued workflow launch was cancelled before validation finished.");
+      }
+      return {
+        message: `Workflow ${workflow.name} will start after this turn finishes.`,
+        details: {
+          action: "start",
+          workflow: workflow.name,
+          source: resolved.source,
+          queued: true,
+        },
+      };
+    } catch (error) {
+      if (pendingToolLaunch === reservation) {
+        pendingToolLaunch = null;
+      }
+      throw error;
+    }
   };
 
   pi.registerCommand("workflow", {
@@ -1491,7 +1537,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
       let control: WorkflowControlResult;
       switch (params.action) {
         case "list":
-          control = await listWorkflowControl(ctx);
+          control = await listWorkflowControl(ctx, params.offset);
           break;
         case "start":
           control = await queueToolLaunch(ctx, params.workflow, params.input ?? {});

--- a/src/extension/workflow-tool.ts
+++ b/src/extension/workflow-tool.ts
@@ -1,0 +1,53 @@
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type, type TSchema } from "typebox";
+
+const noExtraProperties = { additionalProperties: false } as const;
+
+export const WorkflowToolParameters: TSchema = Type.Union([
+  Type.Object({ action: StringEnum(["list"] as const) }, noExtraProperties),
+  Type.Object(
+    {
+      action: StringEnum(["start"] as const),
+      workflow: Type.String({ description: "Discovered workflow name or workflow file path" }),
+      input: Type.Optional(Type.Unknown({ description: "Structured workflow input" })),
+    },
+    noExtraProperties,
+  ),
+  Type.Object(
+    {
+      action: StringEnum(["status"] as const),
+      runId: Type.Optional(Type.String({ description: "Run id; omit for the active run" })),
+    },
+    noExtraProperties,
+  ),
+  Type.Object({ action: StringEnum(["pause"] as const) }, noExtraProperties),
+  Type.Object({ action: StringEnum(["resume"] as const) }, noExtraProperties),
+  Type.Object({ action: StringEnum(["cancel"] as const) }, noExtraProperties),
+  Type.Object(
+    {
+      action: StringEnum(["answer"] as const),
+      input: Type.Unknown({ description: "Checkpoint answer" }),
+      runId: Type.Optional(Type.String({ description: "Waiting run id" })),
+    },
+    noExtraProperties,
+  ),
+  Type.Object(
+    {
+      action: StringEnum(["submit"] as const),
+      step: Type.String({ description: "Step id from the workflow step contract" }),
+      attempt: Type.String({ description: "Attempt id from the workflow step contract" }),
+      output: Type.Unknown({ description: "Step output matching the expected shape" }),
+    },
+    noExtraProperties,
+  ),
+]);
+
+export type WorkflowToolInput =
+  | { action: "list" }
+  | { action: "start"; workflow: string; input?: unknown }
+  | { action: "status"; runId?: string }
+  | { action: "pause" }
+  | { action: "resume" }
+  | { action: "cancel" }
+  | { action: "answer"; input: unknown; runId?: string }
+  | { action: "submit"; step: string; attempt: string; output: unknown };

--- a/src/extension/workflow-tool.ts
+++ b/src/extension/workflow-tool.ts
@@ -4,7 +4,13 @@ import { Type, type TSchema } from "typebox";
 const noExtraProperties = { additionalProperties: false } as const;
 
 export const WorkflowToolParameters: TSchema = Type.Union([
-  Type.Object({ action: StringEnum(["list"] as const) }, noExtraProperties),
+  Type.Object(
+    {
+      action: StringEnum(["list"] as const),
+      offset: Type.Optional(Type.Integer({ minimum: 0, description: "Workflow list offset" })),
+    },
+    noExtraProperties,
+  ),
   Type.Object(
     {
       action: StringEnum(["start"] as const),
@@ -43,7 +49,7 @@ export const WorkflowToolParameters: TSchema = Type.Union([
 ]);
 
 export type WorkflowToolInput =
-  | { action: "list" }
+  | { action: "list"; offset?: number }
   | { action: "start"; workflow: string; input?: unknown }
   | { action: "status"; runId?: string }
   | { action: "pause" }

--- a/src/host/rpc-bridge.ts
+++ b/src/host/rpc-bridge.ts
@@ -1,3 +1,4 @@
+import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
@@ -14,15 +15,19 @@ export default function piWorkflowsRpcBridge(pi: ExtensionAPI) {
     name: "workflow",
     label: "Workflow",
     description: [
-      "Submit the output for the pending workflow step.",
+      "Submit the output for the pending workflow step with action submit.",
       "Only call this tool when a workflow step contract in the conversation asks you to.",
       "Pass the exact step id from the contract and your result as the output.",
     ].join(" "),
-    parameters: Type.Object({
-      step: Type.String({ description: "The step id from the workflow step contract" }),
-      attempt: Type.String({ description: "The attempt id from the workflow step contract" }),
-      output: Type.Unknown({ description: "The step output, matching the expected output shape" }),
-    }),
+    parameters: Type.Object(
+      {
+        action: StringEnum(["submit"] as const),
+        step: Type.String({ description: "Step id from the workflow step contract" }),
+        attempt: Type.String({ description: "Attempt id from the workflow step contract" }),
+        output: Type.Unknown({ description: "Step output matching the expected shape" }),
+      },
+      { additionalProperties: false },
+    ),
     async execute(_toolCallId, params) {
       process.stderr.write(`${RPC_SUBMISSION_PREFIX}${JSON.stringify(params)}\n`);
       return {

--- a/src/host/rpc-executor.ts
+++ b/src/host/rpc-executor.ts
@@ -17,6 +17,7 @@ const BRIDGE_PATH = ["./rpc-bridge.js", "./rpc-bridge.ts"]
 const ABORT_GRACE_MS = 3_000;
 
 type StepSubmission = {
+  action: "submit";
   step: string;
   attempt: string;
   output: unknown;
@@ -179,7 +180,11 @@ export class RpcStepExecutor implements AgentStepExecutor {
         }
         try {
           const parsed = JSON.parse(line.slice(RPC_SUBMISSION_PREFIX.length)) as StepSubmission;
-          if (typeof parsed.step === "string" && typeof parsed.attempt === "string") {
+          if (
+            parsed.action === "submit" &&
+            typeof parsed.step === "string" &&
+            typeof parsed.attempt === "string"
+          ) {
             this.submissions.push(parsed);
           }
         } catch {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -1117,7 +1117,7 @@ export function appendStepContract(
     `Workflow step contract (workflow: ${workflowName}, step: ${nodeId}, attempt: ${attemptId})`,
     "",
     "Complete this step by calling the `workflow` tool exactly once with:",
-    `{"step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
+    `{"action": "submit", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
     `Expected output: ${expectedOutput ?? "a JSON object with your result"}`,
     "The step is complete only after the workflow tool accepts the output.",
     "If the tool reports a validation error, correct the output and call it again.",

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -12,7 +12,7 @@ const WORKFLOW_FILE_SUFFIXES = [".workflow.ts", ".workflow.js", ".workflow.mts",
 export type DiscoveredWorkflow = {
   name: string;
   path: string;
-  source: "project" | "global" | "path";
+  source: "project" | "global" | "builtin" | "path";
 };
 
 export type WorkflowSearchPaths = {
@@ -20,14 +20,16 @@ export type WorkflowSearchPaths = {
   homeDir?: string;
 };
 
-/** Directories scanned for `*.workflow.ts` files, in precedence order. */
+/** Directories scanned for workflow files, in precedence order. */
 export function workflowSearchDirs(
   options: WorkflowSearchPaths,
-): { dir: string; source: "project" | "global" }[] {
+): { dir: string; source: "project" | "global" | "builtin" }[] {
   const homeDir = options.homeDir ?? os.homedir();
+  const builtinDir = fileURLToPath(new URL("../builtins/", import.meta.url));
   return [
     { dir: path.join(options.cwd, ".pi", "workflows"), source: "project" },
     { dir: path.join(homeDir, ".pi", "agent", "workflows"), source: "global" },
+    { dir: builtinDir, source: "builtin" },
   ];
 }
 

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -160,7 +160,7 @@ function assertValidEdgeShape(edge: WorkflowEdge, index: number): void {
  * Names claimed by `/workflow` subcommands; a workflow with one of these
  * names could never be started because the keyword wins the argument slot.
  */
-const RESERVED_WORKFLOW_NAMES = new Set(["cancel", "list", "pause", "resume"]);
+const RESERVED_WORKFLOW_NAMES = new Set(["answer", "cancel", "list", "pause", "resume", "status"]);
 
 export function assertValidWorkflowDefinitionShape(definition: WorkflowDefinition): void {
   assertRecord(definition, "workflow");

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -248,6 +248,23 @@ describe.sequential("pi-workflows end to end", () => {
         if (lastUserText.includes("Presentation instructions:")) {
           return { kind: "text", text: "Implemented the boring, proven design." };
         }
+        if (lastRole === "user" && lastUserText === "Start the built-in monitor now.") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "start",
+              workflow: "monitor",
+              input: {
+                task: "Check the fixture once",
+                everyMinutes: 30,
+                reportWhen: "The fixture fails",
+                stopWhen: "The first check is complete",
+                maxChecks: 1,
+              },
+            },
+          };
+        }
         if (lastRole === "tool") {
           return {
             kind: "text",
@@ -266,6 +283,7 @@ describe.sequential("pi-workflows end to end", () => {
             thinking: "Build and submit the proposed workflow output.",
             toolName: "workflow",
             args: {
+              action: "submit",
               step: "propose",
               attempt,
               output: { proposal: "Ship the boring, proven design." },
@@ -278,9 +296,29 @@ describe.sequential("pi-workflows end to end", () => {
             thinking: "Choose the accepted workflow route.",
             toolName: "workflow",
             args: {
+              action: "submit",
               step: "confirm",
               attempt,
               output: { route: "y", reason: "proposal matches the holy grail" },
+            },
+          };
+        }
+        const monitorStepMatch = lastUserText.match(
+          /workflow step contract \(workflow: monitor, step: ([a-z_]+), attempt: ([a-z0-9-]+)\)/i,
+        );
+        if (monitorStepMatch?.[1] === "check") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "submit",
+              step: "check",
+              attempt: monitorStepMatch[2] ?? "",
+              output: {
+                route: "stop_quiet",
+                observation: "The fixture check completed.",
+                reason: "The requested first check is complete.",
+              },
             },
           };
         }
@@ -292,6 +330,7 @@ describe.sequential("pi-workflows end to end", () => {
             kind: "tool",
             toolName: "workflow",
             args: {
+              action: "submit",
               step: "work",
               attempt: hostStepMatch[2] ?? "",
               output: { finished: "host did it" },
@@ -652,6 +691,26 @@ describe.sequential("pi-workflows end to end", () => {
       Promise.all(terminalFiles.map((file) => fs.readFile(path.join(runDir, file), "utf8"))),
     ).resolves.toEqual(terminalContents);
   }, 120_000);
+
+  it("starts the built-in monitor from the model-facing workflow tool", async () => {
+    pi.send({ id: "monitor-1", type: "prompt", message: "Start the built-in monitor now." });
+
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "monitor" &&
+        (candidate.status === "completed" || candidate.status === "failed"),
+      () => `pi stderr:\n${pi.stderr()}\npi stdout tail:\n${pi.stdoutLines.slice(-15).join("\n")}`,
+    );
+
+    expect(state.status).toBe("completed");
+    expect(state.workflowName).toBe("monitor");
+    expect(state.finalOutput).toMatchObject({
+      observation: "The fixture check completed.",
+      reason: "The requested first check is complete.",
+    });
+    expect(state.steps.some((step) => step.nodeId === "sleep")).toBe(false);
+  });
 
   it("reconciles a durable controller through the real pi extension", async () => {
     pi.send({

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -188,7 +188,9 @@ describe("WorkflowEngine", () => {
     const attemptId = request?.contract.attemptId ?? "";
     expect(prompt).toContain("Base prompt");
     expect(prompt).toContain("Workflow step contract");
-    expect(prompt).toContain(`{"step": "ask", "attempt": "${attemptId}", "output": <your result>}`);
+    expect(prompt).toContain(
+      `{"action": "submit", "step": "ask", "attempt": "${attemptId}", "output": <your result>}`,
+    );
     expect(prompt).toContain(`Expected output: { "x": 1 }`);
     expect(prompt).toBe(
       appendStepContract("Base prompt", "contract", "ask", attemptId, `{ "x": 1 }`),

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -361,6 +361,37 @@ describe("pi-workflows extension", () => {
     }
   });
 
+  it("bounds failed-run errors returned by workflow status", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-status-error");
+    const runsDir = await makeTempDir("pi-workflows-tool-status-error-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      const dir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "fail.workflow.ts"),
+        `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  name: "fail",
+  startAt: "fail",
+  nodes: { fail: compute({ run: () => { throw new Error("x".repeat(10000)); } }) },
+  edges: [],
+});
+`,
+      );
+      const harness = makeHarness({ cwd, respond: () => {} });
+
+      await harness.command.handler("fail", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("failed")));
+      const status = await harness.tool.execute("status-error", { action: "status" });
+
+      expect(status.details.error).toEqual(expect.stringContaining("[error truncated]"));
+      expect(String(status.details.error).length).toBeLessThan(4_100);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("queues an opted-in result presentation after completion", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const runsDir = await makeTempDir("pi-workflows-ext-runs");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -361,6 +361,62 @@ describe("pi-workflows extension", () => {
     }
   });
 
+  it("bounds and paginates workflow lists returned to the model", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-list");
+    vi.stubEnv("HOME", await makeTempDir("pi-workflows-tool-list-home"));
+    try {
+      const workflowDir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(workflowDir, { recursive: true });
+      await Promise.all(
+        Array.from({ length: 60 }, async (_, index) => {
+          const name = `item-${String(index).padStart(3, "0")}.workflow.ts`;
+          await fs.writeFile(path.join(workflowDir, name), "", "utf8");
+        }),
+      );
+      const harness = makeHarness({ cwd, respond: () => {} });
+
+      const first = await harness.tool.execute("list-first", { action: "list" });
+      expect(first.details).toMatchObject({ total: 61, offset: 0, omitted: 11, nextOffset: 50 });
+      expect(first.details.workflows).toHaveLength(50);
+      expect(first.content[0]?.text).toContain("11 more omitted; list again with offset 50");
+
+      const second = await harness.tool.execute("list-second", { action: "list", offset: 50 });
+      expect(second.details).toMatchObject({ total: 61, offset: 50, omitted: 0 });
+      expect(second.details.workflows).toHaveLength(11);
+      expect(second.details).not.toHaveProperty("nextOffset");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("reserves one model-started workflow while it validates", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-start-reservation");
+    await writeEchoWorkflow(cwd);
+    const harness = makeHarness({ cwd, respond: () => {} });
+
+    await expect(
+      harness.tool.execute("start-missing", {
+        action: "start",
+        workflow: "missing",
+      }),
+    ).rejects.toThrow(/Unknown workflow/);
+
+    const starts = await Promise.allSettled([
+      harness.tool.execute("start-first", { action: "start", workflow: "mini" }),
+      harness.tool.execute("start-second", { action: "start", workflow: "mini" }),
+    ]);
+    expect(starts.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(starts.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(starts.find((result) => result.status === "rejected")).toMatchObject({
+      reason: expect.objectContaining({
+        message: expect.stringMatching(/launch is already waiting/),
+      }),
+    });
+
+    const cancelled = await harness.tool.execute("cancel-pending", { action: "cancel" });
+    expect(cancelled.details).toMatchObject({ action: "cancel", workflow: "mini", queued: false });
+  });
+
   it("bounds failed-run errors returned by workflow status", async () => {
     const cwd = await makeTempDir("pi-workflows-tool-status-error");
     const runsDir = await makeTempDir("pi-workflows-tool-status-error-runs");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -356,6 +356,9 @@ describe("pi-workflows extension", () => {
 
       const status = await harness.tool.execute("status-1", { action: "status" });
       expect(status.details).toMatchObject({ workflowName: "mini", status: "completed" });
+      await expect(
+        harness.tool.execute("status-missing", { action: "status", runId: "missing-run" }),
+      ).rejects.toThrow(/Workflow run not found/);
     } finally {
       vi.unstubAllEnvs();
     }
@@ -384,6 +387,16 @@ describe("pi-workflows extension", () => {
       expect(second.details).toMatchObject({ total: 61, offset: 50, omitted: 0 });
       expect(second.details.workflows).toHaveLength(11);
       expect(second.details).not.toHaveProperty("nextOffset");
+
+      await expect(
+        harness.tool.execute("list-fraction", { action: "list", offset: 1.5 }),
+      ).rejects.toThrow(/offset must be an integer/);
+      await expect(
+        harness.tool.execute("list-negative", { action: "list", offset: -1 }),
+      ).rejects.toThrow(/offset must be an integer/);
+      await expect(
+        harness.tool.execute("list-too-large", { action: "list", offset: 62 }),
+      ).rejects.toThrow(/offset must be an integer/);
     } finally {
       vi.unstubAllEnvs();
     }
@@ -415,6 +428,13 @@ describe("pi-workflows extension", () => {
 
     const cancelled = await harness.tool.execute("cancel-pending", { action: "cancel" });
     expect(cancelled.details).toMatchObject({ action: "cancel", workflow: "mini", queued: false });
+
+    const validating = harness.tool.execute("start-cancelled", {
+      action: "start",
+      workflow: "mini",
+    });
+    await harness.tool.execute("cancel-validating", { action: "cancel" });
+    await expect(validating).rejects.toThrow(/cancelled before validation finished/);
   });
 
   it("bounds failed-run errors returned by workflow status", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,15 +5,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SqliteControllerStore } from "../src/controllers/sqlite.js";
 import { projectControllerStorePath } from "../src/controllers/store.js";
 import piWorkflows from "../src/extension/index.js";
+import type { WorkflowToolInput } from "../src/extension/workflow-tool.js";
 import { readRunBundle } from "../src/workflows/store.js";
 import { makeTempDir } from "./helpers.js";
 
+type ToolResult = {
+  content: { type: string; text: string }[];
+  details: Record<string, unknown>;
+};
+
 type RegisteredTool = {
+  name: string;
+  execute: (toolCallId: string, params: WorkflowToolInput) => Promise<ToolResult>;
+};
+
+type RegisteredToolSpec = {
   name: string;
   execute: (
     toolCallId: string,
-    params: { step: string; attempt: string; output: unknown },
-  ) => Promise<unknown>;
+    params: WorkflowToolInput,
+    signal: AbortSignal,
+    onUpdate: (update: unknown) => void,
+    ctx: FakeContext,
+  ) => Promise<ToolResult>;
 };
 
 type RegisteredCommand = {
@@ -82,8 +96,18 @@ function makeHarness(options: {
     registerCommand: (name: string, spec: RegisteredCommand) => {
       commands.set(name, spec);
     },
-    registerTool: (spec: RegisteredTool) => {
-      tool = spec;
+    registerTool: (spec: RegisteredToolSpec) => {
+      tool = {
+        name: spec.name,
+        execute: async (toolCallId, params) =>
+          await spec.execute(
+            toolCallId,
+            params,
+            new AbortController().signal,
+            () => undefined,
+            ctx,
+          ),
+      };
     },
     registerShortcut: (key: string, spec: { handler: (ctx: FakeContext) => void }) => {
       shortcuts.set(key, spec.handler);
@@ -244,7 +268,11 @@ describe("pi-workflows extension", () => {
         respond: (prompt, tool) => {
           const contract = stepFromPrompt(prompt);
           if (contract) {
-            void tool.execute("call-1", { ...contract, output: { reply: "hi" } });
+            void tool.execute("call-1", {
+              action: "submit",
+              ...contract,
+              output: { reply: "hi" },
+            });
           }
         },
       });
@@ -285,6 +313,54 @@ describe("pi-workflows extension", () => {
     }
   });
 
+  it("lets the model list, start, and inspect workflows through one tool", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-control");
+    const runsDir = await makeTempDir("pi-workflows-tool-control-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({
+        cwd,
+        respond: (prompt, tool) => {
+          const contract = stepFromPrompt(prompt);
+          if (contract) {
+            void tool.execute("submit-1", {
+              action: "submit",
+              ...contract,
+              output: { reply: "hi" },
+            });
+          }
+        },
+      });
+
+      const listed = await harness.tool.execute("list-1", { action: "list" });
+      expect(listed.details.workflows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "mini", source: "project" }),
+          expect.objectContaining({ name: "monitor", source: "builtin" }),
+        ]),
+      );
+
+      const queued = await harness.tool.execute("start-1", {
+        action: "start",
+        workflow: "mini",
+        input: { task: "say hi" },
+      });
+      expect(queued.details).toMatchObject({ action: "start", workflow: "mini", queued: true });
+      expect(harness.notifications.some((note) => note.includes("Workflow mini started"))).toBe(
+        false,
+      );
+
+      await harness.emitAsync("agent_settled");
+      await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
+
+      const status = await harness.tool.execute("status-1", { action: "status" });
+      expect(status.details).toMatchObject({ workflowName: "mini", status: "completed" });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("queues an opted-in result presentation after completion", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const runsDir = await makeTempDir("pi-workflows-ext-runs");
@@ -313,7 +389,11 @@ export default defineWorkflow({
         respond: (prompt, tool) => {
           const contract = stepFromPrompt(prompt);
           if (contract) {
-            void tool.execute("call-1", { ...contract, output: { answer: "forty-two" } });
+            void tool.execute("call-1", {
+              action: "submit",
+              ...contract,
+              output: { answer: "forty-two" },
+            });
           }
         },
       });
@@ -578,7 +658,7 @@ export default defineWorkflow({
     expect(harness.notifications.at(-1)).toContain("Could not start workflow");
   });
 
-  it("warns when no workflows are discoverable", async () => {
+  it("lists the built-in monitor when no user workflows are discoverable", async () => {
     const cwd = await makeTempDir("pi-workflows-ext-empty");
     // The real home directory may have global workflows installed; point
     // discovery at an empty home so this test stays hermetic.
@@ -586,7 +666,7 @@ export default defineWorkflow({
     try {
       const harness = makeHarness({ cwd, respond: () => {} });
       await harness.command.handler("", harness.ctx);
-      expect(harness.notifications.at(-1)).toContain("No workflows found");
+      expect(harness.notifications.at(-1)).toContain("monitor (builtin)");
     } finally {
       homedirSpy.mockRestore();
     }
@@ -644,7 +724,7 @@ export default defineWorkflow({
     }
   });
 
-  it("pauses and resumes a live run via subcommands", async () => {
+  it("shares pause, resume, and cancel behavior between commands and the tool", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const runsDir = await makeTempDir("pi-workflows-ext-runs");
     vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
@@ -659,17 +739,18 @@ export default defineWorkflow({
       await harness.command.handler("mini", harness.ctx);
       await waitFor(() => harness.notifications.some((note) => note.includes("started")));
 
-      await harness.command.handler("pause", harness.ctx);
-      expect(harness.notifications.at(-1)).toContain("Pausing workflow mini");
-      await harness.command.handler("pause", harness.ctx);
-      expect(harness.notifications.at(-1)).toContain("already pausing or paused");
+      const paused = await harness.tool.execute("pause-1", { action: "pause" });
+      expect(paused.content[0]?.text).toContain("Pausing workflow mini");
+      const pausedAgain = await harness.tool.execute("pause-2", { action: "pause" });
+      expect(pausedAgain.content[0]?.text).toContain("already pausing or paused");
 
-      await harness.command.handler("resume", harness.ctx);
-      expect(harness.notifications.at(-1)).toContain("Workflow mini resumed");
-      await harness.command.handler("resume", harness.ctx);
-      expect(harness.notifications.at(-1)).toContain("is not paused");
+      const resumed = await harness.tool.execute("resume-1", { action: "resume" });
+      expect(resumed.content[0]?.text).toContain("Workflow mini resumed");
+      const resumedAgain = await harness.tool.execute("resume-2", { action: "resume" });
+      expect(resumedAgain.content[0]?.text).toContain("is not paused");
 
-      await harness.command.handler("cancel", harness.ctx);
+      const cancelled = await harness.tool.execute("cancel-1", { action: "cancel" });
+      expect(cancelled.content[0]?.text).toContain("Cancelling workflow mini");
       await waitFor(() => harness.notifications.some((note) => note.includes("cancelled")));
     } finally {
       vi.unstubAllEnvs();
@@ -748,12 +829,17 @@ export default defineWorkflow({
     expect(harness.widgets).toHaveLength(0);
   });
 
-  it("rejects tool calls outside a workflow", async () => {
+  it("rejects submissions outside a workflow", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const harness = makeHarness({ cwd, respond: () => {} });
     await expect(
-      harness.tool.execute("call-1", { step: "reply", attempt: "a1", output: {} }),
-    ).rejects.toThrow(/No workflow is running/);
+      harness.tool.execute("call-1", {
+        action: "submit",
+        step: "reply",
+        attempt: "a1",
+        output: {},
+      }),
+    ).rejects.toThrow(/No workflow step is waiting/);
   });
 
   it("cancels a running workflow", async () => {
@@ -1069,7 +1155,11 @@ export default defineWorkflow({
       const respond = (prompt: string, tool: RegisteredTool) => {
         const contract = stepFromPrompt(prompt);
         if (contract) {
-          void tool.execute("call-1", { ...contract, output: { reply: "hi" } });
+          void tool.execute("call-1", {
+            action: "submit",
+            ...contract,
+            output: { reply: "hi" },
+          });
         }
       };
       // Session A drives a run to completion.
@@ -1133,7 +1223,11 @@ export default defineWorkflow({
         respond: (prompt, tool) => {
           const contract = stepFromPrompt(prompt);
           if (contract) {
-            void tool.execute("call-1", { ...contract, output: { reply: "hi" } });
+            void tool.execute("call-1", {
+              action: "submit",
+              ...contract,
+              output: { reply: "hi" },
+            });
           }
         },
       });
@@ -1252,8 +1346,13 @@ export default defineWorkflow({
         await harness.emitAsync("session_start");
         // No active run.
         await expect(
-          harness.tool.execute("call-x", { step: "s", attempt: "a", output: {} }),
-        ).rejects.toThrow(/No workflow is running/);
+          harness.tool.execute("call-x", {
+            action: "submit",
+            step: "s",
+            attempt: "a",
+            output: {},
+          }),
+        ).rejects.toThrow(/No workflow step is waiting/);
 
         // An active run with a pending step contract.
         await fs.mkdir(path.join(cwd, ".pi", "workflows"), { recursive: true });
@@ -1287,7 +1386,12 @@ export default defineWorkflow({
         });
         // A compute node has no agent contract: submissions are rejected.
         await expect(
-          harness.tool.execute("call-y", { step: "work", attempt: "wrong", output: {} }),
+          harness.tool.execute("call-y", {
+            action: "submit",
+            step: "work",
+            attempt: "wrong",
+            output: {},
+          }),
         ).rejects.toThrow();
         await harness.emitAsync("session_shutdown");
       } finally {
@@ -1305,9 +1409,9 @@ export default defineWorkflow({
     const workflow = harness.commands.get("workflow");
     const controller = harness.commands.get("controller");
 
-    // No workflows or controllers exist in this project.
+    // The built-in monitor exists even when the project has no local workflows or controllers.
     await workflow?.handler("", harness.ctx);
-    expect(harness.notifications.at(-1)).toContain("No workflows found");
+    expect(harness.notifications.at(-1)).toContain("monitor (builtin)");
     await workflow?.handler("pause", harness.ctx);
     expect(harness.notifications.at(-1)).toContain("No workflow is running");
     await workflow?.handler("resume", harness.ctx);
@@ -1636,10 +1740,16 @@ export default defineWorkflow({
       );
       await first.emitAsync("session_shutdown");
 
-      // Session B has no in-memory waiting run; discovery comes from disk.
+      // Session B has no in-memory waiting run; the tool discovers it from disk
+      // and starts the continuation after the answering turn settles.
       const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
       await second.emitAsync("session_start");
-      await second.command.handler('answer {"approved":true}', second.ctx);
+      const queued = await second.tool.execute("answer-1", {
+        action: "answer",
+        input: { approved: true },
+      });
+      expect(queued.details).toMatchObject({ action: "start", queued: true });
+      await second.emitAsync("agent_settled");
       await waitFor(() => second.notifications.some((note) => note.includes("completed")));
 
       const queue = new SqliteControllerStore(projectControllerStorePath(cwd), {

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -49,6 +49,7 @@ describe("discoverWorkflows", () => {
     expect(discovered.map((w) => [w.name, w.source])).toEqual([
       ["local", "project"],
       ["global", "global"],
+      ["monitor", "builtin"],
     ]);
   });
 
@@ -59,14 +60,28 @@ describe("discoverWorkflows", () => {
 
     const discovered = await discoverWorkflows({ cwd, homeDir });
 
-    expect(discovered).toHaveLength(1);
+    expect(discovered).toHaveLength(2);
     expect(discovered[0]?.source).toBe("project");
+    expect(discovered[1]).toMatchObject({ name: "monitor", source: "builtin" });
   });
 
-  it("returns empty for missing directories", async () => {
+  it("returns the built-in monitor for missing user directories", async () => {
     const cwd = await makeTempDir("pi-workflows-empty");
     const homeDir = await makeTempDir("pi-workflows-empty-home");
-    expect(await discoverWorkflows({ cwd, homeDir })).toEqual([]);
+    expect(await discoverWorkflows({ cwd, homeDir })).toEqual([
+      expect.objectContaining({ name: "monitor", source: "builtin" }),
+    ]);
+  });
+
+  it("lets a project workflow override the built-in monitor", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    const target = await copyExample(path.join(cwd, ".pi", "workflows"), "monitor.workflow.ts");
+
+    const discovered = await discoverWorkflows({ cwd, homeDir });
+
+    expect(discovered.filter((workflow) => workflow.name === "monitor")).toEqual([
+      { name: "monitor", path: target, source: "project" },
+    ]);
   });
 });
 
@@ -93,6 +108,15 @@ describe("resolveWorkflowRef", () => {
     const resolved = await resolveWorkflowRef("mine", { cwd, homeDir });
 
     expect(resolved).toEqual({ path: target, source: "project" });
+  });
+
+  it("resolves and loads the built-in monitor", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir });
+    const workflow = await loadWorkflowFile(resolved.path);
+
+    expect(resolved.source).toBe("builtin");
+    expect(workflow.name).toBe("monitor");
   });
 
   it("resolves direct paths", async () => {

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -3,7 +3,9 @@ import monitor from "../src/builtins/monitor.workflow.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import { WorkflowRunStore } from "../src/workflows/store.js";
 import type {
+  AgentNodeDefinition,
   AgentStepExecutor,
+  ComputeNodeDefinition,
   ShellActionNodeDefinition,
   WorkflowNodeContext,
 } from "../src/workflows/types.js";
@@ -122,11 +124,19 @@ describe("built-in monitor workflow", () => {
 
   it.each([
     [null, "monitor input must be an object"],
+    [[], "monitor input must be an object"],
     [{ task: 1, everyMinutes: 30 }, "task must be a string"],
     [{ task: " ", everyMinutes: 30 }, "task must not be empty"],
     [{ task: "x".repeat(8_001), everyMinutes: 30 }, "task must be at most 8000"],
+    [{ task: "check", everyMinutes: "30" }, "everyMinutes must be an integer"],
     [{ task: "check", everyMinutes: 1.5 }, "everyMinutes must be an integer"],
+    [{ task: "check", everyMinutes: 0 }, "everyMinutes must be an integer"],
+    [{ task: "check", everyMinutes: 1_441 }, "everyMinutes must be an integer"],
+    [{ task: "check", everyMinutes: 30, maxChecks: 1.5 }, "maxChecks must be an integer"],
     [{ task: "check", everyMinutes: 30, maxChecks: 0 }, "maxChecks must be an integer"],
+    [{ task: "check", everyMinutes: 30, maxChecks: 1_001 }, "maxChecks must be an integer"],
+    [{ task: "check", everyMinutes: 30, reportWhen: false }, "reportWhen must be a string"],
+    [{ task: "check", everyMinutes: 30, stopWhen: " " }, "stopWhen must not be empty"],
   ])("rejects invalid monitor input %#", async (input, expectedError) => {
     const outputRoot = await makeTempDir("pi-workflows-monitor-input");
     const engine = new WorkflowEngine({
@@ -197,6 +207,78 @@ describe("built-in monitor workflow", () => {
     expect(badCheck.state.error).toContain("route must be one of");
     expect(noReport.state.error).toContain("requires a report");
     expect(badAck.state.error).toContain("reported to true");
+  });
+
+  it("formats monitor prompts, guards, and fallback output", async () => {
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_quiet",
+          observation: "Initial state",
+          reason: "Test complete",
+        },
+      ]),
+      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-callbacks")),
+    });
+    const result = await engine.run(monitor, monitorInput());
+    const context: WorkflowNodeContext = {
+      input: result.state.input,
+      outputs: result.state.outputs,
+      results: result.state.results,
+      state: result.state,
+      signal: new AbortController().signal,
+    };
+
+    if (typeof monitor.title !== "function" || typeof monitor.presentationPrompt !== "function") {
+      throw new Error("Monitor title and presentation prompt must be functions");
+    }
+    expect(await monitor.title({ input: monitorInput(), workflowName: "monitor" })).toContain(
+      "monitor: Check pull request 123",
+    );
+    expect(await monitor.title({ input: null, workflowName: "monitor" })).toBe("monitor");
+    expect(
+      await monitor.presentationPrompt({
+        state: result.state,
+        finalOutput: { reported: true },
+        signal: context.signal,
+      }),
+    ).toBeUndefined();
+    expect(
+      await monitor.presentationPrompt({
+        state: result.state,
+        finalOutput: {},
+        signal: context.signal,
+      }),
+    ).toContain("monitor ended");
+
+    const check = monitor.nodes.check as AgentNodeDefinition;
+    expect(await check.prompt(context)).toContain("Previous accepted observation: Initial state");
+    const report = monitor.nodes.report_stop as AgentNodeDefinition;
+    expect(
+      await report.prompt({
+        ...context,
+        outputs: { check: { observation: "Fallback observation" } },
+      }),
+    ).toContain("Fallback observation");
+
+    const guard = monitor.nodes.guard as ComputeNodeDefinition;
+    expect(
+      await guard.run({
+        ...context,
+        outputs: {
+          ...context.outputs,
+          prepare: { ...monitorInput(), maxChecks: 1 },
+        },
+      }),
+    ).toMatchObject({ route: "stop", checks: 1, reason: "Reached the 1-check limit." });
+    const continueGuard = monitor.nodes.continue_guard as ComputeNodeDefinition;
+    expect(await continueGuard.run(context)).toMatchObject({ route: "sleep", checks: 1 });
+    const finish = monitor.nodes.finish as ComputeNodeDefinition;
+    expect(await finish.run({ ...context, outputs: {} })).toEqual({
+      reason: "Monitor finished.",
+      observation: null,
+      reported: false,
+    });
   });
 
   it("configures a 30-minute shell sleep above both timeout limits", async () => {

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import monitor from "../src/builtins/monitor.workflow.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { WorkflowRunStore } from "../src/workflows/store.js";
+import type {
+  AgentStepExecutor,
+  ShellActionNodeDefinition,
+  WorkflowNodeContext,
+} from "../src/workflows/types.js";
+import { makeTempDir } from "./helpers.js";
+
+function scriptedExecutor(outputs: unknown[]): AgentStepExecutor {
+  const remaining = [...outputs];
+  return {
+    async runAgentStep(request) {
+      const output = remaining.shift();
+      if (output === undefined) {
+        throw new Error("No scripted monitor output remains");
+      }
+      const accepted = await request.accept(output);
+      if (!accepted.ok) {
+        throw new Error(accepted.error);
+      }
+      return { output: accepted.value };
+    },
+  };
+}
+
+function monitorInput(overrides: Record<string, unknown> = {}) {
+  return {
+    task: "Check pull request 123",
+    everyMinutes: 30,
+    reportWhen: "Checks fail",
+    stopWhen: "The pull request is merged or closed",
+    maxChecks: 5,
+    ...overrides,
+  };
+}
+
+describe("built-in monitor workflow", () => {
+  it("finishes quietly when the first check meets the stop condition", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_quiet",
+          observation: "Pull request 123 is merged.",
+          reason: "The configured stop condition is true.",
+        },
+      ]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+
+    const result = await engine.run(monitor, monitorInput());
+
+    expect(result.state.status).toBe("completed");
+    expect(result.state.finalOutput).toMatchObject({
+      reason: "The configured stop condition is true.",
+      observation: "Pull request 123 is merged.",
+      reported: false,
+    });
+  });
+
+  it("runs a report step before finishing when the check asks to report", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-report");
+    const prompts: string[] = [];
+    const outputs = [
+      {
+        route: "stop_report",
+        observation: "The Linux check failed.",
+        report: "PR 123 now has a failed Linux check.",
+        reason: "A requested report condition is true and the pull request closed.",
+      },
+      { reported: true },
+    ];
+    const executor: AgentStepExecutor = {
+      async runAgentStep(request) {
+        prompts.push(request.prompt);
+        const output = outputs.shift();
+        const accepted = await request.accept(output);
+        if (!accepted.ok) {
+          throw new Error(accepted.error);
+        }
+        return { output: accepted.value };
+      },
+    };
+    const engine = new WorkflowEngine({
+      executor,
+      store: new WorkflowRunStore(outputRoot),
+    });
+
+    const result = await engine.run(monitor, monitorInput());
+
+    expect(result.state.status).toBe("completed");
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toContain("PR 123 now has a failed Linux check.");
+    expect(result.state.finalOutput).toMatchObject({ reported: true });
+  });
+
+  it("stops at the check limit before starting another sleep", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-limit");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "continue_quiet",
+          observation: "Pull request 123 is still open.",
+          reason: "The stop condition is not true.",
+        },
+      ]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+
+    const result = await engine.run(monitor, monitorInput({ maxChecks: 1 }));
+
+    expect(result.state.status).toBe("completed");
+    expect(result.state.finalOutput).toMatchObject({
+      reason: "Reached the 1-check limit.",
+      observation: "Pull request 123 is still open.",
+    });
+    expect(result.state.steps.some((step) => step.nodeId === "sleep")).toBe(false);
+  });
+
+  it.each([
+    [null, "monitor input must be an object"],
+    [{ task: 1, everyMinutes: 30 }, "task must be a string"],
+    [{ task: " ", everyMinutes: 30 }, "task must not be empty"],
+    [{ task: "x".repeat(8_001), everyMinutes: 30 }, "task must be at most 8000"],
+    [{ task: "check", everyMinutes: 1.5 }, "everyMinutes must be an integer"],
+    [{ task: "check", everyMinutes: 30, maxChecks: 0 }, "maxChecks must be an integer"],
+  ])("rejects invalid monitor input %#", async (input, expectedError) => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-input");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+
+    const result = await engine.run(monitor, input);
+
+    expect(result.state.status).toBe("failed");
+    expect(result.state.error).toContain(expectedError);
+    expect(result.state.steps).toHaveLength(1);
+  });
+
+  it("applies default report, stop, and check limits", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-defaults");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_quiet",
+          observation: "Initial state",
+          reason: "Done",
+        },
+      ]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+
+    const result = await engine.run(monitor, { task: "Check a target", everyMinutes: 30 });
+
+    expect(result.state.status).toBe("completed");
+    expect(result.state.outputs.prepare).toMatchObject({
+      maxChecks: 1_000,
+      reportWhen: expect.stringContaining("changes materially"),
+      stopWhen: expect.stringContaining("maximum check count"),
+    });
+  });
+
+  it("rejects invalid check and report outputs", async () => {
+    const invalidCheck = new WorkflowEngine({
+      executor: scriptedExecutor([{ route: "unknown", observation: "state", reason: "bad route" }]),
+      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-bad-check")),
+    });
+    const missingReport = new WorkflowEngine({
+      executor: scriptedExecutor([
+        { route: "stop_report", observation: "state", reason: "missing report" },
+      ]),
+      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-no-report")),
+    });
+    const invalidAck = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_report",
+          observation: "state",
+          report: "State changed.",
+          reason: "report",
+        },
+        { reported: false },
+      ]),
+      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-bad-ack")),
+    });
+
+    const [badCheck, noReport, badAck] = await Promise.all([
+      invalidCheck.run(monitor, monitorInput()),
+      missingReport.run(monitor, monitorInput()),
+      invalidAck.run(monitor, monitorInput()),
+    ]);
+
+    expect(badCheck.state.error).toContain("route must be one of");
+    expect(noReport.state.error).toContain("requires a report");
+    expect(badAck.state.error).toContain("reported to true");
+  });
+
+  it("configures a 30-minute shell sleep above both timeout limits", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-sleep");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_quiet",
+          observation: "Initial state",
+          reason: "Test complete",
+        },
+      ]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+    const result = await engine.run(monitor, monitorInput());
+    const sleep = monitor.nodes.sleep as ShellActionNodeDefinition;
+    const context: WorkflowNodeContext = {
+      input: result.state.input,
+      outputs: result.state.outputs,
+      results: result.state.results,
+      state: result.state,
+      signal: new AbortController().signal,
+    };
+
+    const execution = await sleep.exec(context);
+
+    expect(execution).toMatchObject({ command: "sleep", args: ["1800"] });
+    expect(execution.timeoutMs).toBeGreaterThan(30 * 60_000);
+    expect(sleep.timeoutMs).toBeGreaterThan(30 * 60_000);
+  });
+});

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -223,7 +223,10 @@ describe("built-in monitor workflow", () => {
 
     const execution = await sleep.exec(context);
 
-    expect(execution).toMatchObject({ command: "sleep", args: ["1800"] });
+    expect(execution).toMatchObject({
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => {}, Number(process.argv[1]))", "1800000"],
+    });
     expect(execution.timeoutMs).toBeGreaterThan(30 * 60_000);
     expect(sleep.timeoutMs).toBeGreaterThan(30 * 60_000);
   });

--- a/test/rpc-executor-flow.test.ts
+++ b/test/rpc-executor-flow.test.ts
@@ -30,7 +30,7 @@ async function makeFakePi(
 }
 
 function submissionLine(step: string, attempt: string, output: unknown): string {
-  return `PI_WORKFLOWS_STEP_SUBMISSION ${JSON.stringify({ step, attempt, output })}\\n`;
+  return `PI_WORKFLOWS_STEP_SUBMISSION ${JSON.stringify({ action: "submit", step, attempt, output })}\\n`;
 }
 
 describe("RpcStepExecutor submissions", () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -42,7 +42,7 @@ describe("defineWorkflow validation", () => {
   });
 
   it("rejects reserved workflow names claimed by /workflow subcommands", () => {
-    for (const name of ["cancel", "list", "pause", "resume"]) {
+    for (const name of ["answer", "cancel", "list", "pause", "resume", "status"]) {
       expect(() => define({ name })).toThrow(/reserved for \/workflow subcommands/);
     }
   });

--- a/test/workflow-args.test.ts
+++ b/test/workflow-args.test.ts
@@ -32,6 +32,12 @@ describe("parseWorkflowArgs answer", () => {
     expect(() => parseWorkflowArgs("answer")).toThrow(/requires/);
   });
 
+  it("parses status with an optional run id", () => {
+    expect(parseWorkflowArgs("status")).toEqual({ kind: "status" });
+    expect(parseWorkflowArgs("status run-123")).toEqual({ kind: "status", runId: "run-123" });
+    expect(() => parseWorkflowArgs("status bad id")).toThrow(/valid run id/);
+  });
+
   it("parses --input-json for runs", () => {
     expect(parseWorkflowArgs('mini --input-json {"task":"hi"}')).toEqual({
       kind: "run",


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Users can now ask an agent to monitor something repeatedly without writing workflow JSON or using a slash command.
The existing `workflow` tool can start and manage runs, and Pi Workflows ships a built-in monitor that checks, reports, sleeps, and loops.

## What Changed

The model and the user now use the same workflow lifecycle implementation.
A model-started workflow waits for the current model turn to finish before its first workflow prompt is delivered.

- Expanded the `workflow` tool with `list`, `start`, `status`, `pause`, `resume`, `cancel`, `answer`, and `submit` actions.
- Changed step contracts to require `action: "submit"`.
- Kept the headless RPC bridge restricted to step submission.
- Added lowest-priority built-in workflow discovery with project and global override support.
- Added the built-in `monitor` workflow with bounded intervals, reports, stop conditions, check limits, and shell-based waits.
- Added real-Pi coverage for a normal model turn starting and completing a monitor.
- Updated the README, workflow guide, development guide, and implementation plan.

## Testing

The full local quality gate, real-Pi end-to-end suite, dependency boundary check, and package-content check pass.
The 30-minute path is verified by inspecting the exact `sleep 1800` command and timeout margins rather than waiting for 30 minutes.

- `npm ci`
- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `npm pack --dry-run --json`
- `git diff --check`

`npx -y @simpledoc/simpledoc check` still reports ten older repository documents that need migration. The new dated plan follows the current naming and frontmatter rules.

## Risks

The tool submission shape changes in place, so every workflow step now sends `action: "submit"`.
A monitor uses the session's one active workflow slot, and its shell sleep restarts if the owning Pi process stops and later resumes the run.

- Intervals are limited to 1 through 1,440 minutes.
- Monitors default to and cap at 1,000 checks.
- The built-in monitor observes only unless the task explicitly authorizes mutation.
