### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Prepare pi-workflows 0.3.0 for publication on npm and crates.io.

## What changed

- Set `@osolmaz/pi-workflows` to `0.3.0` in the npm manifest and lock file.
- Set the `pi-workflows` Rust crate to `0.3.0` in the Cargo manifest and lock file.

This release includes the durable controller runtime, workflow parking and resume, the standalone workflow host, agent-managed workflow controls, and the built-in monitor workflow added since 0.2.0.

## Compatibility note

Direct callers of the model-visible workflow tool must now include `"action": "submit"` with step submissions. Existing run bundles remain readable because the new continuation and workflow-source fields are optional.

## Validation

- `npm ci`
- `npm run check`: 41 files and 660 tests passed.
- `npm run test:e2e`: 6 tests passed.
- `npm pack --dry-run`: package 0.3.0, 240 files.
- `npm audit --omit=dev`: no vulnerabilities.
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 57 tests passed.
- `cargo publish --dry-run --allow-dirty`: package verification passed.
- `npx slophammer-ts@latest dry .`: no findings.