### PR TITLE
fix: coordinate workflow timeouts with Pi turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ Pi Workflows includes a `monitor` workflow for plain-language requests such as:
 
 The monitor checks immediately, reports only the states requested by the user,
 waits with a normal shell action, and loops until its stop condition or check
-limit. Its input supports `task`, `everyMinutes`, `reportWhen`, `stopWhen`, and
-`maxChecks`. Project and global workflows can replace the built-in `monitor`
+limit. Its input supports `task`, `everyMinutes`, `reportWhen`, `stopWhen`,
+`maxChecks`, and an optional `checkTimeoutMinutes`. Project and global
+workflows can replace the built-in `monitor`
 by using the same file name.
 
 A monitor occupies the session's one active workflow slot. If its Pi runner

--- a/docs/plans/2026-08-12-coordinated-workflow-timeouts-plan.md
+++ b/docs/plans/2026-08-12-coordinated-workflow-timeouts-plan.md
@@ -1,0 +1,74 @@
+---
+title: Coordinate Workflow Timeouts With Pi Turns
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-12
+status: implemented
+---
+
+# Coordinate Workflow Timeouts With Pi Turns
+
+A workflow agent node can time out while its Pi turn keeps running. The model can then continue to use tools and submit output for an attempt that the workflow engine has already closed. A failed or timed-out monitor can also call its normal result presenter without a final output. This plan makes the workflow deadline own the corresponding Pi turn and gives monitor checks an explicit timeout.
+
+## Requirements
+
+- Stop the active Pi turn when its workflow agent node times out, is cancelled, parks, or loses its claim.
+- Keep user Escape behavior separate. A user interrupt must still pause the workflow until `/workflow resume`.
+- Reject late submissions after the pending attempt closes.
+- Let workflow nodes derive a timeout from their input through a documented callback.
+- Give the built-in monitor an optional `checkTimeoutMinutes` input with safe bounds and a useful default.
+- Run normal result presentation only for completed runs and waiting checkpoints.
+- Keep the workflow engine independent of Pi.
+- Preserve existing run-bundle and workflow file formats.
+
+## Scope
+
+The workflow engine will expose agent-step aborts through its existing `AbortSignal`. The Pi extension will bind that signal to the Pi turn by calling the documented `ExtensionContext.abort()` method. It will record the attempt that requested the abort so the later `agent_end` event does not treat that abort as a user interrupt.
+
+`WorkflowNodeCommon.timeoutMs` will accept a positive number or a callback that returns a positive number from the node context. The engine will resolve and validate that value before it dispatches the node. Existing numeric timeouts and the 15-minute engine default will continue to work.
+
+The monitor will accept `checkTimeoutMinutes`. Its default will be the larger of 60 minutes and `everyMinutes`, with a maximum of 24 hours. The timeout will apply to check and report agent nodes. The shell wait keeps its current interval-specific timeout.
+
+## Non-goals
+
+- Do not change Pi internals.
+- Do not add a persistent timeout registry or change the run-state schema.
+- Do not make timed-out runs resumable.
+- Do not remove safety deadlines from workflow nodes.
+- Do not add compatibility code for submissions that omit `action: "submit"`.
+
+## Implementation
+
+1. Extend the conversation executor with an `onAbort` callback. Call it once when the engine abort signal closes a pending agent step. Pass the attempt contract and abort reason.
+2. In the Pi extension, keep a short-lived in-memory marker for the system-aborted attempt. Call `ctx.abort()` only when Pi is still busy. Clear the marker after the matching aborted agent end or when no turn was active.
+3. In `agent_end`, pause only for unmarked aborted turns. System aborts leave the engine's terminal or parked state in control.
+4. Resolve node timeout callbacks before creating the timer. Validate that the result is a finite positive number. Abort timeout resolution after a short fixed deadline so a callback cannot block node dispatch forever.
+5. Add and validate `checkTimeoutMinutes` in the monitor. Apply the derived timeout to `check`, `report_continue`, and `report_stop`.
+6. Restrict normal result presentation to `completed` and `waiting` states. Terminal failures continue to use the existing deterministic notification with the persisted error.
+7. Add tests for timeout-driven Pi abort, user Escape, late submissions, dynamic timeout validation, monitor timeout selection, and failed-run presentation.
+8. Add a real Pi RPC regression test where a model turn exceeds a short workflow timeout. Confirm that Pi aborts the turn, the run times out, and later tool work does not occur.
+
+## Acceptance criteria
+
+- A timed-out workflow agent node aborts its active Pi turn exactly once.
+- The timed-out attempt no longer accepts output.
+- A system-triggered abort does not pause the workflow as a user interrupt.
+- Escape continues to pause and `/workflow resume` continues the pending step.
+- Monitor checks use `checkTimeoutMinutes`, or the documented default when it is absent.
+- Failed, timed-out, and cancelled runs never call `presentationPrompt`.
+- Completed and waiting runs keep their current presentation behavior.
+- Existing workflow definitions with numeric or omitted timeouts continue to work.
+- No Pi internal API or persistent schema changes.
+
+## Verification
+
+Run:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+```
+
+Also start Pi through the package in RPC mode and complete a `get_state` request. The real Pi end-to-end suite must exercise timeout-driven turn cancellation.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -127,7 +127,10 @@ agent({
   prompt: ({ outputs }) => `Review this: ${JSON.stringify(outputs.implement)}`,
   expectedOutput: `{ "verdict": "clean" | "issues_found" }`,
   validate: (output) => output, // optional; throw to reject the submission
-  timeoutMs: 30 * 60_000, // optional; default 15 minutes
+  timeoutMs: ({ input }) =>
+    (input as { timeoutMinutes?: number }).timeoutMinutes
+      ? (input as { timeoutMinutes: number }).timeoutMinutes * 60_000
+      : 30 * 60_000, // optional number or context callback; default 15 minutes
   statusDetail: "reviewing", // optional; shown in widget and viewer
 });
 ```
@@ -137,7 +140,15 @@ calls the tool, the output passes through normalization (a JSON string is
 parsed tolerantly) and then `validate`. If `validate` throws, the tool call
 returns an error and the model can retry within the same step. If the agent
 ends its turn without submitting, the extension nudges it, twice by default,
-then fails the step.
+then fails the step. If an agent node times out or the workflow is cancelled,
+the extension also aborts its active Pi turn. The model cannot continue to use
+tools after the engine has closed that attempt.
+
+`timeoutMs` can be a finite positive number or a function of the normal node
+context. A timeout function can use prepared outputs to select a deadline for
+this run. It has 30 seconds to return a value. Computed timeout functions are
+runtime code, so definition snapshots omit them; fixed numeric timeouts remain
+in the snapshot.
 
 ### compute
 
@@ -276,7 +287,8 @@ one looping workflow run. Its input is:
   "everyMinutes": 30,
   "reportWhen": "Checks fail or the state changes materially",
   "stopWhen": "The pull request is merged or closed",
-  "maxChecks": 1000
+  "maxChecks": 1000,
+  "checkTimeoutMinutes": 60
 }
 ```
 
@@ -286,8 +298,10 @@ separate agent node so its structured check result is validated before the user
 sees the message. The next check can read the previous accepted observation.
 
 Intervals must be whole minutes from 1 through 1,440. `maxChecks` defaults to
-1,000 and cannot exceed 1,000. The workflow also has a finite step limit and
-bounded observation and report sizes.
+1,000 and cannot exceed 1,000. `checkTimeoutMinutes` is optional and applies to
+check and report agent nodes. It must be from 5 through 1,440 minutes. Its
+default is the larger of 60 minutes and `everyMinutes`. The workflow also has
+a finite step limit and bounded observation and report sizes.
 
 The interval uses the existing shell action to launch the current Node
 executable with a timer. This works on every platform supported by Pi. The node
@@ -344,8 +358,9 @@ After the final run state has been persisted, the Pi extension sends the
 presentation instructions and bounded final result to the model as a hidden
 follow-up message. The next visible message is a normal assistant response.
 Returning `undefined`, returning an empty string, or omitting
-`presentationPrompt` produces no follow-up. Cancelled runs are never
-presented. Async prompt builders have 30 seconds to finish and receive an
+`presentationPrompt` produces no follow-up. Failed, timed-out, and cancelled
+runs are never presented; the extension reports their persisted status and
+error directly. Async prompt builders have 30 seconds to finish and receive an
 `AbortSignal` that fires on timeout, session shutdown, or when a new workflow
 or normal user turn starts; stale presentations are discarded. Once a presentation message has
 been queued, another workflow cannot start until that assistant response
@@ -364,8 +379,10 @@ Runs execute one node at a time. Every transition is persisted to the run
 bundle before the engine moves on, which is what makes the live viewer
 possible. Defaults worth knowing:
 
-- Node timeout is 15 minutes unless the node sets `timeoutMs`. A timed-out
-  node has outcome `timed_out` and can be routed with `$result.outcome`.
+- Node timeout is 15 minutes unless the node sets `timeoutMs` to a positive
+  number or context callback. A timed-out node has outcome `timed_out` and can
+  be routed with `$result.outcome`. A timed-out agent node also aborts its Pi
+  turn, and late output for that attempt is rejected.
 - `maxSteps` (workflow-level, default 100) bounds loops built from cycles in
   the graph.
 - `/workflow pause` requests a pause: the current step finishes normally,

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -3,6 +3,9 @@ import type { WorkflowNodeContext } from "../workflows/types.js";
 
 const MIN_INTERVAL_MINUTES = 1;
 const MAX_INTERVAL_MINUTES = 24 * 60;
+const MIN_CHECK_TIMEOUT_MINUTES = 5;
+const MAX_CHECK_TIMEOUT_MINUTES = 24 * 60;
+const DEFAULT_MIN_CHECK_TIMEOUT_MINUTES = 60;
 const DEFAULT_MAX_CHECKS = 1_000;
 const MAX_CHECKS = 1_000;
 const MAX_OBSERVATION_CHARS = 8_000;
@@ -17,6 +20,7 @@ type MonitorInput = {
   reportWhen?: string;
   stopWhen?: string;
   maxChecks?: number;
+  checkTimeoutMinutes?: number;
 };
 
 type MonitorConfig = {
@@ -25,6 +29,7 @@ type MonitorConfig = {
   reportWhen: string;
   stopWhen: string;
   maxChecks: number;
+  checkTimeoutMinutes: number;
 };
 
 type MonitorRoute = "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report";
@@ -81,6 +86,17 @@ function prepareInput(input: unknown): MonitorConfig {
   if (!Number.isInteger(maxChecks) || maxChecks <= 0 || maxChecks > MAX_CHECKS) {
     throw new Error(`maxChecks must be an integer from 1 through ${MAX_CHECKS}`);
   }
+  const checkTimeoutMinutes =
+    value.checkTimeoutMinutes ?? Math.max(DEFAULT_MIN_CHECK_TIMEOUT_MINUTES, value.everyMinutes);
+  if (
+    !Number.isInteger(checkTimeoutMinutes) ||
+    checkTimeoutMinutes < MIN_CHECK_TIMEOUT_MINUTES ||
+    checkTimeoutMinutes > MAX_CHECK_TIMEOUT_MINUTES
+  ) {
+    throw new Error(
+      `checkTimeoutMinutes must be an integer from ${MIN_CHECK_TIMEOUT_MINUTES} through ${MAX_CHECK_TIMEOUT_MINUTES}`,
+    );
+  }
   return {
     task,
     everyMinutes: value.everyMinutes,
@@ -93,11 +109,16 @@ function prepareInput(input: unknown): MonitorConfig {
         ? "The user cancels the monitor or it reaches its maximum check count."
         : requireBoundedString(value.stopWhen, "stopWhen", 4_000),
     maxChecks,
+    checkTimeoutMinutes,
   };
 }
 
 function configFrom(outputs: Record<string, unknown>): MonitorConfig {
   return outputs.prepare as MonitorConfig;
+}
+
+function agentTimeoutMs({ outputs }: WorkflowNodeContext): number {
+  return configFrom(outputs).checkTimeoutMinutes * 60_000;
 }
 
 function completedChecks(context: WorkflowNodeContext): number {
@@ -190,6 +211,7 @@ export default defineWorkflow({
     }),
     check: agent({
       statusDetail: "checking monitored target",
+      timeoutMs: agentTimeoutMs,
       prompt: (context) => {
         const config = configFrom(context.outputs);
         const previous = context.outputs.check as MonitorCheck | undefined;
@@ -212,12 +234,14 @@ export default defineWorkflow({
     }),
     report_continue: agent({
       statusDetail: "reporting monitor update",
+      timeoutMs: agentTimeoutMs,
       prompt: ({ outputs }) => reportPrompt(outputs),
       expectedOutput: '{ "reported": true }',
       validate: (output) => validateReportAck(output),
     }),
     report_stop: agent({
       statusDetail: "reporting final monitor update",
+      timeoutMs: agentTimeoutMs,
       prompt: ({ outputs }) => reportPrompt(outputs),
       expectedOutput: '{ "reported": true }',
       validate: (output) => validateReportAck(output),

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -33,6 +33,8 @@ export type ConversationStepExecutorOptions = {
   maxNudges?: number;
   /** Conversation linkage hooks, wired to the session recorder. */
   conversation?: ConversationHooks;
+  /** Called when the engine aborts a pending agent step. */
+  onAbort?: (contract: AgentStepRequest["contract"], reason: unknown) => void;
 };
 
 type PendingStep = {
@@ -61,6 +63,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
   private readonly sendPrompt: (delivery: PromptDelivery) => void;
   private readonly maxNudges: number;
   private readonly conversation: ConversationHooks | undefined;
+  private readonly onAbort: ConversationStepExecutorOptions["onAbort"];
   private pending: PendingStep | null = null;
   private streaming = false;
   private heldByUser = false;
@@ -69,6 +72,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     this.sendPrompt = options.sendPrompt;
     this.maxNudges = options.maxNudges ?? DEFAULT_MAX_NUDGES;
     this.conversation = options.conversation;
+    this.onAbort = options.onAbort;
   }
 
   /** Track agent streaming state (wire to agent_start / agent_settled). */
@@ -121,8 +125,15 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     return await new Promise<AgentStepSubmission>((resolve, reject) => {
       const onAbort = () => {
         const reason: unknown = signal.reason ?? new Error("Workflow step aborted");
+        if (this.pending?.request !== request) {
+          return;
+        }
         this.clearPending();
-        reject(reason);
+        try {
+          this.onAbort?.(request.contract, reason);
+        } finally {
+          reject(reason);
+        }
       };
       signal.addEventListener("abort", onAbort, { once: true });
       let markCleared!: () => void;

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -772,7 +772,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           contract,
           reason: reason instanceof TimeoutError ? "timed out" : `ended: ${errorMessage(reason)}`,
         };
-        if (!ctx.isIdle()) {
+        if (!executor.held && !ctx.isIdle()) {
           systemTurnAbort = contract;
           ctx.abort();
         }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -8,7 +8,12 @@ import {
 import type { JsonObject } from "../controllers/types.js";
 import type { WorkflowSchedulerResult } from "../controllers/workflows.js";
 import { WorkflowEngine } from "../workflows/engine.js";
-import { ClaimLostError, errorMessage, isClaimLostError } from "../workflows/errors.js";
+import {
+  ClaimLostError,
+  errorMessage,
+  isClaimLostError,
+  TimeoutError,
+} from "../workflows/errors.js";
 import {
   discoverWorkflows,
   hashWorkflowSource,
@@ -24,6 +29,7 @@ import {
   createDefinitionSnapshot,
 } from "../workflows/store.js";
 import type {
+  AgentStepContract,
   WorkflowDefinition,
   WorkflowDefinitionSnapshot,
   WorkflowRunResult,
@@ -348,6 +354,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
     runSyncTimer.unref?.();
   };
   let activeRun: ActiveRun | null = null;
+  let systemTurnAbort: AgentStepContract | null = null;
+  let lastExpiredAttempt: { contract: AgentStepContract; reason: string } | null = null;
   let pendingToolLaunch: {
     ctx: ExtensionContext;
     ref: string;
@@ -506,7 +514,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (
       sessionClosed ||
       run.generation !== runGeneration ||
-      state.status === "cancelled" ||
+      (state.status !== "completed" && state.status !== "waiting") ||
       run.presentationPrompt === undefined
     ) {
       return;
@@ -639,7 +647,9 @@ export default function piWorkflows(pi: ExtensionAPI) {
     const summary =
       state.status === "waiting" && state.waitingOn
         ? `Workflow ${state.workflowName} parked at checkpoint ${state.waitingOn} — answer with /workflow answer <json> (run ${state.runId})`
-        : `Workflow ${state.workflowName} ${state.status} (run ${state.runId})`;
+        : `Workflow ${state.workflowName} ${state.status} (run ${state.runId})${
+            state.error !== undefined ? `: ${state.error.slice(0, MAX_STATUS_ERROR_CHARS)}` : ""
+          }`;
     notify(ctx, summary, state.status === "completed" ? "info" : "warning");
     try {
       const childResult =
@@ -756,6 +766,16 @@ export default function piWorkflows(pi: ExtensionAPI) {
     const executor = new ConversationStepExecutor({
       sendPrompt: ({ prompt, streaming }) => {
         pi.sendUserMessage(prompt, streaming ? { deliverAs: "steer" } : undefined);
+      },
+      onAbort: (contract, reason) => {
+        lastExpiredAttempt = {
+          contract,
+          reason: reason instanceof TimeoutError ? "timed out" : `ended: ${errorMessage(reason)}`,
+        };
+        if (!ctx.isIdle()) {
+          systemTurnAbort = contract;
+          ctx.abort();
+        }
       },
       conversation: {
         beginAttempt: (contract) => run.recorder?.beginAttempt(contract),
@@ -1563,6 +1583,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
         }
         case "submit": {
           if (!activeRun) {
+            if (
+              lastExpiredAttempt?.contract.attemptId === params.attempt &&
+              lastExpiredAttempt.contract.nodeId === params.step
+            ) {
+              throw new Error(
+                `Workflow step ${JSON.stringify(params.step)} attempt ${JSON.stringify(params.attempt)} ${lastExpiredAttempt.reason}; its output is no longer accepted.`,
+              );
+            }
             throw new Error("No workflow step is waiting for output.");
           }
           // Flush the conversation into the bundle before accepting, so the
@@ -1632,13 +1660,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_end", (event, ctx) => {
-    const run = activeRun;
-    if (!run) {
-      return;
-    }
-    // An aborted turn means the user hit escape to take the conversation
-    // back. Nudging or dispatching the next step would immediately steal it
-    // again, so hold the run until an explicit /workflow resume.
     const aborted = event.messages.some(
       (message) =>
         typeof message === "object" &&
@@ -1646,6 +1667,17 @@ export default function piWorkflows(pi: ExtensionAPI) {
         "stopReason" in message &&
         (message as { stopReason?: string }).stopReason === "aborted",
     );
+    if (aborted && systemTurnAbort !== null) {
+      systemTurnAbort = null;
+      return;
+    }
+    const run = activeRun;
+    if (!run) {
+      return;
+    }
+    // An aborted turn means the user hit escape to take the conversation
+    // back. Nudging or dispatching the next step would immediately steal it
+    // again, so hold the run until an explicit /workflow resume.
     if (!aborted || runHeld()) {
       return;
     }
@@ -1719,6 +1751,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async () => {
     sessionClosed = true;
+    systemTurnAbort = null;
     supersedePresentation();
     const run = activeRun;
     if (run !== null && run.claimToken !== undefined) {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -39,6 +39,7 @@ import type {
 const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_MAX_STEPS = 100;
 const TITLE_TIMEOUT_MS = 30_000;
+const TIMEOUT_RESOLUTION_TIMEOUT_MS = 30_000;
 // Covers the shell SIGTERM → SIGKILL escalation (1s) plus stdio close.
 const ABORT_CLEANUP_GRACE_MS = 2_000;
 
@@ -758,36 +759,43 @@ export class WorkflowEngine {
     node: WorkflowNodeDefinition,
     meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
-    const timeoutMs = node.timeoutMs ?? this.defaultNodeTimeoutMs;
     const abort = new AbortController();
+    const context = this.createNodeContext(state, abort.signal);
+    let timer: NodeJS.Timeout | undefined;
+    let dispatchSettled: Promise<void> | undefined;
     this.activeAbort = abort;
-    if (this.parked) {
-      // A park that landed during the node_started persist must not let the
-      // node dispatch: its discarded side effects would rerun on resume.
-      throw new RunParkedError();
-    }
-    if (this.cancelled) {
-      throw new CancelledError();
-    }
-
-    const timer = setTimeout(() => {
-      abort.abort(new TimeoutError(timeoutMs));
-    }, timeoutMs);
-    const dispatched = this.dispatchNode(
-      workflow,
-      state,
-      runDir,
-      nodeId,
-      attemptId,
-      node,
-      abort.signal,
-      meta,
-    );
-    const dispatchSettled = dispatched.then(
-      () => undefined,
-      () => undefined,
-    );
     try {
+      if (this.parked) {
+        // A park that landed during the node_started persist must not let the
+        // node dispatch: its discarded side effects would rerun on resume.
+        throw new RunParkedError();
+      }
+      if (this.cancelled) {
+        throw new CancelledError();
+      }
+
+      const timeoutMs = await this.resolveNodeTimeout(node, context, abort);
+      if (abort.signal.aborted) {
+        throw abortError(abort.signal);
+      }
+      timer = setTimeout(() => {
+        abort.abort(new TimeoutError(timeoutMs));
+      }, timeoutMs);
+      const dispatched = this.dispatchNode(
+        workflow,
+        state,
+        runDir,
+        nodeId,
+        attemptId,
+        node,
+        context,
+        abort.signal,
+        meta,
+      );
+      dispatchSettled = dispatched.then(
+        () => undefined,
+        () => undefined,
+      );
       // Race the dispatch against the abort signal so timeouts and cancel
       // take effect even for node callbacks that never observe the signal.
       const execution = await Promise.race([dispatched, abortRejection(abort.signal)]);
@@ -799,7 +807,7 @@ export class WorkflowEngine {
       assertJsonSerializable(execution.output, `Node ${nodeId} output`);
       return execution;
     } catch (error) {
-      if (node.nodeType === "action" && "exec" in node) {
+      if (node.nodeType === "action" && "exec" in node && dispatchSettled !== undefined) {
         // Give the killed shell command a short grace period to close so its
         // action receipt lands in `meta` before the failed attempt persists.
         await Promise.race([
@@ -810,8 +818,36 @@ export class WorkflowEngine {
       const reason: unknown = abort.signal.aborted ? abort.signal.reason : undefined;
       throw reason instanceof TimeoutError || reason instanceof CancelledError ? reason : error;
     } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      if (this.activeAbort === abort) {
+        this.activeAbort = null;
+      }
+    }
+  }
+
+  private async resolveNodeTimeout(
+    node: WorkflowNodeDefinition,
+    context: WorkflowNodeContext,
+    abort: AbortController,
+  ): Promise<number> {
+    const configured = node.timeoutMs;
+    if (typeof configured !== "function") {
+      return assertValidTimeout(configured ?? this.defaultNodeTimeoutMs);
+    }
+    const timer = setTimeout(
+      () => abort.abort(new TimeoutError(TIMEOUT_RESOLUTION_TIMEOUT_MS)),
+      TIMEOUT_RESOLUTION_TIMEOUT_MS,
+    );
+    try {
+      const resolved = await Promise.race([
+        Promise.resolve(configured(context)),
+        abortRejection(abort.signal),
+      ]);
+      return assertValidTimeout(resolved);
+    } finally {
       clearTimeout(timer);
-      this.activeAbort = null;
     }
   }
 
@@ -822,10 +858,10 @@ export class WorkflowEngine {
     nodeId: string,
     attemptId: string,
     node: WorkflowNodeDefinition,
+    context: WorkflowNodeContext,
     signal: AbortSignal,
     meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
-    const context = this.createNodeContext(state, signal);
     switch (node.nodeType) {
       case "agent":
         return await this.runAgentNode(
@@ -1044,7 +1080,13 @@ async function runShellActionNode(
   return { output, promptText: null, action: shellReceipt(result) };
 }
 
-/** Rejects with the abort reason once the signal fires; never resolves. */
+function assertValidTimeout(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("Node timeoutMs must resolve to a finite positive number");
+  }
+  return value;
+}
+
 /** The error carried by an aborted signal, normalized to an Error. */
 function abortError(signal: AbortSignal): Error {
   const reason: unknown = signal.reason ?? new CancelledError();

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -34,9 +34,10 @@ function assertOptionalFunction(value: unknown, description: string): void {
 function assertCommonNodeFields(node: WorkflowNodeDefinition, nodeId: string): void {
   if (
     node.timeoutMs !== undefined &&
+    typeof node.timeoutMs !== "function" &&
     (typeof node.timeoutMs !== "number" || !Number.isFinite(node.timeoutMs) || node.timeoutMs <= 0)
   ) {
-    fail(`node ${nodeId} timeoutMs must be a finite positive number`);
+    fail(`node ${nodeId} timeoutMs must be a finite positive number or function`);
   }
   if (node.statusDetail !== undefined && typeof node.statusDetail !== "string") {
     fail(`node ${nodeId} statusDetail must be a string`);

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1317,7 +1317,7 @@ export function createDefinitionSnapshot(workflow: WorkflowDefinition): Workflow
 function snapshotNode(node: WorkflowNodeDefinition): WorkflowNodeSnapshot {
   const common: WorkflowNodeSnapshot = {
     nodeType: node.nodeType,
-    ...(node.timeoutMs !== undefined ? { timeoutMs: node.timeoutMs } : {}),
+    ...(typeof node.timeoutMs === "number" ? { timeoutMs: node.timeoutMs } : {}),
     ...(node.statusDetail !== undefined ? { statusDetail: node.statusDetail } : {}),
   };
   if (node.nodeType === "agent" && node.expectedOutput !== undefined) {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -20,8 +20,11 @@ export type WorkflowNodeContext<TInput = unknown> = {
 };
 
 export type WorkflowNodeCommon = {
-  /** Per-node timeout. Falls back to the engine default (15 minutes). */
-  timeoutMs?: number;
+  /**
+   * Per-node timeout or a callback that derives it from the run context.
+   * Falls back to the engine default (15 minutes).
+   */
+  timeoutMs?: number | ((context: WorkflowNodeContext) => MaybePromise<number>);
   /** Short human-readable label shown in the viewer while the node runs. */
   statusDetail?: string;
 };

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -78,6 +78,21 @@ export default defineWorkflow({
 });
 `;
 
+const TIMEOUT_E2E_WORKFLOW = `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "timeout-e2e",
+  startAt: "work",
+  nodes: {
+    work: agent({
+      prompt: () => "Try to write the timeout marker.",
+      timeoutMs: 50,
+    }),
+  },
+  edges: [],
+});
+`;
+
 const E2E_WORKFLOW = `import { agent, decision, decisionEdge, defineWorkflow, shell } from "@osolmaz/pi-workflows";
 
 const choices = ["y", "n"] as const;
@@ -239,6 +254,7 @@ describe.sequential("pi-workflows end to end", () => {
   let agentDir: string;
   let controllerDir: string;
   let controllerFile: string;
+  let timeoutMarker: string;
 
   beforeAll(async () => {
     // The scripted "model": answers each workflow step contract through the
@@ -322,6 +338,19 @@ describe.sequential("pi-workflows end to end", () => {
             },
           };
         }
+        const timeoutStepMatch = lastUserText.match(
+          /workflow step contract \(workflow: timeout-e2e, step: work, attempt: ([a-z0-9-]+)\)/i,
+        );
+        if (timeoutStepMatch) {
+          return {
+            kind: "tool",
+            toolName: "write",
+            args: {
+              path: timeoutMarker,
+              content: "This tool call must not finish after the workflow timeout.",
+            },
+          };
+        }
         const hostStepMatch = lastUserText.match(
           /workflow step contract \(workflow: host-e2e, step: ([a-z_]+), attempt: ([a-z0-9-]+)\)/i,
         );
@@ -357,12 +386,18 @@ describe.sequential("pi-workflows end to end", () => {
       controllerProjectScope(projectDir),
       "controller.sqlite",
     );
+    timeoutMarker = path.join(projectDir, "timeout-marker.txt");
 
     await fs.mkdir(path.join(projectDir, ".pi", "workflows"), { recursive: true });
     await fs.mkdir(path.join(projectDir, ".pi", "controllers"), { recursive: true });
     await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "e2e.workflow.ts"),
       E2E_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "timeout-e2e.workflow.ts"),
+      TIMEOUT_E2E_WORKFLOW,
       "utf8",
     );
     await fs.writeFile(
@@ -691,6 +726,20 @@ describe.sequential("pi-workflows end to end", () => {
       Promise.all(terminalFiles.map((file) => fs.readFile(path.join(runDir, file), "utf8"))),
     ).resolves.toEqual(terminalContents);
   }, 120_000);
+
+  it("stops the real Pi turn when an agent node times out", async () => {
+    pi.send({ id: "timeout-1", type: "prompt", message: "/workflow timeout-e2e" });
+
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) => candidate.workflowName === "timeout-e2e" && candidate.status === "timed_out",
+      () => `${pi.stderr()}\n${pi.stdoutLines.join("\n")}`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(state.results.work?.outcome).toBe("timed_out");
+    await expect(fs.stat(timeoutMarker)).rejects.toThrow();
+  }, 90_000);
 
   it("starts the built-in monitor from the model-facing workflow tool", async () => {
     pi.send({ id: "monitor-1", type: "prompt", message: "Start the built-in monitor now." });

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -316,6 +316,44 @@ describe("WorkflowEngine", () => {
     expect(state.results.ask?.outcome).toBe("timed_out");
   });
 
+  it("resolves a node timeout from run context", async () => {
+    const workflow = defineWorkflow({
+      name: "derived-timeout",
+      startAt: "ask",
+      nodes: {
+        ask: agent({
+          prompt: () => "?",
+          timeoutMs: ({ input }) => (input as { timeoutMs: number }).timeoutMs,
+        }),
+      },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { hang: true });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, { timeoutMs: 25 });
+
+    expect(state.status).toBe("timed_out");
+    expect(state.results.ask?.durationMs).toBeGreaterThanOrEqual(20);
+  });
+
+  it("fails before dispatch when a derived timeout is invalid", async () => {
+    const workflow = defineWorkflow({
+      name: "bad-derived-timeout",
+      startAt: "ask",
+      nodes: { ask: agent({ prompt: () => "?", timeoutMs: () => 0 }) },
+      edges: [],
+    });
+    const executor = new ScriptedExecutor().respond("ask", { output: {} });
+    const { engine } = await makeEngine(executor);
+
+    const { state } = await engine.run(workflow, {});
+
+    expect(state.status).toBe("failed");
+    expect(state.error).toMatch(/timeoutMs must resolve to a finite positive number/);
+    expect(executor.requests).toHaveLength(0);
+  });
+
   it("supports cancel() while an agent step is pending", async () => {
     const workflow = defineWorkflow({
       name: "cancellable",

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -137,6 +137,24 @@ describe("ConversationStepExecutor", () => {
     expect(executor.pendingStepId).toBeNull();
   });
 
+  it("reports an engine abort exactly once", async () => {
+    const aborted: { attemptId: string; reason: unknown }[] = [];
+    const abort = new AbortController();
+    const executor = new ConversationStepExecutor({
+      sendPrompt: () => undefined,
+      onAbort: (contract, reason) => aborted.push({ attemptId: contract.attemptId, reason }),
+    });
+    const stepPromise = executor.runAgentStep(makeRequest(), abort.signal);
+
+    abort.abort(new Error("timed out"));
+    abort.abort(new Error("again"));
+
+    await expect(stepPromise).rejects.toThrow(/timed out/);
+    expect(aborted).toHaveLength(1);
+    expect(aborted[0]?.attemptId).toBe("a1");
+    expect(aborted[0]?.reason).toEqual(new Error("timed out"));
+  });
+
   it("rejects immediately when the signal is already aborted", async () => {
     const { executor, sent } = makeExecutor();
     const abort = new AbortController();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -793,6 +793,34 @@ export default defineWorkflow({
     }
   });
 
+  it("does not abort a later user turn after Escape holds the workflow", async () => {
+    const cwd = await makeTempDir("pi-workflows-held-timeout");
+    const runsDir = await makeTempDir("pi-workflows-held-timeout-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeTimeoutWorkflow(cwd);
+      let promptDelivered = false;
+      const harness = makeHarness({
+        cwd,
+        respond: () => {
+          promptDelivered = true;
+        },
+      });
+
+      await harness.command.handler("timeout", harness.ctx);
+      await waitFor(() => promptDelivered);
+      await harness.emitAsync("agent_end", { messages: [{ stopReason: "aborted" }] });
+      expect(harness.notifications.at(-1)).toContain("paused (turn interrupted)");
+      harness.setIdle(false);
+
+      await waitFor(() => harness.notifications.some((note) => note.includes("timed_out")));
+
+      expect(harness.abortCalls).toBe(0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("does not present cancelled runs", async () => {
     const cwd = await makeTempDir("pi-workflows-ext");
     const runsDir = await makeTempDir("pi-workflows-ext-runs");

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -43,6 +43,8 @@ type SentMessage = {
 type FakeContext = {
   cwd: string;
   hasUI: boolean;
+  isIdle: () => boolean;
+  abort: () => void;
   sessionManager: {
     getSessionId: () => string;
     getLeafId: () => string | null;
@@ -76,10 +78,17 @@ function makeHarness(options: {
   const shortcuts = new Map<string, (ctx: FakeContext) => void>();
   const commands = new Map<string, RegisteredCommand>();
   let tool: RegisteredTool | null = null;
+  let idle = true;
+  let abortCalls = 0;
 
   const ctx: FakeContext = {
     cwd: options.cwd,
     hasUI: true,
+    isIdle: () => idle,
+    abort: () => {
+      abortCalls += 1;
+      idle = true;
+    },
     sessionManager: {
       getSessionId: () => options.sessionId ?? "test-session",
       getLeafId: () => null,
@@ -119,6 +128,7 @@ function makeHarness(options: {
     },
     sendUserMessage: (prompt: string) => {
       // Deliver asynchronously like the real runtime would.
+      idle = false;
       queueMicrotask(() => options.respond(prompt, tool as RegisteredTool));
     },
     sendMessage: (message: SentMessage["message"], messageOptions: SentMessage["options"]) => {
@@ -137,6 +147,12 @@ function makeHarness(options: {
     widgets,
     statuses,
     sentMessages,
+    get abortCalls() {
+      return abortCalls;
+    },
+    setIdle: (value: boolean) => {
+      idle = value;
+    },
     command: workflowCommand,
     commands,
     tool: tool as RegisteredTool,
@@ -170,6 +186,25 @@ export default defineWorkflow({
       expectedOutput: '{ "reply": "…" }',
     }),
   },
+  edges: [],
+});
+`,
+    "utf8",
+  );
+}
+
+async function writeTimeoutWorkflow(cwd: string): Promise<void> {
+  const dir = path.join(cwd, ".pi", "workflows");
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "timeout.workflow.ts"),
+    `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "timeout",
+  presentationPrompt: () => { throw new Error("must not present failed run"); },
+  startAt: "wait",
+  nodes: { wait: agent({ prompt: () => "Wait.", timeoutMs: 30 }) },
   edges: [],
 });
 `,
@@ -707,6 +742,52 @@ export default defineWorkflow({
 
       expect(harness.notifications.some((note) => note.includes("completed"))).toBe(true);
       expect(harness.sentMessages).toHaveLength(0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("aborts a timed-out Pi turn without treating it as a user interruption", async () => {
+    const cwd = await makeTempDir("pi-workflows-timeout");
+    const runsDir = await makeTempDir("pi-workflows-timeout-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeTimeoutWorkflow(cwd);
+      let contract: { step: string; attempt: string } | null = null;
+      const harness = makeHarness({
+        cwd,
+        respond: (prompt) => {
+          contract = stepFromPrompt(prompt);
+        },
+      });
+
+      await harness.command.handler("timeout", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("timed_out")));
+      expect(harness.abortCalls).toBe(1);
+      expect(contract).not.toBeNull();
+
+      await harness.emitAsync("agent_end", { messages: [{ stopReason: "aborted" }] });
+      expect(harness.notifications.some((note) => note.includes("paused (turn interrupted)"))).toBe(
+        false,
+      );
+      expect(harness.notifications.some((note) => note.includes("must not present"))).toBe(false);
+      expect(harness.sentMessages).toHaveLength(0);
+
+      const capturedContract = contract as unknown as {
+        step: string;
+        attempt: string;
+      } | null;
+      if (capturedContract === null) {
+        throw new Error("workflow contract was not captured");
+      }
+      await expect(
+        harness.tool.execute("late-submit", {
+          action: "submit",
+          step: capturedContract.step,
+          attempt: capturedContract.attempt,
+          output: { too: "late" },
+        }),
+      ).rejects.toThrow(/timed out; its output is no longer accepted/);
     } finally {
       vi.unstubAllEnvs();
     }

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -281,6 +281,56 @@ describe("built-in monitor workflow", () => {
     });
   });
 
+  it("derives agent timeouts from the prepared monitor configuration", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-monitor-timeout");
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([
+        {
+          route: "stop_quiet",
+          observation: "Initial state",
+          reason: "Test complete",
+        },
+      ]),
+      store: new WorkflowRunStore(outputRoot),
+    });
+    const result = await engine.run(monitor, monitorInput({ checkTimeoutMinutes: 90 }));
+    const context: WorkflowNodeContext = {
+      input: result.state.input,
+      outputs: result.state.outputs,
+      results: result.state.results,
+      state: result.state,
+      signal: new AbortController().signal,
+    };
+
+    for (const nodeId of ["check", "report_continue", "report_stop"] as const) {
+      const node = monitor.nodes[nodeId] as AgentNodeDefinition;
+      expect(node.timeoutMs).toBeTypeOf("function");
+      expect(await (node.timeoutMs as (context: WorkflowNodeContext) => number)(context)).toBe(
+        90 * 60_000,
+      );
+    }
+    expect(result.state.outputs.prepare).toMatchObject({ checkTimeoutMinutes: 90 });
+  });
+
+  it("defaults the agent timeout to at least 60 minutes", async () => {
+    const prepare = monitor.nodes.prepare as ComputeNodeDefinition;
+    const state = {
+      steps: [],
+    } as never;
+    const context = {
+      input: monitorInput({ everyMinutes: 30 }),
+      outputs: {},
+      results: {},
+      state,
+      signal: new AbortController().signal,
+    } satisfies WorkflowNodeContext;
+
+    expect(await prepare.run(context)).toMatchObject({ checkTimeoutMinutes: 60 });
+    expect(() =>
+      prepare.run({ ...context, input: monitorInput({ checkTimeoutMinutes: 4 }) }),
+    ).toThrow(/checkTimeoutMinutes/);
+  });
+
   it("configures a 30-minute shell sleep above both timeout limits", async () => {
     const outputRoot = await makeTempDir("pi-workflows-monitor-sleep");
     const engine = new WorkflowEngine({

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -100,6 +100,7 @@ describe("node constructors", () => {
     );
     expect(() => agent({ prompt: () => "p", validate: "x" as never })).toThrow(/validate/);
     expect(() => agent({ prompt: () => "p", timeoutMs: -1 })).toThrow(/timeoutMs/);
+    expect(agent({ prompt: () => "p", timeoutMs: () => 1 }).timeoutMs).toBeTypeOf("function");
     expect(() => agent({ prompt: () => "p", statusDetail: 1 as never })).toThrow(/statusDetail/);
     expect(agent({ prompt: () => "p" }).nodeType).toBe("agent");
   });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { agent, compute, defineWorkflow } from "../src/workflows/definition.js";
 import {
   WorkflowRunStore,
   createDefinitionSnapshot,
@@ -54,6 +54,19 @@ describe("workflowRunsBaseDir", () => {
 });
 
 describe("WorkflowRunStore", () => {
+  it("omits computed timeouts from the portable definition snapshot", () => {
+    const snapshot = createDefinitionSnapshot(
+      defineWorkflow({
+        name: "computed-timeout",
+        startAt: "one",
+        nodes: { one: agent({ prompt: () => "?", timeoutMs: () => 60_000 }) },
+        edges: [],
+      }),
+    );
+
+    expect(snapshot.nodes.one?.timeoutMs).toBeUndefined();
+  });
+
   it("initializes and updates a run bundle", async () => {
     const outputRoot = await makeTempDir("pi-workflows-store");
     const store = new WorkflowRunStore(outputRoot);


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A workflow agent step could time out while its Pi turn kept running.
The model could then continue to use tools and submit output after the workflow had already failed.
This change makes the workflow deadline stop the matching Pi turn, gives monitor checks a suitable configurable deadline, and keeps failed runs out of the normal result presenter.

## What Changed

The extension now owns the full lifetime of each workflow agent turn.
Engine timeouts, cancellation, parking, and claim loss abort the active Pi turn, while a user Escape still pauses the workflow for manual resume.

- Added an executor abort hook and classified system-driven turn aborts separately from user interrupts.
- Added clear rejection text for late submissions from an expired attempt.
- Let nodes set `timeoutMs` from the normal workflow context, with bounded resolution and runtime validation.
- Added monitor `checkTimeoutMinutes`; it defaults to the larger of 60 minutes and the monitor interval.
- Applied the monitor timeout to check and report nodes.
- Limited normal result presentation to completed and waiting runs.
- Included persisted terminal errors in direct workflow notifications.
- Added unit, integration, and real Pi RPC regression tests.

## Testing

The full local quality gate and the real Pi end-to-end suite pass.
The new RPC test verifies that a timed-out model stream cannot finish a later tool call.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`

`npx -y @simpledoc/simpledoc check` still reports the repository's 10 existing legacy document migrations. The new dated plan is valid, and this change does not migrate unrelated documents.

## Risks

The main risk is abort classification around Pi lifecycle events.
The implementation uses Pi's public `ctx.abort()` and `ctx.isIdle()` APIs, and tests cover both system timeout aborts and normal user Escape behavior.

Computed timeout callbacks are runtime code and cannot be serialized. Definition snapshots therefore keep fixed numeric timeouts and omit computed callbacks, without changing the persisted schema.
