### PR TITLE
fix: load built-in workflows atomically

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -16,7 +16,10 @@ Files are discovered by suffix (`.workflow.ts`, `.workflow.js`, `.workflow.mts`,
 3. Workflows built into Pi Workflows
 
 Pi Workflows includes a built-in `monitor` workflow. A project or global file
-named `monitor.workflow.ts` replaces it.
+named `monitor.workflow.ts` replaces it. Built-ins are loaded with the engine
+when a Pi process starts. Updating the package on disk cannot mix a new
+built-in with that process's old engine; reload or restart Pi to use the new
+built-in. Project and global workflow files still reload on each run.
 
 The workflow's command name is the file stem, so `.pi/workflows/triage.workflow.ts`
 runs as `/workflow triage`. A direct path also works: `/workflow ./somewhere/x.workflow.ts`.

--- a/src/workflows/builtin-registry.ts
+++ b/src/workflows/builtin-registry.ts
@@ -20,27 +20,28 @@ export function captureBuiltinWorkflows(candidates: BuiltinWorkflowCandidate[]):
   byPath: Map<string, BuiltinWorkflow>;
 } {
   const byName = new Map<string, BuiltinWorkflow>();
+  const byPath = new Map<string, BuiltinWorkflow>();
   for (const candidate of candidates) {
-    const modulePath = candidate.candidatePaths
-      .map((filePath) => {
-        try {
-          return { filePath, source: readFileSync(filePath) };
-        } catch {
-          return undefined;
-        }
-      })
-      .find((file) => file !== undefined);
-    if (modulePath === undefined) {
+    const moduleFiles = candidate.candidatePaths.flatMap((filePath) => {
+      try {
+        return [{ filePath, source: readFileSync(filePath) }];
+      } catch {
+        return [];
+      }
+    });
+    const moduleFile = moduleFiles[0];
+    if (moduleFile === undefined) {
       throw new Error(`Built-in workflow module is missing: ${candidate.name}`);
     }
-    byName.set(candidate.name, {
+    const workflow = {
       definition: candidate.definition,
-      path: modulePath.filePath,
-      sourceHash: createHash("sha256").update(modulePath.source).digest("hex"),
-    });
+      path: moduleFile.filePath,
+      sourceHash: createHash("sha256").update(moduleFile.source).digest("hex"),
+    };
+    byName.set(candidate.name, workflow);
+    for (const file of moduleFiles) {
+      byPath.set(file.filePath, workflow);
+    }
   }
-  return {
-    byName,
-    byPath: new Map([...byName.values()].map((workflow) => [workflow.path, workflow])),
-  };
+  return { byName, byPath };
 }

--- a/src/workflows/builtin-registry.ts
+++ b/src/workflows/builtin-registry.ts
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { WorkflowDefinition } from "./types.js";
+
+export type BuiltinWorkflow = {
+  definition: WorkflowDefinition;
+  path: string;
+  sourceHash: string;
+};
+
+export type BuiltinWorkflowCandidate = {
+  name: string;
+  definition: WorkflowDefinition;
+  candidatePaths: string[];
+};
+
+/** Capture built-in definitions and source hashes for one process version. */
+export function captureBuiltinWorkflows(candidates: BuiltinWorkflowCandidate[]): {
+  byName: Map<string, BuiltinWorkflow>;
+  byPath: Map<string, BuiltinWorkflow>;
+} {
+  const byName = new Map<string, BuiltinWorkflow>();
+  for (const candidate of candidates) {
+    const modulePath = candidate.candidatePaths
+      .map((filePath) => {
+        try {
+          return { filePath, source: readFileSync(filePath) };
+        } catch {
+          return undefined;
+        }
+      })
+      .find((file) => file !== undefined);
+    if (modulePath === undefined) {
+      throw new Error(`Built-in workflow module is missing: ${candidate.name}`);
+    }
+    byName.set(candidate.name, {
+      definition: candidate.definition,
+      path: modulePath.filePath,
+      sourceHash: createHash("sha256").update(modulePath.source).digest("hex"),
+    });
+  }
+  return {
+    byName,
+    byPath: new Map([...byName.values()].map((workflow) => [workflow.path, workflow])),
+  };
+}

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
+import { captureBuiltinWorkflows } from "./builtin-registry.js";
 import { isWorkflowDefinition } from "./definition.js";
 import monitorWorkflow from "./monitor.workflow.js";
 import type { WorkflowDefinition } from "./types.js";
@@ -24,42 +24,17 @@ export type WorkflowSearchPaths = {
 
 const BUILTIN_DIR = fileURLToPath(new URL("./", import.meta.url));
 
-type BuiltinWorkflow = {
-  definition: WorkflowDefinition;
-  path: string;
-  sourceHash: string;
-};
-
-function builtinWorkflow(name: string, definition: WorkflowDefinition): BuiltinWorkflow {
-  const modulePath = WORKFLOW_FILE_SUFFIXES.map((suffix) =>
-    path.join(BUILTIN_DIR, `${name}${suffix}`),
-  )
-    .map((candidate) => {
-      try {
-        return { candidate, source: readFileSync(candidate) };
-      } catch {
-        return undefined;
-      }
-    })
-    .find((candidate) => candidate !== undefined);
-  if (modulePath === undefined) {
-    throw new Error(`Built-in workflow module is missing: ${name}`);
-  }
-  return {
-    definition,
-    path: modulePath.candidate,
-    sourceHash: createHash("sha256").update(modulePath.source).digest("hex"),
-  };
-}
-
 // Capture each built-in definition and source hash when this module loads.
 // Later package updates cannot mix new files with this process's old engine.
-const BUILTIN_WORKFLOWS = new Map<string, BuiltinWorkflow>([
-  ["monitor", builtinWorkflow("monitor", monitorWorkflow)],
+const { byName: BUILTIN_WORKFLOWS, byPath: BUILTIN_WORKFLOWS_BY_PATH } = captureBuiltinWorkflows([
+  {
+    name: "monitor",
+    definition: monitorWorkflow,
+    candidatePaths: WORKFLOW_FILE_SUFFIXES.map((suffix) =>
+      path.join(BUILTIN_DIR, `monitor${suffix}`),
+    ),
+  },
 ]);
-const BUILTIN_WORKFLOWS_BY_PATH = new Map(
-  [...BUILTIN_WORKFLOWS.values()].map((workflow) => [workflow.path, workflow]),
-);
 
 /** Directories scanned for workflow files, in precedence order. */
 export function workflowSearchDirs(

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import { isWorkflowDefinition } from "./definition.js";
+import monitorWorkflow from "./monitor.workflow.js";
 import type { WorkflowDefinition } from "./types.js";
 
 const WORKFLOW_FILE_SUFFIXES = [".workflow.ts", ".workflow.js", ".workflow.mts", ".workflow.mjs"];
@@ -20,23 +22,66 @@ export type WorkflowSearchPaths = {
   homeDir?: string;
 };
 
+const BUILTIN_DIR = fileURLToPath(new URL("./", import.meta.url));
+
+type BuiltinWorkflow = {
+  definition: WorkflowDefinition;
+  path: string;
+  sourceHash: string;
+};
+
+function builtinWorkflow(name: string, definition: WorkflowDefinition): BuiltinWorkflow {
+  const modulePath = WORKFLOW_FILE_SUFFIXES.map((suffix) =>
+    path.join(BUILTIN_DIR, `${name}${suffix}`),
+  )
+    .map((candidate) => {
+      try {
+        return { candidate, source: readFileSync(candidate) };
+      } catch {
+        return undefined;
+      }
+    })
+    .find((candidate) => candidate !== undefined);
+  if (modulePath === undefined) {
+    throw new Error(`Built-in workflow module is missing: ${name}`);
+  }
+  return {
+    definition,
+    path: modulePath.candidate,
+    sourceHash: createHash("sha256").update(modulePath.source).digest("hex"),
+  };
+}
+
+// Capture each built-in definition and source hash when this module loads.
+// Later package updates cannot mix new files with this process's old engine.
+const BUILTIN_WORKFLOWS = new Map<string, BuiltinWorkflow>([
+  ["monitor", builtinWorkflow("monitor", monitorWorkflow)],
+]);
+const BUILTIN_WORKFLOWS_BY_PATH = new Map(
+  [...BUILTIN_WORKFLOWS.values()].map((workflow) => [workflow.path, workflow]),
+);
+
 /** Directories scanned for workflow files, in precedence order. */
 export function workflowSearchDirs(
   options: WorkflowSearchPaths,
 ): { dir: string; source: "project" | "global" | "builtin" }[] {
   const homeDir = options.homeDir ?? os.homedir();
-  const builtinDir = fileURLToPath(new URL("../builtins/", import.meta.url));
   return [
     { dir: path.join(options.cwd, ".pi", "workflows"), source: "project" },
     { dir: path.join(homeDir, ".pi", "agent", "workflows"), source: "global" },
-    { dir: builtinDir, source: "builtin" },
+    { dir: BUILTIN_DIR, source: "builtin" },
   ];
 }
 
 /** SHA-256 of a workflow source file, recorded in run state for resume pinning. */
 export async function hashWorkflowSource(filePath: string): Promise<string> {
+  const absolutePath = path.resolve(filePath);
+  const builtin = BUILTIN_WORKFLOWS_BY_PATH.get(absolutePath);
+  if (builtin !== undefined) {
+    return builtin.sourceHash;
+  }
   return createHash("sha256")
-    .update(await fs.readFile(filePath))
+    .update(await fs.readFile(absolutePath))
     .digest("hex");
 }
 
@@ -55,9 +100,17 @@ export function workflowFileStem(filePath: string): string {
 // (tests, tsx) or from the built dist inside the installed package.
 const SELF_ENTRY = path.join(path.dirname(fileURLToPath(import.meta.url)), "index");
 
-/** Load a workflow module from disk. The default export must be `defineWorkflow(...)`. */
+/**
+ * Load a workflow definition. Built-ins come from this process's module graph,
+ * so a package update on disk cannot mix a new built-in with old engine code.
+ * User workflow files are reloaded from disk for normal edit-and-run behavior.
+ */
 export async function loadWorkflowFile(filePath: string): Promise<WorkflowDefinition> {
   const absolutePath = path.resolve(filePath);
+  const builtin = BUILTIN_WORKFLOWS_BY_PATH.get(absolutePath);
+  if (builtin !== undefined) {
+    return builtin.definition;
+  }
   const jiti = createJiti(pathToFileURL(absolutePath).href, {
     interopDefault: true,
     moduleCache: false,
@@ -77,7 +130,11 @@ export async function discoverWorkflows(
   const discovered: DiscoveredWorkflow[] = [];
   const seenNames = new Set<string>();
   for (const { dir, source } of workflowSearchDirs(options)) {
-    for (const filePath of await listWorkflowFiles(dir)) {
+    const filePaths =
+      source === "builtin"
+        ? [...BUILTIN_WORKFLOWS.values()].map((workflow) => workflow.path)
+        : await listWorkflowFiles(dir);
+    for (const filePath of filePaths) {
       const name = workflowFileStem(filePath);
       if (seenNames.has(name)) {
         continue;

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -23,6 +23,13 @@ export type WorkflowSearchPaths = {
 };
 
 const BUILTIN_DIR = fileURLToPath(new URL("./", import.meta.url));
+const PACKAGE_ROOT = path.resolve(BUILTIN_DIR, "..", "..");
+
+function builtinCandidatePaths(name: string): string[] {
+  return ["src/workflows", "dist/workflows"].flatMap((dir) =>
+    WORKFLOW_FILE_SUFFIXES.map((suffix) => path.join(PACKAGE_ROOT, dir, `${name}${suffix}`)),
+  );
+}
 
 // Capture each built-in definition and source hash when this module loads.
 // Later package updates cannot mix new files with this process's old engine.
@@ -30,9 +37,7 @@ const { byName: BUILTIN_WORKFLOWS, byPath: BUILTIN_WORKFLOWS_BY_PATH } = capture
   {
     name: "monitor",
     definition: monitorWorkflow,
-    candidatePaths: WORKFLOW_FILE_SUFFIXES.map((suffix) =>
-      path.join(BUILTIN_DIR, `monitor${suffix}`),
-    ),
+    candidatePaths: builtinCandidatePaths("monitor"),
   },
 ]);
 

--- a/src/workflows/monitor.workflow.ts
+++ b/src/workflows/monitor.workflow.ts
@@ -1,4 +1,4 @@
-import { agent, compute, defineWorkflow, shell } from "../workflows/index.js";
+import { agent, compute, defineWorkflow, shell } from "../workflows/definition.js";
 import type { WorkflowNodeContext } from "../workflows/types.js";
 
 const MIN_INTERVAL_MINUTES = 1;

--- a/test/builtin-registry.test.ts
+++ b/test/builtin-registry.test.ts
@@ -16,9 +16,11 @@ describe("captureBuiltinWorkflows", () => {
   it("keeps a definition and source hash stable after its temp file changes", async () => {
     const dir = await makeTempDir("pi-workflows-builtins");
     const filePath = path.join(dir, "fixture.workflow.js");
+    const aliasPath = path.join(dir, "fixture.workflow.ts");
     await fs.writeFile(filePath, "export default 'first';\n", "utf8");
+    await fs.writeFile(aliasPath, "export default 'source alias';\n", "utf8");
     const captured = captureBuiltinWorkflows([
-      { name: "fixture", definition: workflow, candidatePaths: [filePath] },
+      { name: "fixture", definition: workflow, candidatePaths: [filePath, aliasPath] },
     ]);
     const before = captured.byName.get("fixture");
 
@@ -26,6 +28,7 @@ describe("captureBuiltinWorkflows", () => {
 
     expect(before?.definition).toBe(workflow);
     expect(captured.byPath.get(filePath)).toBe(before);
+    expect(captured.byPath.get(aliasPath)).toBe(before);
     expect(captured.byName.get("fixture")?.sourceHash).toBe(before?.sourceHash);
   });
 

--- a/test/builtin-registry.test.ts
+++ b/test/builtin-registry.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { captureBuiltinWorkflows } from "../src/workflows/builtin-registry.js";
+import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { makeTempDir } from "./helpers.js";
+
+const workflow = defineWorkflow({
+  name: "fixture",
+  startAt: "done",
+  nodes: { done: compute({ run: () => true }) },
+  edges: [],
+});
+
+describe("captureBuiltinWorkflows", () => {
+  it("keeps a definition and source hash stable after its temp file changes", async () => {
+    const dir = await makeTempDir("pi-workflows-builtins");
+    const filePath = path.join(dir, "fixture.workflow.js");
+    await fs.writeFile(filePath, "export default 'first';\n", "utf8");
+    const captured = captureBuiltinWorkflows([
+      { name: "fixture", definition: workflow, candidatePaths: [filePath] },
+    ]);
+    const before = captured.byName.get("fixture");
+
+    await fs.writeFile(filePath, "export default 'second';\n", "utf8");
+
+    expect(before?.definition).toBe(workflow);
+    expect(captured.byPath.get(filePath)).toBe(before);
+    expect(captured.byName.get("fixture")?.sourceHash).toBe(before?.sourceHash);
+  });
+
+  it("rejects a built-in without a readable source file", () => {
+    expect(() =>
+      captureBuiltinWorkflows([
+        { name: "missing", definition: workflow, candidatePaths: ["/missing/workflow.js"] },
+      ]),
+    ).toThrow(/Built-in workflow module is missing/);
+  });
+});

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   discoverWorkflows,
-  hashWorkflowSource,
   loadWorkflowFile,
   resolveWorkflowRef,
   workflowFileStem,
@@ -118,21 +117,6 @@ describe("resolveWorkflowRef", () => {
 
     expect(resolved.source).toBe("builtin");
     expect(workflow.name).toBe("monitor");
-  });
-
-  it("keeps a built-in definition and source hash stable after its file changes", async () => {
-    const { cwd, homeDir } = await makeSearchDirs();
-    const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir });
-    const original = await fs.readFile(resolved.path, "utf8");
-    const originalHash = await hashWorkflowSource(resolved.path);
-    try {
-      await fs.writeFile(resolved.path, "throw new Error('new package code loaded');\n", "utf8");
-
-      expect((await loadWorkflowFile(resolved.path)).name).toBe("monitor");
-      expect(await hashWorkflowSource(resolved.path)).toBe(originalHash);
-    } finally {
-      await fs.writeFile(resolved.path, original, "utf8");
-    }
   });
 
   it("resolves direct paths", async () => {

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   discoverWorkflows,
+  hashWorkflowSource,
   loadWorkflowFile,
   resolveWorkflowRef,
   workflowFileStem,
@@ -117,6 +118,21 @@ describe("resolveWorkflowRef", () => {
 
     expect(resolved.source).toBe("builtin");
     expect(workflow.name).toBe("monitor");
+  });
+
+  it("keeps a built-in definition and source hash stable after its file changes", async () => {
+    const { cwd, homeDir } = await makeSearchDirs();
+    const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir });
+    const original = await fs.readFile(resolved.path, "utf8");
+    const originalHash = await hashWorkflowSource(resolved.path);
+    try {
+      await fs.writeFile(resolved.path, "throw new Error('new package code loaded');\n", "utf8");
+
+      expect((await loadWorkflowFile(resolved.path)).name).toBe("monitor");
+      expect(await hashWorkflowSource(resolved.path)).toBe(originalHash);
+    } finally {
+      await fs.writeFile(resolved.path, original, "utf8");
+    }
   });
 
   it("resolves direct paths", async () => {

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import monitor from "../src/builtins/monitor.workflow.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
+import monitor from "../src/workflows/monitor.workflow.js";
 import { WorkflowRunStore } from "../src/workflows/store.js";
 import type {
   AgentNodeDefinition,


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A Pi session that stayed open during a Pi Workflows package update could mix its old engine with the new built-in monitor file.
That caused the old validator to reject the monitor's new timeout callback.
This change loads built-in workflows and their source hashes with the engine at process startup, so one process always uses one coherent package version.

## What Changed

Built-in workflows are now part of the workflow core's in-memory module graph.
Project and global workflow files still reload from disk for normal edit-and-run use.

- Moved the built-in monitor definition into the workflow layer.
- Registered built-ins as loaded definitions with startup-captured source hashes.
- Changed discovery, loading, and hashing to use that registry for built-ins.
- Added a regression test that changes the built-in file after startup and verifies that both the loaded definition and source hash stay stable.
- Documented that package updates require a Pi reload or restart before the new built-in is used.

This follows the coordinated timeout change in #17.

## Testing

The full local gate, real Pi end-to-end suite, and dependency-boundary checks pass.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`

## Risks

Risk is low and limited to built-in workflow discovery and loading.
The monitor keeps the same discovered name and source path, and user workflow precedence is unchanged.

An old process deliberately keeps its old built-in until reload or restart. This is safer than loading only part of a new package into an old runtime.
