### PR TITLE
fix: route workflow reports to origin sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ finishes with a JSON output, and edges decide what runs next.
 
 An `agent` node sends a prompt into the pi conversation and waits for the
 model to submit its output through the `workflow` tool. A `compute` node runs
-a pure TypeScript function. An `action` node performs a side effect, either a
-TypeScript function (`action({ run })`) or a runtime-owned shell command
-(`shell({ exec, parse })`). A `checkpoint` node ends the run in a `waiting`
-state so a human can pick it up. On top of `agent`, the `decision` helper asks
+a pure TypeScript function. A `notify` node writes a durable message for the
+Pi session that started the run. An `action` node performs a side effect,
+either a TypeScript function (`action({ run })`) or a runtime-owned shell
+command (`shell({ exec, parse })`). A `checkpoint` node ends the run in a
+`waiting` state so a human can pick it up. On top of `agent`, the `decision` helper asks
 the model to pick from a fixed set of choices and validates the answer, and
 `decisionEdge` routes on the result with compile-time case checking.
 
@@ -221,7 +222,9 @@ The standalone CLI provides read-only views with `pi-workflows controllers` and 
 
 ## Always-on workflows
 
-Runs do not depend on the Pi window. Every `/workflow` run is claimed through a durable queue, so closing Pi mid-run **parks** the run instead of cancelling it, and any runner can **resume** it later at the node it stopped on. Reopening Pi resumes parked runs itself and catches the session up through the shared event feed; a checkpointed run waits durably until you answer it with `/workflow answer <json>`, which continues the graph in a linked run.
+Runs do not depend on the Pi window. Every `/workflow` run is claimed through a durable queue, so closing Pi mid-run **parks** the run instead of cancelling it. Another interactive session cannot claim it. Reopening the exact session that started the run resumes it. A standalone host can also resume it without changing where reports go. A checkpointed run waits durably until you answer it with `/workflow answer <json>`, which continues the graph in a linked run.
+
+Workflow reports use a durable session-addressed outbox. A report waits while its starting session is closed and is delivered only to that session when it opens again. Runs in the same directory do not broadcast messages to each other's conversations.
 
 For runs that must continue while Pi is closed, keep the standalone host running:
 

--- a/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
+++ b/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
@@ -1,0 +1,92 @@
+---
+title: Route workflow reports to their starting session
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-13
+---
+
+# Route workflow reports to their starting session
+
+Pi Workflows must not send one workflow's report into an unrelated conversation. A workflow started in one Pi session must report only to that session, even when another session or the standalone host executes part of the run.
+
+## Requirements
+
+- Record the starting Pi session as the origin of each interactive workflow run.
+- Keep execution events separate from user-facing notifications.
+- Store each notification durably and address it to one Pi session.
+- Deliver a notification only when its target session is open.
+- Keep undelivered notifications until the target session opens again.
+- Prevent unrelated sessions from claiming session-bound runs.
+- Permit a detached host to execute a run without changing its report target.
+- Give workflow authors a runtime-owned notification node instead of using an agent step to relay text.
+- Migrate active path-based runs and existing queue rows without guessing their origin.
+- Remove project-wide hidden-message broadcasts and the shared project watermark.
+
+## Data model
+
+Queue records gain an optional `origin_session_id`. Interactive runs set it from `ctx.sessionManager.getSessionId()`. Controller-created detached runs leave it empty. A session runner can claim a record only when the origin is empty or matches its current session. The standalone host can claim either form.
+
+A `workflow_notifications` table is the durable outbox:
+
+| Field               | Meaning                                    |
+| ------------------- | ------------------------------------------ |
+| `notification_id`   | Stable unique delivery ID                  |
+| `run_id`            | Workflow run that created the notification |
+| `node_id`           | Node that created it                       |
+| `attempt_id`        | Node attempt that created it               |
+| `target_session_id` | Exact Pi session that may receive it       |
+| `kind`              | `progress` or `final`                      |
+| `content`           | Bounded plain-text report                  |
+| `created_at`        | Creation time                              |
+| `delivered_at`      | Delivery time, or null while pending       |
+
+`(run_id, node_id, attempt_id)` is unique. Retrying one accepted node attempt cannot create a duplicate notification. Delivery claims one pending row atomically before adding it to the current session. A stable notification ID is included in the custom session entry so the same session can detect a delivery completed before a crash.
+
+The existing `run_events` table remains an execution audit feed. It does not inject conversation messages. The obsolete `session_watermarks` table is no longer used.
+
+## Workflow API
+
+Add a `notify(...)` node. Its message callback returns plain text. The engine calls a host-provided notification sink and persists the resulting receipt as the node output. The node does not ask the model to relay a message and does not depend on the runner's active conversation.
+
+The built-in monitor uses `notify` for progress and final reports. Its check agent still decides whether a report is needed, but delivery always targets the origin session.
+
+## Migration
+
+For each active run with a queue row and no origin:
+
+1. Read `session/binding.json` from its run bundle.
+2. If the binding exists, set `origin_session_id` to its `piSessionId`.
+3. If no binding exists, keep the run detached.
+4. Never infer an origin from the working directory.
+
+Existing lifecycle events are not converted into notifications. This prevents old completion events from appearing in unrelated sessions after the update.
+
+## Non-goals
+
+- Do not modify Pi core or Pi session files directly.
+- Do not broadcast workflow reports to all sessions in a project.
+- Do not keep compatibility aliases for the shared project watermark behavior.
+- Do not make closed Pi sessions execute workflow steps.
+
+## Acceptance criteria
+
+- Two open Pi sessions in the same directory cannot receive each other's workflow reports.
+- A report executed by the standalone host is delivered after the origin session opens.
+- A report remains pending while its origin session is closed.
+- A session-bound run is not claimed by a different interactive session.
+- Duplicate polling and process restart do not duplicate a delivered notification.
+- Monitor progress and final reports use the notification outbox.
+- Existing active runs gain their recorded binding as origin when available.
+- Pi starts with the released package in OnurPi.
+
+## Verification
+
+- `npm run check`
+- `npm run test:e2e`
+- `npm run slophammer`
+- `git diff --check`
+- `npx -y @simpledoc/simpledoc check`
+- `cargo fmt --check --manifest-path tui/Cargo.toml`
+- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings`
+- `cargo test --manifest-path tui/Cargo.toml`
+- `pi-reviewer --base main`
+- Start two isolated RPC Pi sessions in one directory and prove that only the matching session receives a targeted notification.

--- a/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
+++ b/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
@@ -27,19 +27,22 @@ Queue records gain an optional `origin_session_id`. Interactive runs set it from
 
 A `workflow_notifications` table is the durable outbox:
 
-| Field               | Meaning                                    |
-| ------------------- | ------------------------------------------ |
-| `notification_id`   | Stable unique delivery ID                  |
-| `run_id`            | Workflow run that created the notification |
-| `node_id`           | Node that created it                       |
-| `attempt_id`        | Node attempt that created it               |
-| `target_session_id` | Exact Pi session that may receive it       |
-| `kind`              | `progress` or `final`                      |
-| `content`           | Bounded plain-text report                  |
-| `created_at`        | Creation time                              |
-| `delivered_at`      | Delivery time, or null while pending       |
+| Field                       | Meaning                                             |
+| --------------------------- | --------------------------------------------------- |
+| `notification_id`           | Stable unique delivery ID                           |
+| `run_id`                    | Workflow run that created the notification          |
+| `node_id`                   | Node that created it                                |
+| `attempt_id`                | Latest node attempt that requested it               |
+| `notification_index`        | Stable one-based occurrence of this node in the run |
+| `target_session_id`         | Exact Pi session that may receive it                |
+| `kind`                      | `progress` or `final`                               |
+| `content`                   | Bounded plain-text report                           |
+| `created_at`                | Creation time                                       |
+| `delivery_claim_token`      | Current delivery owner, or null                     |
+| `delivery_claim_expires_at` | Delivery lease deadline, or null                    |
+| `delivered_at`              | Delivery time, or null while pending                |
 
-`(run_id, node_id, attempt_id)` is unique. Retrying one accepted node attempt cannot create a duplicate notification. Delivery claims one pending row atomically before adding it to the current session. A stable notification ID is included in the custom session entry so the same session can detect a delivery completed before a crash.
+`(run_id, node_id, notification_index)` is unique. A crash retry reuses the same logical index, even though it gets a new attempt ID. A later loop iteration gets the next index. Delivery polling claims pending rows with a short lease before it writes to a session. This prevents two Pi processes that open the same session from sending the same notification concurrently. If a process stops, another process can reclaim the row after the lease expires. A stable notification ID is included in the custom session entry so the same session can detect a delivery completed before a crash.
 
 The existing `run_events` table remains an execution audit feed. It does not inject conversation messages. The obsolete `session_watermarks` table is no longer used.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -177,7 +177,9 @@ notify({
 });
 ```
 
-The runtime deduplicates notifications by run, node, and attempt. A workflow
+The runtime gives each logical execution of a notification node a stable index.
+A retry after a crash reuses that index, so it cannot queue the same message
+twice. Re-entering the node later in a loop gets the next index. A workflow
 with a `notify` node must be an interactive queued run with an origin session.
 Controller child workflows are detached and must report through their
 controller resource instead.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -117,10 +117,9 @@ Conversation nodes execute in headless `pi --mode rpc` children that load a
 small bridge extension; the model sees the same `workflow` tool contract as an
 in-session run. The host is a foreground process: start it in a terminal and
 stop it with Ctrl-C. A second host for the same project refuses to start, and
-a host that dies has its orphaned children reaped by the next one. While the
-host works, any open Pi session stays current: a per-session watermark over
-the shared run event feed produces catch-up summaries and quiet context
-updates.
+a host that dies has its orphaned children reaped by the next one. While the host works, reports enter a durable outbox addressed to the Pi
+session that started the run. They remain pending while that session is closed
+and never enter another conversation in the same project.
 
 ## Node types
 
@@ -164,6 +163,24 @@ Runs a TypeScript function inline. Use it for pure data shaping.
 ```typescript
 compute({ run: ({ outputs }) => ({ merged: { ...outputs } }) });
 ```
+
+### notify
+
+Queues a durable plain-text message for the Pi session that started the run.
+The runner does not write the message into its own conversation. A standalone
+host can execute this node, and the message still waits for the origin session.
+
+```typescript
+notify({
+  kind: "progress", // or "final"
+  message: ({ outputs }) => String(outputs.check),
+});
+```
+
+The runtime deduplicates notifications by run, node, and attempt. A workflow
+with a `notify` node must be an interactive queued run with an origin session.
+Controller child workflows are detached and must report through their
+controller resource instead.
 
 ### action
 

--- a/src/builtins/catalog.ts
+++ b/src/builtins/catalog.ts
@@ -4,18 +4,28 @@ import monitorWorkflow from "./monitor.workflow.js";
 export const builtinWorkflowCatalog = new BuiltinWorkflowCatalog([
   {
     id: "monitor",
-    revision: "1",
+    revision: "2",
     definition: monitorWorkflow,
     legacySources: [
       {
         workflowHash: "7a22158da94d18ec1c9fe42e70d72017a4e0620d5e5142ae839d0cd6eea55c06",
-        revision: "1",
+        revision: "2",
         pathSuffixes: [
           "/src/builtins/monitor.workflow.ts",
           "/dist/builtins/monitor.workflow.js",
           "/src/workflows/monitor.workflow.ts",
           "/dist/workflows/monitor.workflow.js",
         ],
+      },
+      {
+        workflowHash: "352fc09c88922c7375281b52f049c1039d05441ce37f2082f5ff07fea66d5318",
+        revision: "2",
+        pathSuffixes: ["/dist/builtins/monitor.workflow.js"],
+      },
+      {
+        workflowHash: "dc601e2323a8213f5d52fa555e804ae8ed0846f809b3a1e9e5073a3c9c3a114e",
+        revision: "2",
+        pathSuffixes: ["/dist/builtins/monitor.workflow.js"],
       },
     ],
   },

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -1,4 +1,4 @@
-import { agent, compute, defineWorkflow, shell } from "../workflows/definition.js";
+import { agent, compute, defineWorkflow, notify, shell } from "../workflows/definition.js";
 import type { WorkflowNodeContext } from "../workflows/types.js";
 
 const MIN_INTERVAL_MINUTES = 1;
@@ -150,22 +150,9 @@ function validateCheck(output: unknown): MonitorCheck {
   };
 }
 
-function validateReportAck(output: unknown): { reported: true } {
-  const value = requireRecord(output, "report acknowledgement");
-  if (value.reported !== true) {
-    throw new Error("report acknowledgement must set reported to true");
-  }
-  return { reported: true };
-}
-
-function reportPrompt(outputs: Record<string, unknown>): string {
+function reportMessage(outputs: Record<string, unknown>): string {
   const check = outputs.check as MonitorCheck;
-  return [
-    "Write one concise normal assistant message to the user with this monitoring update:",
-    check.report ?? check.observation,
-    "Do not add unrelated detail.",
-    "After writing the update, submit the acknowledgement required by the workflow step contract.",
-  ].join("\n\n");
+  return check.report ?? check.observation;
 }
 
 export default defineWorkflow({
@@ -232,19 +219,15 @@ export default defineWorkflow({
         '{ "route": "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report", "observation": "current factual state", "report": "required for report routes", "reason": "short reason" }',
       validate: (output) => validateCheck(output),
     }),
-    report_continue: agent({
-      statusDetail: "reporting monitor update",
-      timeoutMs: agentTimeoutMs,
-      prompt: ({ outputs }) => reportPrompt(outputs),
-      expectedOutput: '{ "reported": true }',
-      validate: (output) => validateReportAck(output),
+    report_continue: notify({
+      statusDetail: "queueing monitor update",
+      message: ({ outputs }) => reportMessage(outputs),
+      kind: "progress",
     }),
-    report_stop: agent({
-      statusDetail: "reporting final monitor update",
-      timeoutMs: agentTimeoutMs,
-      prompt: ({ outputs }) => reportPrompt(outputs),
-      expectedOutput: '{ "reported": true }',
-      validate: (output) => validateReportAck(output),
+    report_stop: notify({
+      statusDetail: "queueing final monitor update",
+      message: ({ outputs }) => reportMessage(outputs),
+      kind: "final",
     }),
     sleep: shell({
       statusDetail: "waiting for next monitor check",

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -23,6 +23,7 @@ export { createResultHelpers, requeue, requeueAfter, settled } from "./results.j
 export {
   SqliteControllerStore,
   type RunEventRecord,
+  type WorkflowNotificationRecord,
   type WorkflowRunQueueRecord,
 } from "./sqlite.js";
 export {

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -93,6 +93,7 @@ type WorkflowRunQueueRow = {
   claim_token: string | null;
   claim_expires_at: number | null;
   affinity_runner_id: string | null;
+  origin_session_id: string | null;
   parent_run_id: string | null;
   created_at: string;
   updated_at: string;
@@ -111,9 +112,35 @@ export type WorkflowRunQueueRecord = {
   claimToken: string | null;
   claimExpiresAt: string | null;
   affinityRunnerId: string | null;
+  /** Pi session that owns delivery and interactive execution, or null for detached runs. */
+  originSessionId: string | null;
   parentRunId: string | null;
   createdAt: string;
   updatedAt: string;
+};
+
+type WorkflowNotificationRow = {
+  notification_id: string;
+  run_id: string;
+  node_id: string;
+  attempt_id: string;
+  target_session_id: string;
+  kind: "progress" | "final";
+  content: string;
+  created_at: string;
+  delivered_at: string | null;
+};
+
+export type WorkflowNotificationRecord = {
+  notificationId: string;
+  runId: string;
+  nodeId: string;
+  attemptId: string;
+  targetSessionId: string;
+  kind: "progress" | "final";
+  content: string;
+  createdAt: string;
+  deliveredAt: string | null;
 };
 
 type RunEventRow = {
@@ -774,6 +801,13 @@ export class SqliteControllerStore implements ControllerStore {
         .prepare("INSERT OR IGNORE INTO schema_info (singleton, schema_id) VALUES (1, ?)")
         .run(CONTROLLER_STORE_SCHEMA);
       this.database.exec(SCHEMA_SQL);
+      const queueColumns = this.database.pragma("table_info(workflow_run_queue)") as {
+        name: string;
+      }[];
+      if (!queueColumns.some((column) => column.name === "origin_session_id")) {
+        this.database.exec("ALTER TABLE workflow_run_queue ADD COLUMN origin_session_id TEXT");
+      }
+      this.database.exec("DROP TABLE IF EXISTS session_watermarks");
     });
   }
 
@@ -875,6 +909,7 @@ export class SqliteControllerStore implements ControllerStore {
     claimToken: string;
     leaseMs: number;
     affinityRunnerId?: string;
+    originSessionId?: string;
     parentRunId?: string;
     now?: string;
   }): WorkflowRunQueueRecord {
@@ -884,6 +919,9 @@ export class SqliteControllerStore implements ControllerStore {
     validateKey(options.runnerId, "runner id");
     validateKey(options.claimToken, "claim token");
     validateDuration(options.leaseMs, "leaseMs");
+    if (options.originSessionId !== undefined) {
+      validateKey(options.originSessionId, "origin session id");
+    }
     const inputJson = canonicalJson(options.input ?? null, "workflow run input");
     validateJsonSize(inputJson, "Workflow run input", MAX_RESOURCE_VALUE_BYTES);
     const now = validTimestamp(options.now);
@@ -893,8 +931,8 @@ export class SqliteControllerStore implements ControllerStore {
         `INSERT INTO workflow_run_queue (
           run_id, workflow_ref, workflow_path, input_json, status,
           runner_id, claim_token, claim_expires_at, affinity_runner_id,
-          parent_run_id, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, 'claimed', ?, ?, ?, ?, ?, ?, ?)`,
+          origin_session_id, parent_run_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, 'claimed', ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         options.runId,
@@ -905,6 +943,7 @@ export class SqliteControllerStore implements ControllerStore {
         options.claimToken,
         expiresAt,
         options.affinityRunnerId ?? options.runnerId,
+        options.originSessionId ?? null,
         options.parentRunId ?? null,
         now,
         now,
@@ -945,11 +984,14 @@ export class SqliteControllerStore implements ControllerStore {
     claimToken: string;
     leaseMs: number;
     excludeRunIds?: string[];
+    /** Interactive sessions provide their id; detached hosts omit it. */
+    sessionId?: string;
     now?: string;
   }): WorkflowRunQueueRecord | undefined {
     validateKey(options.runnerId, "runner id");
     validateKey(options.claimToken, "claim token");
     validateDuration(options.leaseMs, "leaseMs");
+    if (options.sessionId !== undefined) validateKey(options.sessionId, "session id");
     const now = validTimestamp(options.now);
     const nowMs = epoch(now);
     const expiresAt = nowMs + options.leaseMs;
@@ -959,6 +1001,10 @@ export class SqliteControllerStore implements ControllerStore {
     }
     const exclusion =
       excluded.length === 0 ? "" : `AND run_id NOT IN (${excluded.map(() => "?").join(", ")})`;
+    const sessionFilter =
+      options.sessionId === undefined
+        ? ""
+        : "AND (origin_session_id IS NULL OR origin_session_id = ?)";
     const claimable = `(
       status = 'parked'
       OR (status = 'claimed' AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
@@ -967,13 +1013,18 @@ export class SqliteControllerStore implements ControllerStore {
       const candidate = this.database
         .prepare(
           `SELECT run_id FROM workflow_run_queue
-           WHERE ${claimable} ${exclusion}
+           WHERE ${claimable} ${exclusion} ${sessionFilter}
            ORDER BY
              CASE WHEN affinity_runner_id = ? THEN 0 ELSE 1 END,
              created_at ASC
            LIMIT 1`,
         )
-        .get(nowMs, ...excluded, options.runnerId) as { run_id: string } | undefined;
+        .get(
+          nowMs,
+          ...excluded,
+          ...(options.sessionId === undefined ? [] : [options.sessionId]),
+          options.runnerId,
+        ) as { run_id: string } | undefined;
       if (candidate === undefined) {
         return undefined;
       }
@@ -1235,37 +1286,96 @@ export class SqliteControllerStore implements ControllerStore {
     }));
   }
 
-  /** The highest run event seq in the feed; 0 when empty. */
-  latestRunEventSeq(): number {
-    const row = this.database.prepare("SELECT MAX(seq) AS latest FROM run_events").get() as {
-      latest: number | null;
-    };
-    return row.latest ?? 0;
-  }
-
-  /** The last run event this session was told about; 0 before any sync. */
-  getSessionWatermark(sessionId: string): number {
-    validateKey(sessionId, "session id");
-    const row = this.database
-      .prepare("SELECT last_event_seq FROM session_watermarks WHERE session_id = ?")
-      .get(sessionId) as { last_event_seq: number } | undefined;
-    return row?.last_event_seq ?? 0;
-  }
-
-  setSessionWatermark(sessionId: string, seq: number, now?: string): void {
-    validateKey(sessionId, "session id");
-    if (!Number.isSafeInteger(seq) || seq < 0) {
-      throw new Error(`Invalid run event watermark: ${seq}`);
+  enqueueWorkflowNotification(options: {
+    runId: string;
+    nodeId: string;
+    attemptId: string;
+    targetSessionId: string;
+    kind: "progress" | "final";
+    content: string;
+    notificationId?: string;
+    now?: string;
+  }): WorkflowNotificationRecord {
+    validateRunId(options.runId);
+    validateKey(options.nodeId, "workflow node id");
+    validateKey(options.attemptId, "workflow attempt id");
+    validateKey(options.targetSessionId, "target session id");
+    if (options.content.trim().length === 0 || options.content.length > MAX_EVENT_BYTES) {
+      throw new Error(`Workflow notification content must be 1-${MAX_EVENT_BYTES} characters`);
     }
+    const notificationId = options.notificationId ?? randomUUID();
+    validateKey(notificationId, "notification id");
     this.database
       .prepare(
-        `INSERT INTO session_watermarks (session_id, last_event_seq, updated_at)
-         VALUES (?, ?, ?)
-         ON CONFLICT(session_id) DO UPDATE SET
-           last_event_seq = MAX(session_watermarks.last_event_seq, excluded.last_event_seq),
-           updated_at = excluded.updated_at`,
+        `INSERT INTO workflow_notifications (
+          notification_id, run_id, node_id, attempt_id, target_session_id,
+          kind, content, created_at, delivered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+        ON CONFLICT(run_id, node_id, attempt_id) DO NOTHING`,
       )
-      .run(sessionId, seq, validTimestamp(now));
+      .run(
+        notificationId,
+        options.runId,
+        options.nodeId,
+        options.attemptId,
+        options.targetSessionId,
+        options.kind,
+        options.content.trim(),
+        validTimestamp(options.now),
+      );
+    const row = this.database
+      .prepare(
+        "SELECT * FROM workflow_notifications WHERE run_id = ? AND node_id = ? AND attempt_id = ?",
+      )
+      .get(options.runId, options.nodeId, options.attemptId) as WorkflowNotificationRow;
+    return workflowNotificationFromRow(row);
+  }
+
+  listPendingWorkflowNotifications(
+    targetSessionId: string,
+    options: { limit?: number } = {},
+  ): WorkflowNotificationRecord[] {
+    validateKey(targetSessionId, "target session id");
+    const limit = options.limit ?? 20;
+    if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
+      throw new Error("Workflow notification limit must be an integer from 1 through 100");
+    }
+    const rows = this.database
+      .prepare(
+        `SELECT * FROM workflow_notifications
+         WHERE target_session_id = ? AND delivered_at IS NULL
+         ORDER BY created_at, notification_id LIMIT ?`,
+      )
+      .all(targetSessionId, limit) as WorkflowNotificationRow[];
+    return rows.map(workflowNotificationFromRow);
+  }
+
+  markWorkflowNotificationDelivered(options: {
+    notificationId: string;
+    targetSessionId: string;
+    now?: string;
+  }): boolean {
+    validateKey(options.notificationId, "notification id");
+    validateKey(options.targetSessionId, "target session id");
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_notifications SET delivered_at = ?
+         WHERE notification_id = ? AND target_session_id = ? AND delivered_at IS NULL`,
+      )
+      .run(validTimestamp(options.now), options.notificationId, options.targetSessionId);
+    return result.changes === 1;
+  }
+
+  setWorkflowRunOriginSession(runId: string, originSessionId: string): boolean {
+    validateRunId(runId);
+    validateKey(originSessionId, "origin session id");
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_run_queue SET origin_session_id = ?
+         WHERE run_id = ? AND origin_session_id IS NULL`,
+      )
+      .run(originSessionId, runId);
+    return result.changes === 1;
   }
 
   private requireWorkflowRun(runId: string): WorkflowRunQueueRecord {
@@ -1329,6 +1439,7 @@ const SCHEMA_SQL = `
     claim_token TEXT,
     claim_expires_at INTEGER,
     affinity_runner_id TEXT,
+    origin_session_id TEXT,
     parent_run_id TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -1351,11 +1462,21 @@ const SCHEMA_SQL = `
   );
   CREATE INDEX IF NOT EXISTS run_events_run ON run_events(run_id);
 
-  CREATE TABLE IF NOT EXISTS session_watermarks (
-    session_id TEXT PRIMARY KEY,
-    last_event_seq INTEGER NOT NULL CHECK (last_event_seq >= 0),
-    updated_at TEXT NOT NULL
+  CREATE TABLE IF NOT EXISTS workflow_notifications (
+    notification_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    attempt_id TEXT NOT NULL,
+    target_session_id TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('progress', 'final')),
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    delivered_at TEXT,
+    UNIQUE (run_id, node_id, attempt_id)
   );
+  CREATE INDEX IF NOT EXISTS workflow_notifications_pending
+    ON workflow_notifications(target_session_id, created_at)
+    WHERE delivered_at IS NULL;
 
   CREATE TABLE IF NOT EXISTS effects (
     effect_key TEXT NOT NULL,
@@ -1447,6 +1568,20 @@ function workflowFromRow(row: WorkflowRow): ChildWorkflowRecord {
   };
 }
 
+function workflowNotificationFromRow(row: WorkflowNotificationRow): WorkflowNotificationRecord {
+  return {
+    notificationId: row.notification_id,
+    runId: row.run_id,
+    nodeId: row.node_id,
+    attemptId: row.attempt_id,
+    targetSessionId: row.target_session_id,
+    kind: row.kind,
+    content: row.content,
+    createdAt: row.created_at,
+    deliveredAt: row.delivered_at,
+  };
+}
+
 function workflowRunFromRow(row: WorkflowRunQueueRow): WorkflowRunQueueRecord {
   return {
     runId: row.run_id,
@@ -1458,6 +1593,7 @@ function workflowRunFromRow(row: WorkflowRunQueueRow): WorkflowRunQueueRecord {
     claimToken: row.claim_token,
     claimExpiresAt: row.claim_expires_at === null ? null : iso(row.claim_expires_at),
     affinityRunnerId: row.affinity_runner_id,
+    originSessionId: row.origin_session_id,
     parentRunId: row.parent_run_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -124,10 +124,13 @@ type WorkflowNotificationRow = {
   run_id: string;
   node_id: string;
   attempt_id: string;
+  notification_index: number;
   target_session_id: string;
   kind: "progress" | "final";
   content: string;
   created_at: string;
+  delivery_claim_token: string | null;
+  delivery_claim_expires_at: number | null;
   delivered_at: string | null;
 };
 
@@ -136,10 +139,12 @@ export type WorkflowNotificationRecord = {
   runId: string;
   nodeId: string;
   attemptId: string;
+  notificationIndex: number;
   targetSessionId: string;
   kind: "progress" | "final";
   content: string;
   createdAt: string;
+  deliveryClaimExpiresAt: string | null;
   deliveredAt: string | null;
 };
 
@@ -1290,6 +1295,7 @@ export class SqliteControllerStore implements ControllerStore {
     runId: string;
     nodeId: string;
     attemptId: string;
+    notificationIndex: number;
     targetSessionId: string;
     kind: "progress" | "final";
     content: string;
@@ -1299,6 +1305,9 @@ export class SqliteControllerStore implements ControllerStore {
     validateRunId(options.runId);
     validateKey(options.nodeId, "workflow node id");
     validateKey(options.attemptId, "workflow attempt id");
+    if (!Number.isSafeInteger(options.notificationIndex) || options.notificationIndex <= 0) {
+      throw new Error("Workflow notification index must be a positive safe integer");
+    }
     validateKey(options.targetSessionId, "target session id");
     if (options.content.trim().length === 0 || options.content.length > MAX_EVENT_BYTES) {
       throw new Error(`Workflow notification content must be 1-${MAX_EVENT_BYTES} characters`);
@@ -1308,16 +1317,17 @@ export class SqliteControllerStore implements ControllerStore {
     this.database
       .prepare(
         `INSERT INTO workflow_notifications (
-          notification_id, run_id, node_id, attempt_id, target_session_id,
-          kind, content, created_at, delivered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
-        ON CONFLICT(run_id, node_id, attempt_id) DO NOTHING`,
+          notification_id, run_id, node_id, attempt_id, notification_index,
+          target_session_id, kind, content, created_at, delivered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+        ON CONFLICT(run_id, node_id, notification_index) DO NOTHING`,
       )
       .run(
         notificationId,
         options.runId,
         options.nodeId,
         options.attemptId,
+        options.notificationIndex,
         options.targetSessionId,
         options.kind,
         options.content.trim(),
@@ -1325,44 +1335,84 @@ export class SqliteControllerStore implements ControllerStore {
       );
     const row = this.database
       .prepare(
-        "SELECT * FROM workflow_notifications WHERE run_id = ? AND node_id = ? AND attempt_id = ?",
+        "SELECT * FROM workflow_notifications WHERE run_id = ? AND node_id = ? AND notification_index = ?",
       )
-      .get(options.runId, options.nodeId, options.attemptId) as WorkflowNotificationRow;
+      .get(options.runId, options.nodeId, options.notificationIndex) as WorkflowNotificationRow;
     return workflowNotificationFromRow(row);
   }
 
-  listPendingWorkflowNotifications(
-    targetSessionId: string,
-    options: { limit?: number } = {},
-  ): WorkflowNotificationRecord[] {
-    validateKey(targetSessionId, "target session id");
+  claimPendingWorkflowNotifications(options: {
+    targetSessionId: string;
+    claimToken: string;
+    leaseMs: number;
+    limit?: number;
+    now?: string;
+  }): WorkflowNotificationRecord[] {
+    validateKey(options.targetSessionId, "target session id");
+    validateKey(options.claimToken, "notification claim token");
+    validateDuration(options.leaseMs, "notification leaseMs");
     const limit = options.limit ?? 20;
     if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
       throw new Error("Workflow notification limit must be an integer from 1 through 100");
     }
-    const rows = this.database
-      .prepare(
-        `SELECT * FROM workflow_notifications
-         WHERE target_session_id = ? AND delivered_at IS NULL
-         ORDER BY created_at, notification_id LIMIT ?`,
-      )
-      .all(targetSessionId, limit) as WorkflowNotificationRow[];
-    return rows.map(workflowNotificationFromRow);
+    const now = validTimestamp(options.now);
+    const nowMs = epoch(now);
+    return this.transaction(() => {
+      const ids = this.database
+        .prepare(
+          `SELECT notification_id FROM workflow_notifications
+           WHERE target_session_id = ? AND delivered_at IS NULL
+             AND (delivery_claim_expires_at IS NULL OR delivery_claim_expires_at <= ?)
+           ORDER BY created_at, notification_id LIMIT ?`,
+        )
+        .all(options.targetSessionId, nowMs, limit) as { notification_id: string }[];
+      if (ids.length === 0) return [];
+      const placeholders = ids.map(() => "?").join(", ");
+      this.database
+        .prepare(
+          `UPDATE workflow_notifications
+           SET delivery_claim_token = ?, delivery_claim_expires_at = ?
+           WHERE notification_id IN (${placeholders}) AND delivered_at IS NULL
+             AND (delivery_claim_expires_at IS NULL OR delivery_claim_expires_at <= ?)`,
+        )
+        .run(
+          options.claimToken,
+          nowMs + options.leaseMs,
+          ...ids.map((row) => row.notification_id),
+          nowMs,
+        );
+      const rows = this.database
+        .prepare(
+          `SELECT * FROM workflow_notifications WHERE delivery_claim_token = ?
+           ORDER BY created_at, notification_id`,
+        )
+        .all(options.claimToken) as WorkflowNotificationRow[];
+      return rows.map(workflowNotificationFromRow);
+    });
   }
 
   markWorkflowNotificationDelivered(options: {
     notificationId: string;
     targetSessionId: string;
+    claimToken: string;
     now?: string;
   }): boolean {
     validateKey(options.notificationId, "notification id");
     validateKey(options.targetSessionId, "target session id");
+    validateKey(options.claimToken, "notification claim token");
     const result = this.database
       .prepare(
-        `UPDATE workflow_notifications SET delivered_at = ?
-         WHERE notification_id = ? AND target_session_id = ? AND delivered_at IS NULL`,
+        `UPDATE workflow_notifications
+         SET delivered_at = ?, delivery_claim_token = NULL, delivery_claim_expires_at = NULL
+         WHERE notification_id = ? AND target_session_id = ?
+           AND delivery_claim_token = ? AND delivered_at IS NULL`,
       )
-      .run(validTimestamp(options.now), options.notificationId, options.targetSessionId);
+      .run(
+        validTimestamp(options.now),
+        options.notificationId,
+        options.targetSessionId,
+        options.claimToken,
+      );
     return result.changes === 1;
   }
 
@@ -1467,15 +1517,18 @@ const SCHEMA_SQL = `
     run_id TEXT NOT NULL,
     node_id TEXT NOT NULL,
     attempt_id TEXT NOT NULL,
+    notification_index INTEGER NOT NULL CHECK (notification_index > 0),
     target_session_id TEXT NOT NULL,
     kind TEXT NOT NULL CHECK (kind IN ('progress', 'final')),
     content TEXT NOT NULL,
     created_at TEXT NOT NULL,
+    delivery_claim_token TEXT,
+    delivery_claim_expires_at INTEGER,
     delivered_at TEXT,
-    UNIQUE (run_id, node_id, attempt_id)
+    UNIQUE (run_id, node_id, notification_index)
   );
   CREATE INDEX IF NOT EXISTS workflow_notifications_pending
-    ON workflow_notifications(target_session_id, created_at)
+    ON workflow_notifications(target_session_id, delivery_claim_expires_at, created_at)
     WHERE delivered_at IS NULL;
 
   CREATE TABLE IF NOT EXISTS effects (
@@ -1574,10 +1627,13 @@ function workflowNotificationFromRow(row: WorkflowNotificationRow): WorkflowNoti
     runId: row.run_id,
     nodeId: row.node_id,
     attemptId: row.attempt_id,
+    notificationIndex: row.notification_index,
     targetSessionId: row.target_session_id,
     kind: row.kind,
     content: row.content,
     createdAt: row.created_at,
+    deliveryClaimExpiresAt:
+      row.delivery_claim_expires_at === null ? null : iso(row.delivery_claim_expires_at),
     deliveredAt: row.delivered_at,
   };
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -42,6 +42,7 @@ import { WorkflowToolParameters, type WorkflowToolInput } from "./workflow-tool.
 const RUN_CLAIM_LEASE_MS = 30_000;
 const RUN_CLAIM_RENEW_MS = 10_000;
 const RUN_SYNC_POLL_MS = 3_000;
+const NOTIFICATION_DELIVERY_LEASE_MS = 30_000;
 const WIDGET_KEY = "pi-workflows";
 const PRESENTATION_MESSAGE_TYPE = "pi-workflows-presentation";
 const FINAL_WIDGET_TTL_MS = 60_000;
@@ -251,7 +252,12 @@ export default function piWorkflows(pi: ExtensionAPI) {
     try {
       const sessionId = ctx.sessionManager.getSessionId();
       const alreadyDelivered = deliveredNotificationIds(ctx);
-      for (const notification of runQueueStore.listPendingWorkflowNotifications(sessionId)) {
+      const claimToken = randomUUID();
+      for (const notification of runQueueStore.claimPendingWorkflowNotifications({
+        targetSessionId: sessionId,
+        claimToken,
+        leaseMs: NOTIFICATION_DELIVERY_LEASE_MS,
+      })) {
         if (!alreadyDelivered.has(notification.notificationId)) {
           pi.sendMessage({
             customType: "pi-workflows-notification",
@@ -268,6 +274,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         runQueueStore.markWorkflowNotificationDelivered({
           notificationId: notification.notificationId,
           targetSessionId: sessionId,
+          claimToken,
         });
       }
     } catch {
@@ -733,6 +740,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
       store,
       notificationSink: {
         notify: (request) => {
+          fence?.();
           if (queueStore === null) throw new Error("Workflow notifications require a queued run");
           const record = queueStore.getWorkflowRun(request.runId);
           if (record?.originSessionId === null || record?.originSessionId === undefined) {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { builtinWorkflowCatalog } from "../builtins/catalog.js";
-import {
-  projectControllerStorePath,
-  type RunEventRecord,
-  SqliteControllerStore,
-} from "../controllers/index.js";
+import { projectControllerStorePath, SqliteControllerStore } from "../controllers/index.js";
 import type { JsonObject } from "../controllers/types.js";
 import type { WorkflowSchedulerResult } from "../controllers/workflows.js";
 import { WorkflowEngine } from "../workflows/engine.js";
@@ -217,11 +213,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
     return runQueueStore;
   };
 
-  // Session sync: a per-session watermark over the run event feed keeps this
-  // session's context current with runs other runners drove.
-  // The sync watermark is project-scoped: a reopened session catches up
-  // where the last one stopped, and two open sessions share one pointer.
-  const SYNC_WATERMARK_KEY = "project";
+  // Session-addressed delivery: each session polls only its durable outbox.
+  // Run events remain an audit feed and never enter a conversation.
   let syncArmed = false;
   let runSyncTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -238,109 +231,48 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
   };
 
-  const describeRunEvent = (event: RunEventRecord): string => {
-    const label = `${event.workflowRef} run ${event.runId}`;
-    switch (event.type) {
-      case "waiting": {
-        const waitingOn =
-          typeof event.payload.waitingOn === "string" ? event.payload.waitingOn : "a checkpoint";
-        return `${label} waits at checkpoint ${waitingOn} — answer with /workflow answer`;
+  const deliveredNotificationIds = (ctx: ExtensionContext): Set<string> => {
+    const ids = new Set<string>();
+    for (const entry of ctx.sessionManager.getBranch()) {
+      if (entry.type !== "custom_message" || entry.customType !== "pi-workflows-notification") {
+        continue;
       }
-      case "parked":
-        return `${label} was parked and will resume when a runner is available`;
-      case "failed": {
-        const detail = typeof event.payload.error === "string" ? `: ${event.payload.error}` : "";
-        return `${label} failed${detail}`;
+      const details = entry.details;
+      if (details !== null && typeof details === "object" && !Array.isArray(details)) {
+        const notificationId = (details as { notificationId?: unknown }).notificationId;
+        if (typeof notificationId === "string") ids.add(notificationId);
       }
-      default:
-        return `${label} ${event.type}`;
     }
+    return ids;
   };
 
-  const runSyncPass = async (ctx: ExtensionContext): Promise<void> => {
-    if (runQueueStore === null || !syncArmed) {
-      return;
-    }
+  const runSyncPass = (ctx: ExtensionContext): void => {
+    if (runQueueStore === null || !syncArmed) return;
     try {
-      const watermark = runQueueStore.getSessionWatermark(SYNC_WATERMARK_KEY);
-      if (watermark === 0) {
-        // First sync ever for this project: never replay the feed (stale
-        // "waits at checkpoint" lines included). Fast-forward, then catch
-        // up from current state instead — what is parked, resuming, or
-        // waiting for an answer right now.
-        const latest = runQueueStore.latestRunEventSeq();
-        if (latest > 0) {
-          runQueueStore.setSessionWatermark(SYNC_WATERMARK_KEY, latest);
+      const sessionId = ctx.sessionManager.getSessionId();
+      const alreadyDelivered = deliveredNotificationIds(ctx);
+      for (const notification of runQueueStore.listPendingWorkflowNotifications(sessionId)) {
+        if (!alreadyDelivered.has(notification.notificationId)) {
+          pi.sendMessage({
+            customType: "pi-workflows-notification",
+            content: notification.content,
+            display: true,
+            details: {
+              notificationId: notification.notificationId,
+              runId: notification.runId,
+              kind: notification.kind,
+            },
+          });
+          alreadyDelivered.add(notification.notificationId);
         }
-        await sendStateSnapshot(ctx);
-        return;
+        runQueueStore.markWorkflowNotificationDelivered({
+          notificationId: notification.notificationId,
+          targetSessionId: sessionId,
+        });
       }
-      const events = runQueueStore.listRunEventsAfter(watermark, { limit: 20 });
-      if (events.length === 0) {
-        return;
-      }
-      // Persist the watermark first. A crash after this point skips the
-      // message, but snapshots recompute from the store, so no information
-      // stays lost; a duplicated state line is the worst outcome.
-      runQueueStore.setSessionWatermark(SYNC_WATERMARK_KEY, events[events.length - 1]?.seq ?? 0);
-      const noteworthy = events.filter(
-        (event) =>
-          event.runnerId !== runnerId &&
-          ["completed", "failed", "timed_out", "cancelled", "waiting", "parked"].includes(
-            event.type,
-          ),
-      );
-      if (noteworthy.length === 0) {
-        return;
-      }
-      const content = `Workflow run update:\n${noteworthy.map(describeRunEvent).join("\n")}`;
-      pi.sendMessage(
-        { customType: "pi-workflows-run-sync", content, display: false },
-        { deliverAs: "steer", triggerTurn: false },
-      );
-      notify(ctx, noteworthy.map(describeRunEvent).join("; "));
     } catch {
-      // Sync is observational.
+      // Delivery retries on the next poll. It never affects workflow execution.
     }
-  };
-
-  // The first-use catch-up: a snapshot of runs that need attention now.
-  const sendStateSnapshot = async (ctx: ExtensionContext) => {
-    if (runQueueStore === null) {
-      return;
-    }
-    const lines: string[] = [];
-    const rows = runQueueStore.listWorkflowRuns();
-    for (const row of rows) {
-      if (row.status === "parked") {
-        lines.push(`${row.workflowName} run ${row.runId} is parked and will resume`);
-      }
-    }
-    const known = new Set(rows.map((row) => row.runId));
-    const continued = new Set(
-      rows.map((row) => row.parentRunId).filter((parent): parent is string => parent !== null),
-    );
-    const bundles = await listRunBundles(new WorkflowRunStore().outputRoot);
-    for (const bundle of bundles) {
-      if (
-        bundle.state.status === "waiting" &&
-        known.has(bundle.state.runId) &&
-        !continued.has(bundle.state.runId)
-      ) {
-        lines.push(
-          `${bundle.state.workflowName} run ${bundle.state.runId} waits at checkpoint ${bundle.state.waitingOn ?? "?"} — answer with /workflow answer`,
-        );
-      }
-    }
-    if (lines.length === 0) {
-      return;
-    }
-    const content = `Workflow runs needing attention:\n${lines.join("\n")}`;
-    pi.sendMessage(
-      { customType: "pi-workflows-run-sync", content, display: false },
-      { deliverAs: "steer", triggerTurn: false },
-    );
-    notify(ctx, lines.join("; "));
   };
 
   const startRunSync = (ctx: ExtensionContext) => {
@@ -746,6 +678,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           runnerId,
           claimToken: token,
           leaseMs: RUN_CLAIM_LEASE_MS,
+          originSessionId: ctx.sessionManager.getSessionId(),
           ...(options.parentRunId !== undefined ? { parentRunId: options.parentRunId } : {}),
         });
         claimToken = token;
@@ -798,6 +731,23 @@ export default function piWorkflows(pi: ExtensionAPI) {
     const engine = new WorkflowEngine({
       executor,
       store,
+      notificationSink: {
+        notify: (request) => {
+          if (queueStore === null) throw new Error("Workflow notifications require a queued run");
+          const record = queueStore.getWorkflowRun(request.runId);
+          if (record?.originSessionId === null || record?.originSessionId === undefined) {
+            throw new Error(`Workflow run ${request.runId} has no origin session`);
+          }
+          const notification = queueStore.enqueueWorkflowNotification({
+            ...request,
+            targetSessionId: record.originSessionId,
+          });
+          return {
+            notificationId: notification.notificationId,
+            targetSessionId: notification.targetSessionId,
+          };
+        },
+      },
       // Awaited by the engine after run_started is persisted, so the session
       // binding and its trace event always precede node and terminal events.
       onRunStarted: async (runDir, state) => {
@@ -980,6 +930,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
       claimToken,
       leaseMs: RUN_CLAIM_LEASE_MS,
       excludeRunIds: [...migrationBlockedRuns],
+      sessionId: ctx.sessionManager.getSessionId(),
     });
     if (claimed === undefined) {
       return;
@@ -1291,7 +1242,12 @@ export default function piWorkflows(pi: ExtensionAPI) {
     let parentRunId = requestedRunId ?? lastWaitingRunId;
     if (parentRunId === null) {
       const rows = ensureRunQueueStore(ctx.cwd).listWorkflowRuns();
-      const known = new Set(rows.map((row) => row.runId));
+      const sessionId = ctx.sessionManager.getSessionId();
+      const known = new Set(
+        rows
+          .filter((row) => row.originSessionId === null || row.originSessionId === sessionId)
+          .map((row) => row.runId),
+      );
       const continued = new Set(
         rows.map((row) => row.parentRunId).filter((parent): parent is string => parent !== null),
       );
@@ -1306,6 +1262,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
     if (parentRunId === null) {
       throw new Error("No workflow is waiting for an answer.");
+    }
+    const queueRecord = ensureRunQueueStore(ctx.cwd).getWorkflowRun(parentRunId);
+    if (
+      queueRecord?.originSessionId !== null &&
+      queueRecord?.originSessionId !== undefined &&
+      queueRecord.originSessionId !== ctx.sessionManager.getSessionId()
+    ) {
+      throw new Error(`Workflow run ${parentRunId} belongs to another Pi session.`);
     }
     const parent = await readRunBundle(new WorkflowRunStore().runDirFor(parentRunId));
     if (

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -269,7 +269,25 @@ export class WorkflowHost {
       ...(this.options.piArgs !== undefined ? { piArgs: this.options.piArgs } : {}),
       ...(this.options.env !== undefined ? { env: this.options.env } : {}),
     });
-    const engine = new WorkflowEngine({ executor, store: fencedStore });
+    const engine = new WorkflowEngine({
+      executor,
+      store: fencedStore,
+      notificationSink: {
+        notify: (request) => {
+          if (record.originSessionId === null) {
+            throw new Error(`Workflow run ${request.runId} has no origin session`);
+          }
+          const notification = store.enqueueWorkflowNotification({
+            ...request,
+            targetSessionId: record.originSessionId,
+          });
+          return {
+            notificationId: notification.notificationId,
+            targetSessionId: notification.targetSessionId,
+          };
+        },
+      },
+    });
     const parkEngine = () => engine.park();
     this.parkedEngines.push(parkEngine);
 

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -274,6 +274,7 @@ export class WorkflowHost {
       store: fencedStore,
       notificationSink: {
         notify: (request) => {
+          fence();
           if (record.originSessionId === null) {
             throw new Error(`Workflow run ${request.runId} has no origin session`);
           }

--- a/src/render/graph-render.ts
+++ b/src/render/graph-render.ts
@@ -79,6 +79,7 @@ const CARD_DYNAMIC_RESERVE = "↻ 100  ◷ 9999d 23h 59m 59s";
 const NODE_TYPE_GLYPHS: Record<string, string> = {
   agent: "●",
   compute: "ƒ",
+  notify: "✉",
   action: "⚙",
   checkpoint: "◆",
 };
@@ -87,6 +88,8 @@ function nodeTypeStyle(nodeType: string): CanvasStyle {
   switch (nodeType) {
     case "agent":
     case "compute":
+    case "notify":
+      return nodeType === "notify" ? "action" : nodeType;
     case "action":
     case "checkpoint":
       return nodeType;

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -3,6 +3,7 @@ import {
   assertValidActionNode,
   assertValidCheckpointNode,
   assertValidComputeNode,
+  assertValidNotifyNode,
   assertValidShellActionNode,
   assertValidWorkflowDefinitionShape,
 } from "./schema.js";
@@ -12,6 +13,7 @@ import type {
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
   FunctionActionNodeDefinition,
+  NotifyNodeDefinition,
   ShellActionNodeDefinition,
   WorkflowDefinition,
 } from "./types.js";
@@ -59,6 +61,15 @@ export function compute(
     ...definition,
   };
   assertValidComputeNode(node);
+  return node;
+}
+
+export function notify(definition: Omit<NotifyNodeDefinition, "nodeType">): NotifyNodeDefinition {
+  const node: NotifyNodeDefinition = {
+    nodeType: "notify",
+    ...definition,
+  };
+  assertValidNotifyNode(node);
   return node;
 }
 

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -879,11 +879,16 @@ export class WorkflowEngine {
         if (typeof content !== "string" || content.trim().length === 0) {
           throw new Error(`Workflow node ${nodeId} notification must be a non-empty string`);
         }
+        const notificationIndex =
+          state.steps.filter(
+            (step) => step.nodeId === nodeId && step.nodeType === "notify" && step.outcome === "ok",
+          ).length + 1;
         const receipt = await this.notificationSink.notify({
           runId: state.runId,
           workflowName: workflow.name,
           nodeId,
           attemptId,
+          notificationIndex,
           kind: node.kind ?? "progress",
           content: content.trim(),
         });

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -30,6 +30,7 @@ import type {
   WorkflowNodeDefinition,
   WorkflowNodeOutcome,
   WorkflowNodeResult,
+  WorkflowNotificationSink,
   WorkflowRunResult,
   WorkflowRunState,
   WorkflowSource,
@@ -74,6 +75,7 @@ type NodeAttempt = {
  */
 export class WorkflowEngine {
   private readonly executor: AgentStepExecutor;
+  private readonly notificationSink: WorkflowNotificationSink | undefined;
   private readonly store: WorkflowRunStore;
   private readonly defaultNodeTimeoutMs: number;
   private readonly maxSteps: number;
@@ -88,6 +90,7 @@ export class WorkflowEngine {
 
   constructor(options: WorkflowEngineOptions) {
     this.executor = options.executor;
+    this.notificationSink = options.notificationSink;
     this.store = options.store ?? new WorkflowRunStore(options.outputRoot);
     this.defaultNodeTimeoutMs = options.defaultNodeTimeoutMs ?? DEFAULT_NODE_TIMEOUT_MS;
     this.maxSteps = options.maxSteps ?? DEFAULT_MAX_STEPS;
@@ -868,6 +871,24 @@ export class WorkflowEngine {
         );
       case "compute":
         return { output: await node.run(context), promptText: null };
+      case "notify": {
+        if (this.notificationSink === undefined) {
+          throw new Error(`Workflow node ${nodeId} requires a notification sink`);
+        }
+        const content = await node.message(context);
+        if (typeof content !== "string" || content.trim().length === 0) {
+          throw new Error(`Workflow node ${nodeId} notification must be a non-empty string`);
+        }
+        const receipt = await this.notificationSink.notify({
+          runId: state.runId,
+          workflowName: workflow.name,
+          nodeId,
+          attemptId,
+          kind: node.kind ?? "progress",
+          content: content.trim(),
+        });
+        return { output: receipt, promptText: null };
+      }
       case "action":
         return await this.runActionNode(node, context, signal, meta);
       case "checkpoint":

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -5,6 +5,7 @@ export {
   compute,
   defineWorkflow,
   isWorkflowDefinition,
+  notify,
   shell,
 } from "./definition.js";
 export { decision, decisionEdge, type DecisionDefinition } from "./decision.js";
@@ -65,6 +66,7 @@ export type {
   ComputeNodeDefinition,
   FunctionActionNodeDefinition,
   MaybePromise,
+  NotifyNodeDefinition,
   ShellActionExecution,
   ShellActionNodeDefinition,
   ShellActionResult,
@@ -79,6 +81,9 @@ export type {
   WorkflowNodeOutcome,
   WorkflowNodeResult,
   WorkflowNodeSnapshot,
+  WorkflowNotificationReceipt,
+  WorkflowNotificationRequest,
+  WorkflowNotificationSink,
   WorkflowPresentationContext,
   WorkflowRunManifest,
   WorkflowRunResult,

--- a/src/workflows/migrate-sources.ts
+++ b/src/workflows/migrate-sources.ts
@@ -25,6 +25,7 @@ export type LegacySourceMigrationQueue = {
   }): boolean;
   parkWorkflowRun(options: { runId: string; claimToken: string }): boolean;
   getWorkflowRun(runId: string): { status: "claimed" | "parked" | "done" } | undefined;
+  setWorkflowRunOriginSession?(runId: string, originSessionId: string): boolean;
 };
 
 const MIGRATION_LEASE_MS = 30_000;
@@ -45,6 +46,12 @@ export async function migrateLegacyWorkflowSources(options: {
   for (const bundle of await listRunBundles(store.outputRoot)) {
     const state = bundle.state;
     if (state.status !== "running" && state.status !== "waiting") continue;
+    if (
+      options.queue?.setWorkflowRunOriginSession !== undefined &&
+      bundle.sessionBinding !== null
+    ) {
+      options.queue.setWorkflowRunOriginSession(state.runId, bundle.sessionBinding.piSessionId);
+    }
     if (state.workflowSource !== undefined) {
       if (options.queue === undefined) continue;
       const claimToken = randomUUID();

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -4,6 +4,7 @@ import type {
   CheckpointNodeDefinition,
   ComputeNodeDefinition,
   FunctionActionNodeDefinition,
+  NotifyNodeDefinition,
   ShellActionNodeDefinition,
   WorkflowDefinition,
   WorkflowEdge,
@@ -62,6 +63,16 @@ export function assertValidComputeNode(node: ComputeNodeDefinition, nodeId = "co
   assertCommonNodeFields(node, nodeId);
 }
 
+export function assertValidNotifyNode(node: NotifyNodeDefinition, nodeId = "notify"): void {
+  if (typeof node.message !== "function") {
+    fail(`node ${nodeId} requires a message function`);
+  }
+  if (node.kind !== undefined && node.kind !== "progress" && node.kind !== "final") {
+    fail(`node ${nodeId} kind must be progress or final`);
+  }
+  assertCommonNodeFields(node, nodeId);
+}
+
 export function assertValidActionNode(node: ActionNodeDefinition, nodeId = "action"): void {
   // Dispatch discriminates with `"exec" in node`, so validation must use the
   // same property semantics: a present-but-invalid `exec` is an error even
@@ -111,6 +122,9 @@ function assertValidNode(node: WorkflowNodeDefinition, nodeId: string): void {
       return;
     case "compute":
       assertValidComputeNode(node, nodeId);
+      return;
+    case "notify":
+      assertValidNotifyNode(node, nodeId);
       return;
     case "action":
       assertValidActionNode(node, nodeId);

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1323,6 +1323,9 @@ function snapshotNode(node: WorkflowNodeDefinition): WorkflowNodeSnapshot {
   if (node.nodeType === "agent" && node.expectedOutput !== undefined) {
     common.expectedOutput = node.expectedOutput;
   }
+  if (node.nodeType === "notify") {
+    common.summary = node.kind ?? "progress";
+  }
   if (node.nodeType === "checkpoint" && node.summary !== undefined) {
     common.summary = node.summary;
   }

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -68,6 +68,13 @@ export type ComputeNodeDefinition = WorkflowNodeCommon & {
   run: (context: WorkflowNodeContext) => MaybePromise<unknown>;
 };
 
+/** A durable user-facing message addressed by the runtime to the run's origin session. */
+export type NotifyNodeDefinition = WorkflowNodeCommon & {
+  nodeType: "notify";
+  message: (context: WorkflowNodeContext) => MaybePromise<string>;
+  kind?: "progress" | "final";
+};
+
 /** A deterministic runtime-owned step implemented as a local function. */
 export type FunctionActionNodeDefinition = WorkflowNodeCommon & {
   nodeType: "action";
@@ -121,6 +128,7 @@ export type CheckpointNodeDefinition = WorkflowNodeCommon & {
 export type WorkflowNodeDefinition =
   | AgentNodeDefinition
   | ComputeNodeDefinition
+  | NotifyNodeDefinition
   | ActionNodeDefinition
   | CheckpointNodeDefinition;
 
@@ -444,8 +452,28 @@ export interface AgentStepExecutor {
   runAgentStep(request: AgentStepRequest, signal: AbortSignal): Promise<AgentStepSubmission>;
 }
 
+export type WorkflowNotificationRequest = {
+  runId: string;
+  workflowName: string;
+  nodeId: string;
+  attemptId: string;
+  kind: "progress" | "final";
+  content: string;
+};
+
+export type WorkflowNotificationReceipt = {
+  notificationId: string;
+  targetSessionId: string;
+};
+
+export interface WorkflowNotificationSink {
+  notify(request: WorkflowNotificationRequest): MaybePromise<WorkflowNotificationReceipt>;
+}
+
 export type WorkflowEngineOptions = {
   executor: AgentStepExecutor;
+  /** Durable destination for notify nodes. Required when a workflow uses one. */
+  notificationSink?: WorkflowNotificationSink;
   /** Root directory for run bundles. Defaults to `~/.pi/agent/workflows/runs`. */
   outputRoot?: string;
   /**

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -457,6 +457,8 @@ export type WorkflowNotificationRequest = {
   workflowName: string;
   nodeId: string;
   attemptId: string;
+  /** Stable one-based occurrence of this notify node within the run. */
+  notificationIndex: number;
   kind: "progress" | "final";
   content: string;
 };

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -754,7 +754,7 @@ describe.sequential("pi-workflows end to end", () => {
 
     expect(state.status).toBe("completed");
     expect(state.workflowName).toBe("monitor");
-    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "1" });
+    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "2" });
     expect(state.workflowPath).toBeUndefined();
     expect(state.workflowHash).toBeUndefined();
     expect(state.finalOutput).toMatchObject({

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -36,8 +36,13 @@ type RegisteredCommand = {
 };
 
 type SentMessage = {
-  message: { customType: string; content: string; display: boolean };
-  options: { deliverAs: string; triggerTurn: boolean };
+  message: {
+    customType: string;
+    content: string;
+    display: boolean;
+    details?: Record<string, unknown>;
+  };
+  options?: { deliverAs?: string; triggerTurn?: boolean };
 };
 
 type FakeContext = {
@@ -49,6 +54,7 @@ type FakeContext = {
     getSessionId: () => string;
     getLeafId: () => string | null;
     getSessionFile: () => string | undefined;
+    getBranch: () => never[];
   };
   ui: {
     notify: (message: string, type?: string) => void;
@@ -93,6 +99,7 @@ function makeHarness(options: {
       getSessionId: () => options.sessionId ?? "test-session",
       getLeafId: () => null,
       getSessionFile: () => undefined,
+      getBranch: () => [],
     },
     ui: {
       notify: (message) => notifications.push(message),
@@ -131,8 +138,11 @@ function makeHarness(options: {
       idle = false;
       queueMicrotask(() => options.respond(prompt, tool as RegisteredTool));
     },
-    sendMessage: (message: SentMessage["message"], messageOptions: SentMessage["options"]) => {
-      sentMessages.push({ message, options: messageOptions });
+    sendMessage: (message: SentMessage["message"], messageOptions?: SentMessage["options"]) => {
+      sentMessages.push({
+        message,
+        ...(messageOptions === undefined ? {} : { options: messageOptions }),
+      });
     },
   };
 
@@ -1362,46 +1372,43 @@ export default defineWorkflow({
     }
   });
 
-  it("never replays old events but picks up new ones live", { timeout: 25_000 }, async () => {
-    const cwd = await makeTempDir("pi-workflows-ext-sync");
+  it("delivers notifications only to their target session", { timeout: 20_000 }, async () => {
+    const cwd = await makeTempDir("pi-workflows-ext-notifications");
     const runsDir = await makeTempDir("pi-workflows-ext-runs");
     vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
     try {
-      await writeEchoWorkflow(cwd);
-      const respond = (prompt: string, tool: RegisteredTool) => {
-        const contract = stepFromPrompt(prompt);
-        if (contract) {
-          void tool.execute("call-1", {
-            action: "submit",
-            ...contract,
-            output: { reply: "hi" },
-          });
-        }
-      };
-      // Session A drives a run to completion.
-      const first = makeHarness({ cwd, sessionId: "session-a", respond });
-      await first.emitAsync("session_start");
-      await first.command.handler("mini say hi", first.ctx);
-      await waitFor(() => first.notifications.some((note) => note.includes("completed")));
-      await first.emitAsync("session_shutdown");
+      const queue = new SqliteControllerStore(projectControllerStorePath(cwd));
+      queue.enqueueWorkflowNotification({
+        runId: "run-targeted",
+        nodeId: "report",
+        attemptId: "attempt-1",
+        targetSessionId: "session-a",
+        kind: "final",
+        content: "Targeted result",
+      });
+      queue.close();
 
-      // Session B opens later: no replay of the completed run.
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
-      await second.emitAsync("session_start");
-      expect(second.notifications.some((note) => note.includes("completed"))).toBe(false);
+      const unrelated = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+      await unrelated.emitAsync("session_start");
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(unrelated.sentMessages).toHaveLength(0);
 
-      // A new run by session C appears in B's live feed within a poll cycle.
-      const third = makeHarness({ cwd, sessionId: "session-c", respond });
-      await third.emitAsync("session_start");
-      await third.command.handler("mini again", third.ctx);
-      await waitFor(() => third.notifications.some((note) => note.includes("completed")));
-      await waitFor(
-        () =>
-          second.notifications.some((note) => note.includes("mini") && note.includes("completed")),
-        10_000,
+      const origin = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
+      await origin.emitAsync("session_start");
+      await waitFor(() =>
+        origin.sentMessages.some((entry) => entry.message.content === "Targeted result"),
       );
-      await second.emitAsync("session_shutdown");
-      await third.emitAsync("session_shutdown");
+      expect(origin.sentMessages[0]?.message).toMatchObject({
+        customType: "pi-workflows-notification",
+        display: true,
+        details: { runId: "run-targeted", kind: "final" },
+      });
+
+      const check = new SqliteControllerStore(projectControllerStorePath(cwd), { readOnly: true });
+      expect(check.listPendingWorkflowNotifications("session-a")).toHaveLength(0);
+      check.close();
+      await unrelated.emitAsync("session_shutdown");
+      await origin.emitAsync("session_shutdown");
     } finally {
       vi.unstubAllEnvs();
     }
@@ -1768,7 +1775,7 @@ export default defineWorkflow({
     try {
       const queueFile = projectControllerStorePath(cwd);
       const queue = new SqliteControllerStore(queueFile);
-      const first = queue.recordRunEvent({
+      queue.recordRunEvent({
         runId: "r-skip",
         workflowRef: "old",
         type: "queued",
@@ -1780,7 +1787,6 @@ export default defineWorkflow({
         type: "resumed",
         runnerId: "other-runner",
       });
-      queue.setSessionWatermark("project", first);
       queue.close();
 
       const harness = makeHarness({ cwd, sessionId: "session-y", respond: () => {} });
@@ -1789,138 +1795,6 @@ export default defineWorkflow({
       await new Promise((resolve) => setTimeout(resolve, 100));
       expect(harness.notifications.some((note) => note.includes("r-resume"))).toBe(false);
       await harness.emitAsync("session_shutdown");
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
-
-  it("describes each noteworthy event kind in the live feed", { timeout: 20_000 }, async () => {
-    const cwd = await makeTempDir("pi-workflows-ext-feed");
-    const runsDir = await makeTempDir("pi-workflows-ext-runs");
-    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
-    try {
-      const queueFile = projectControllerStorePath(cwd);
-      const queue = new SqliteControllerStore(queueFile);
-      const first = queue.recordRunEvent({
-        runId: "r-skip",
-        workflowRef: "old",
-        type: "queued",
-        runnerId: "other-runner",
-      });
-      for (const [runId, type, payload] of [
-        ["r-done", "completed", {}],
-        ["r-fail", "failed", { error: "boom" }],
-        ["r-wait", "waiting", { waitingOn: "review" }],
-        ["r-park", "parked", {}],
-        ["r-cancel", "cancelled", {}],
-        ["r-timeout", "timed_out", {}],
-        ["r-wait2", "waiting", {}],
-        ["r-fail2", "failed", {}],
-      ] as const) {
-        queue.recordRunEvent({
-          runId,
-          workflowRef: "demo",
-          type,
-          runnerId: "other-runner",
-          payload,
-        });
-      }
-      queue.setSessionWatermark("project", first);
-      queue.close();
-
-      const harness = makeHarness({ cwd, sessionId: "session-x", respond: () => {} });
-      await harness.emitAsync("session_start");
-      await waitFor(() => harness.notifications.some((note) => note.includes("boom")));
-      const feed = harness.notifications.find((note) => note.includes("boom")) as string;
-      expect(feed).toContain("demo run r-done completed");
-      expect(feed).toContain("demo run r-fail failed: boom");
-      expect(feed).toContain("waits at checkpoint review");
-      expect(feed).toContain("was parked and will resume");
-      expect(feed).toContain("demo run r-cancel cancelled");
-      expect(feed).toContain("demo run r-timeout timed_out");
-      expect(feed).toContain("demo run r-fail2 failed");
-      expect(feed).not.toContain("r-skip");
-      await harness.emitAsync("session_shutdown");
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
-
-  it("catches up a reopened session with a state snapshot", { timeout: 20_000 }, async () => {
-    const cwd = await makeTempDir("pi-workflows-ext-snapshot");
-    const runsDir = await makeTempDir("pi-workflows-ext-runs");
-    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
-    try {
-      await fs.mkdir(path.join(cwd, ".pi", "workflows"), { recursive: true });
-      await fs.writeFile(
-        path.join(cwd, ".pi", "workflows", "gate.workflow.ts"),
-        `import { checkpoint, compute, defineWorkflow } from "@osolmaz/pi-workflows";
-export default defineWorkflow({
-  name: "gate",
-  startAt: "approval",
-  nodes: {
-    approval: checkpoint({ summary: "approve" }),
-    apply: compute({ run: () => 1 }),
-  },
-  edges: [{ from: "approval", to: "apply" }],
-});
-`,
-        "utf8",
-      );
-      await fs.writeFile(
-        path.join(cwd, ".pi", "workflows", "slow.workflow.ts"),
-        `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
-export default defineWorkflow({
-  name: "slow",
-  startAt: "work",
-  nodes: {
-    work: compute({
-      run: ({ signal }) => new Promise((resolve, reject) => {
-        const timer = setTimeout(() => resolve("done"), 400);
-        signal.addEventListener("abort", () => {
-          clearTimeout(timer);
-          reject(signal.reason);
-        }, { once: true });
-      }),
-    }),
-  },
-  edges: [],
-});
-`,
-        "utf8",
-      );
-      // Session A: one run waits at a checkpoint; another parks mid-flight.
-      const first = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
-      await first.emitAsync("session_start");
-      await first.command.handler("gate", first.ctx);
-      await waitFor(() =>
-        first.notifications.some((note) => note.includes("parked at checkpoint approval")),
-      );
-      await first.command.handler("slow", first.ctx);
-      await waitFor(async () => {
-        const runDirs = await fs.readdir(runsDir);
-        for (const dir of runDirs) {
-          const bundle = await readRunBundle(path.join(runsDir, dir));
-          if (bundle?.state.workflowName === "slow" && bundle.state.currentNode === "work") {
-            return true;
-          }
-        }
-        return false;
-      });
-      await first.emitAsync("session_shutdown");
-
-      // Session B opens: the snapshot names both, without event replay.
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
-      await second.emitAsync("session_start");
-      await waitFor(() =>
-        second.notifications.some((note) => note.includes("waits at checkpoint approval")),
-      );
-      const snapshot = second.notifications.find((note) =>
-        note.includes("waits at checkpoint approval"),
-      );
-      expect(snapshot).toContain("waits at checkpoint approval");
-      expect(snapshot).toContain("is parked and will resume");
-      await second.emitAsync("session_shutdown");
     } finally {
       vi.unstubAllEnvs();
     }
@@ -1956,9 +1830,9 @@ export default defineWorkflow({
       );
       await first.emitAsync("session_shutdown");
 
-      // Session B has no in-memory waiting run; the tool discovers it from disk
-      // and starts the continuation after the answering turn settles.
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+      // Reopening session A discovers its waiting run from disk and starts the
+      // continuation after the answering turn settles.
+      const second = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
       await second.emitAsync("session_start");
       const queued = await second.tool.execute("answer-1", {
         action: "answer",
@@ -2080,7 +1954,7 @@ export default defineWorkflow({
       );
       await harness.emitAsync("session_shutdown");
 
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+      const second = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
       await second.emitAsync("session_start");
       await second.command.handler('answer {"round":2}', second.ctx);
       await waitFor(() => second.notifications.some((note) => note.includes("completed")));
@@ -2148,7 +2022,7 @@ export default defineWorkflow({
       // The workflow file changes while the run is parked.
       await fs.appendFile(workflowFile, "\n// edited while parked\n", "utf8");
 
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+      const second = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
       await second.emitAsync("session_start");
       await waitFor(() => second.notifications.some((note) => note.includes("parked again")));
 
@@ -2216,7 +2090,7 @@ export default defineWorkflow({
 
         // Session B claims it, fails to resume a terminal bundle, and closes
         // the row as done instead of re-parking forever.
-        const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+        const second = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
         await second.emitAsync("session_start");
         await waitFor(() => {
           const reader = new SqliteControllerStore(queueFile, { readOnly: true });
@@ -2274,7 +2148,7 @@ export default defineWorkflow({
 
       // Session B opens: it claims the parked run, resumes the node, and
       // drives it to completion.
-      const second = makeHarness({ cwd, sessionId: "session-b", respond: () => {} });
+      const second = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
       await second.emitAsync("session_start");
       await waitFor(() => second.notifications.some((note) => note.includes("Resumed workflow")));
       await waitFor(() => second.notifications.some((note) => note.includes("completed")));

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1382,6 +1382,7 @@ export default defineWorkflow({
         runId: "run-targeted",
         nodeId: "report",
         attemptId: "attempt-1",
+        notificationIndex: 1,
         targetSessionId: "session-a",
         kind: "final",
         content: "Targeted result",
@@ -1404,8 +1405,14 @@ export default defineWorkflow({
         details: { runId: "run-targeted", kind: "final" },
       });
 
-      const check = new SqliteControllerStore(projectControllerStorePath(cwd), { readOnly: true });
-      expect(check.listPendingWorkflowNotifications("session-a")).toHaveLength(0);
+      const check = new SqliteControllerStore(projectControllerStorePath(cwd));
+      expect(
+        check.claimPendingWorkflowNotifications({
+          targetSessionId: "session-a",
+          claimToken: "post-delivery-check",
+          leaseMs: 1_000,
+        }),
+      ).toHaveLength(0);
       check.close();
       await unrelated.emitAsync("session_shutdown");
       await origin.emitAsync("session_shutdown");

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { projectControllerStorePath, SqliteControllerStore } from "../src/controllers/index.js";
 import { HostProcessRegistry } from "../src/host/processes.js";
 import { WorkflowHost } from "../src/host/runner.js";
-import { compute, defineWorkflow } from "../src/workflows/definition.js";
+import { compute, defineWorkflow, notify } from "../src/workflows/definition.js";
 import { hashWorkflowSource } from "../src/workflows/loader.js";
 import { RUN_STATE_SCHEMA, readRunBundle, WorkflowRunStore } from "../src/workflows/store.js";
 import type { WorkflowRunState } from "../src/workflows/types.js";
@@ -56,12 +56,15 @@ describe("WorkflowHost", () => {
         const workflowPath = path.join(cwd, ".pi", "workflows", "parked-demo.workflow.ts");
         await fs.writeFile(
           workflowPath,
-          `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+          `import { compute, defineWorkflow, notify } from "@osolmaz/pi-workflows";
 export default defineWorkflow({
   name: "parked-demo",
   startAt: "work",
-  nodes: { work: compute({ run: () => "host-finished" }) },
-  edges: [],
+  nodes: {
+    work: compute({ run: () => "host-finished" }),
+    report: notify({ kind: "final", message: ({ outputs }) => String(outputs.work) }),
+  },
+  edges: [{ from: "work", to: "report" }],
 });
 `,
           "utf8",
@@ -77,14 +80,18 @@ export default defineWorkflow({
           runnerId: "session-a",
           claimToken: "token-a",
           leaseMs: 60_000,
+          originSessionId: "origin-session",
         });
         queue.parkWorkflowRun({ runId: "host-run-1", claimToken: "token-a" });
         const runStore = new WorkflowRunStore(runsDir);
         const workflow = defineWorkflow({
           name: "parked-demo",
           startAt: "work",
-          nodes: { work: compute({ run: () => "ignored" }) },
-          edges: [],
+          nodes: {
+            work: compute({ run: () => "ignored" }),
+            report: notify({ kind: "final", message: ({ outputs }) => String(outputs.work) }),
+          },
+          edges: [{ from: "work", to: "report" }],
         });
         const state = {
           ...runningState("host-run-1"),
@@ -121,7 +128,7 @@ export default defineWorkflow({
 
         const bundle = await readRunBundle(runDir);
         expect(bundle?.state.status).toBe("completed");
-        expect(bundle?.state.finalOutput).toBe("host-finished");
+        expect(bundle?.state.outputs.work).toBe("host-finished");
         const reader = new SqliteControllerStore(projectControllerStorePath(cwd), {
           readOnly: true,
         });
@@ -129,6 +136,9 @@ export default defineWorkflow({
           const types = reader.listRunEventsAfter(0).map((event) => event.type);
           expect(types).toContain("resumed");
           expect(types).toContain("completed");
+          expect(reader.listPendingWorkflowNotifications("origin-session")).toMatchObject([
+            { runId: "host-run-1", kind: "final", content: "host-finished" },
+          ]);
         } finally {
           reader.close();
         }

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -129,16 +129,18 @@ export default defineWorkflow({
         const bundle = await readRunBundle(runDir);
         expect(bundle?.state.status).toBe("completed");
         expect(bundle?.state.outputs.work).toBe("host-finished");
-        const reader = new SqliteControllerStore(projectControllerStorePath(cwd), {
-          readOnly: true,
-        });
+        const reader = new SqliteControllerStore(projectControllerStorePath(cwd));
         try {
           const types = reader.listRunEventsAfter(0).map((event) => event.type);
           expect(types).toContain("resumed");
           expect(types).toContain("completed");
-          expect(reader.listPendingWorkflowNotifications("origin-session")).toMatchObject([
-            { runId: "host-run-1", kind: "final", content: "host-finished" },
-          ]);
+          expect(
+            reader.claimPendingWorkflowNotifications({
+              targetSessionId: "origin-session",
+              claimToken: "host-test-reader",
+              leaseMs: 1_000,
+            }),
+          ).toMatchObject([{ runId: "host-run-1", kind: "final", content: "host-finished" }]);
         } finally {
           reader.close();
         }

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -118,7 +118,7 @@ describe("resolveWorkflowRef", () => {
     const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir }, builtinWorkflowCatalog);
 
     expect(resolved.sourceKind).toBe("builtin");
-    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "1" });
+    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "2" });
     expect(resolved.definition.name).toBe("monitor");
   });
 

--- a/test/migrate-sources.test.ts
+++ b/test/migrate-sources.test.ts
@@ -69,6 +69,13 @@ describe("migrateLegacyWorkflowSources", () => {
       leaseMs: 30_000,
     });
     queue.parkWorkflowRun({ runId: "legacy-run", claimToken: "old-claim" });
+    await store.writeSessionBinding(runDir, {
+      schema: "pi-workflows.session-binding.v1",
+      runId: "legacy-run",
+      piSessionId: "origin-session",
+      cwd: "/project",
+      boundAt: new Date().toISOString(),
+    });
 
     const result = await migrateLegacyWorkflowSources({ catalog: catalog(), store, queue });
 
@@ -76,6 +83,7 @@ describe("migrateLegacyWorkflowSources", () => {
     expect(queue.getWorkflowRun("legacy-run")).toMatchObject({
       workflowName: "fixture",
       workflowSourceRef: "builtin:fixture",
+      originSessionId: "origin-session",
       status: "parked",
     });
     queue.close();

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentNodeDefinition,
   AgentStepExecutor,
   ComputeNodeDefinition,
+  NotifyNodeDefinition,
   ShellActionNodeDefinition,
   WorkflowNodeContext,
 } from "../src/workflows/types.js";
@@ -66,6 +67,7 @@ describe("built-in monitor workflow", () => {
   it("runs a report step before finishing when the check asks to report", async () => {
     const outputRoot = await makeTempDir("pi-workflows-monitor-report");
     const prompts: string[] = [];
+    const notifications: string[] = [];
     const outputs = [
       {
         route: "stop_report",
@@ -73,7 +75,6 @@ describe("built-in monitor workflow", () => {
         report: "PR 123 now has a failed Linux check.",
         reason: "A requested report condition is true and the pull request closed.",
       },
-      { reported: true },
     ];
     const executor: AgentStepExecutor = {
       async runAgentStep(request) {
@@ -89,13 +90,19 @@ describe("built-in monitor workflow", () => {
     const engine = new WorkflowEngine({
       executor,
       store: new WorkflowRunStore(outputRoot),
+      notificationSink: {
+        notify: (request) => {
+          notifications.push(request.content);
+          return { notificationId: "notification-1", targetSessionId: "session-1" };
+        },
+      },
     });
 
     const result = await engine.run(monitor, monitorInput());
 
     expect(result.state.status).toBe("completed");
-    expect(prompts).toHaveLength(2);
-    expect(prompts[1]).toContain("PR 123 now has a failed Linux check.");
+    expect(prompts).toHaveLength(1);
+    expect(notifications).toEqual(["PR 123 now has a failed Linux check."]);
     expect(result.state.finalOutput).toMatchObject({ reported: true });
   });
 
@@ -185,7 +192,7 @@ describe("built-in monitor workflow", () => {
       ]),
       store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-no-report")),
     });
-    const invalidAck = new WorkflowEngine({
+    const noSink = new WorkflowEngine({
       executor: scriptedExecutor([
         {
           route: "stop_report",
@@ -193,20 +200,19 @@ describe("built-in monitor workflow", () => {
           report: "State changed.",
           reason: "report",
         },
-        { reported: false },
       ]),
-      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-bad-ack")),
+      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-no-sink")),
     });
 
-    const [badCheck, noReport, badAck] = await Promise.all([
+    const [badCheck, noReport, missingSink] = await Promise.all([
       invalidCheck.run(monitor, monitorInput()),
       missingReport.run(monitor, monitorInput()),
-      invalidAck.run(monitor, monitorInput()),
+      noSink.run(monitor, monitorInput()),
     ]);
 
     expect(badCheck.state.error).toContain("route must be one of");
     expect(noReport.state.error).toContain("requires a report");
-    expect(badAck.state.error).toContain("reported to true");
+    expect(missingSink.state.error).toContain("requires a notification sink");
   });
 
   it("formats monitor prompts, guards, and fallback output", async () => {
@@ -253,9 +259,9 @@ describe("built-in monitor workflow", () => {
 
     const check = monitor.nodes.check as AgentNodeDefinition;
     expect(await check.prompt(context)).toContain("Previous accepted observation: Initial state");
-    const report = monitor.nodes.report_stop as AgentNodeDefinition;
+    const report = monitor.nodes.report_stop as NotifyNodeDefinition;
     expect(
-      await report.prompt({
+      await report.message({
         ...context,
         outputs: { check: { observation: "Fallback observation" } },
       }),
@@ -302,13 +308,11 @@ describe("built-in monitor workflow", () => {
       signal: new AbortController().signal,
     };
 
-    for (const nodeId of ["check", "report_continue", "report_stop"] as const) {
-      const node = monitor.nodes[nodeId] as AgentNodeDefinition;
-      expect(node.timeoutMs).toBeTypeOf("function");
-      expect(await (node.timeoutMs as (context: WorkflowNodeContext) => number)(context)).toBe(
-        90 * 60_000,
-      );
-    }
+    const node = monitor.nodes.check as AgentNodeDefinition;
+    expect(node.timeoutMs).toBeTypeOf("function");
+    expect(await (node.timeoutMs as (context: WorkflowNodeContext) => number)(context)).toBe(
+      90 * 60_000,
+    );
     expect(result.state.outputs.prepare).toMatchObject({ checkTimeoutMinutes: 90 });
   });
 

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -67,7 +67,7 @@ describe("built-in monitor workflow", () => {
   it("runs a report step before finishing when the check asks to report", async () => {
     const outputRoot = await makeTempDir("pi-workflows-monitor-report");
     const prompts: string[] = [];
-    const notifications: string[] = [];
+    const notifications: { content: string; notificationIndex: number }[] = [];
     const outputs = [
       {
         route: "stop_report",
@@ -92,7 +92,10 @@ describe("built-in monitor workflow", () => {
       store: new WorkflowRunStore(outputRoot),
       notificationSink: {
         notify: (request) => {
-          notifications.push(request.content);
+          notifications.push({
+            content: request.content,
+            notificationIndex: request.notificationIndex,
+          });
           return { notificationId: "notification-1", targetSessionId: "session-1" };
         },
       },
@@ -102,7 +105,9 @@ describe("built-in monitor workflow", () => {
 
     expect(result.state.status).toBe("completed");
     expect(prompts).toHaveLength(1);
-    expect(notifications).toEqual(["PR 123 now has a failed Linux check."]);
+    expect(notifications).toEqual([
+      { content: "PR 123 now has a failed Linux check.", notificationIndex: 1 },
+    ]);
     expect(result.state.finalOutput).toMatchObject({ reported: true });
   });
 

--- a/test/run-queue.test.ts
+++ b/test/run-queue.test.ts
@@ -105,6 +105,7 @@ describe("workflow run queue", () => {
       runId: "run-1",
       nodeId: "report",
       attemptId: "attempt-1",
+      notificationIndex: 1,
       targetSessionId: "session-a",
       kind: "progress",
       content: "State changed",
@@ -114,7 +115,8 @@ describe("workflow run queue", () => {
     const duplicate = store.enqueueWorkflowNotification({
       runId: "run-1",
       nodeId: "report",
-      attemptId: "attempt-1",
+      attemptId: "attempt-2",
+      notificationIndex: 1,
       targetSessionId: "session-a",
       kind: "progress",
       content: "State changed",
@@ -122,12 +124,34 @@ describe("workflow run queue", () => {
       now: T1,
     });
     expect(duplicate.notificationId).toBe(first.notificationId);
-    expect(store.listPendingWorkflowNotifications("session-b")).toEqual([]);
-    expect(store.listPendingWorkflowNotifications("session-a")).toEqual([first]);
+    expect(
+      store.claimPendingWorkflowNotifications({
+        targetSessionId: "session-b",
+        claimToken: "claim-b",
+        leaseMs: 1_000,
+        now: T0,
+      }),
+    ).toEqual([]);
+    const claimed = store.claimPendingWorkflowNotifications({
+      targetSessionId: "session-a",
+      claimToken: "claim-a",
+      leaseMs: 1_000,
+      now: T0,
+    });
+    expect(claimed).toMatchObject([{ notificationId: first.notificationId }]);
+    expect(
+      store.claimPendingWorkflowNotifications({
+        targetSessionId: "session-a",
+        claimToken: "claim-other",
+        leaseMs: 1_000,
+        now: T0,
+      }),
+    ).toEqual([]);
     expect(
       store.markWorkflowNotificationDelivered({
         notificationId: first.notificationId,
-        targetSessionId: "session-b",
+        targetSessionId: "session-a",
+        claimToken: "wrong-claim",
         now: T1,
       }),
     ).toBe(false);
@@ -135,10 +159,44 @@ describe("workflow run queue", () => {
       store.markWorkflowNotificationDelivered({
         notificationId: first.notificationId,
         targetSessionId: "session-a",
+        claimToken: "claim-a",
         now: T1,
       }),
     ).toBe(true);
-    expect(store.listPendingWorkflowNotifications("session-a")).toEqual([]);
+
+    const reclaimable = store.enqueueWorkflowNotification({
+      runId: "run-1",
+      nodeId: "report",
+      attemptId: "attempt-3",
+      notificationIndex: 2,
+      targetSessionId: "session-a",
+      kind: "final",
+      content: "Finished",
+      notificationId: "notification-3",
+      now: T1,
+    });
+    store.claimPendingWorkflowNotifications({
+      targetSessionId: "session-a",
+      claimToken: "expired-claim",
+      leaseMs: 1_000,
+      now: T1,
+    });
+    expect(
+      store.claimPendingWorkflowNotifications({
+        targetSessionId: "session-a",
+        claimToken: "replacement-claim",
+        leaseMs: 1_000,
+        now: T3,
+      }),
+    ).toMatchObject([{ notificationId: reclaimable.notificationId }]);
+    expect(
+      store.markWorkflowNotificationDelivered({
+        notificationId: reclaimable.notificationId,
+        targetSessionId: "session-a",
+        claimToken: "expired-claim",
+        now: T3,
+      }),
+    ).toBe(false);
   });
 
   it("rejects duplicate run ids and unsafe inputs", async () => {

--- a/test/run-queue.test.ts
+++ b/test/run-queue.test.ts
@@ -48,6 +48,7 @@ describe("workflow run queue", () => {
       runnerId: "runner-a",
       claimToken: "token-a",
       affinityRunnerId: "runner-a",
+      originSessionId: null,
       parentRunId: null,
       createdAt: T0,
     });
@@ -61,6 +62,83 @@ describe("workflow run queue", () => {
         now: T0,
       }),
     ).toBeUndefined();
+  });
+
+  it("restricts session-bound runs to their origin session", async () => {
+    const store = await makeStore();
+    store.enqueueWorkflowRun({
+      runId: "bound-run",
+      workflowName: "monitor",
+      workflowSourceRef: "builtin:monitor",
+      input: {},
+      runnerId: "runner-a",
+      claimToken: "token-a",
+      leaseMs: 1_000,
+      originSessionId: "session-a",
+      now: T0,
+    });
+    store.parkWorkflowRun({ runId: "bound-run", claimToken: "token-a", now: T1 });
+
+    expect(
+      store.claimNextWorkflowRun({
+        runnerId: "runner-b",
+        claimToken: "token-b",
+        leaseMs: 1_000,
+        sessionId: "session-b",
+        now: T2,
+      }),
+    ).toBeUndefined();
+    expect(
+      store.claimNextWorkflowRun({
+        runnerId: "runner-c",
+        claimToken: "token-c",
+        leaseMs: 1_000,
+        sessionId: "session-a",
+        now: T2,
+      })?.originSessionId,
+    ).toBe("session-a");
+  });
+
+  it("stores and delivers session-addressed notifications idempotently", async () => {
+    const store = await makeStore();
+    const first = store.enqueueWorkflowNotification({
+      runId: "run-1",
+      nodeId: "report",
+      attemptId: "attempt-1",
+      targetSessionId: "session-a",
+      kind: "progress",
+      content: "State changed",
+      notificationId: "notification-1",
+      now: T0,
+    });
+    const duplicate = store.enqueueWorkflowNotification({
+      runId: "run-1",
+      nodeId: "report",
+      attemptId: "attempt-1",
+      targetSessionId: "session-a",
+      kind: "progress",
+      content: "State changed",
+      notificationId: "notification-2",
+      now: T1,
+    });
+    expect(duplicate.notificationId).toBe(first.notificationId);
+    expect(store.listPendingWorkflowNotifications("session-b")).toEqual([]);
+    expect(store.listPendingWorkflowNotifications("session-a")).toEqual([first]);
+    expect(
+      store.markWorkflowNotificationDelivered({
+        notificationId: first.notificationId,
+        targetSessionId: "session-b",
+        now: T1,
+      }),
+    ).toBe(false);
+    expect(
+      store.markWorkflowNotificationDelivered({
+        notificationId: first.notificationId,
+        targetSessionId: "session-a",
+        now: T1,
+      }),
+    ).toBe(true);
+    expect(store.listPendingWorkflowNotifications("session-a")).toEqual([]);
   });
 
   it("rejects duplicate run ids and unsafe inputs", async () => {
@@ -338,7 +416,6 @@ describe("workflow run queue", () => {
       /Invalid workflow run id/,
     );
     expect(() => store.listRunEventsAfter(-1)).toThrow(/Invalid run event watermark/);
-    expect(() => store.setSessionWatermark("s", -1)).toThrow(/Invalid run event watermark/);
     expect(() =>
       store.claimNextWorkflowRun({
         runnerId: "r",
@@ -391,7 +468,6 @@ describe("workflow run queue", () => {
     // A fresh database reports missing runs and empty feeds.
     expect(store.getWorkflowRun("never-existed")).toBeUndefined();
     expect(store.listRunEventsAfter(0)).toEqual([]);
-    expect(store.latestRunEventSeq()).toBe(0);
   });
 
   it("deletes a claimed row by token", async () => {
@@ -449,8 +525,8 @@ describe("workflow run queue", () => {
   });
 });
 
-describe("run event feed and session watermarks", () => {
-  it("records events, pages after a watermark, and tracks sessions independently", async () => {
+describe("run event audit feed", () => {
+  it("records events and pages after a sequence", async () => {
     const store = await makeStore();
     const first = store.recordRunEvent({
       runId: "run-1",
@@ -477,15 +553,6 @@ describe("run event feed and session watermarks", () => {
       type: "completed",
       payload: { finalOutput: "done" },
     });
-
-    expect(store.getSessionWatermark("session-a")).toBe(0);
-    store.setSessionWatermark("session-a", first, T1);
-    store.setSessionWatermark("session-b", second, T2);
-    expect(store.getSessionWatermark("session-a")).toBe(first);
-    expect(store.getSessionWatermark("session-b")).toBe(second);
-    // Watermarks never move backwards.
-    store.setSessionWatermark("session-b", first, T3);
-    expect(store.getSessionWatermark("session-b")).toBe(second);
   });
 
   it("rejects unsafe event fields", async () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -6,6 +6,7 @@ import {
   compute,
   defineWorkflow,
   isWorkflowDefinition,
+  notify,
   shell,
 } from "../src/workflows/definition.js";
 import {
@@ -109,6 +110,12 @@ describe("node constructors", () => {
     expect(() => compute({ run: "nope" as never })).toThrow(/requires a run function/);
   });
 
+  it("validates notification nodes", () => {
+    expect(() => notify({ message: "nope" as never })).toThrow(/requires a message function/);
+    expect(() => notify({ message: () => "ok", kind: "other" as never })).toThrow(/kind/);
+    expect(notify({ message: () => "ok" }).nodeType).toBe("notify");
+  });
+
   it("validates action nodes", () => {
     expect(() => action({} as never)).toThrow(/exactly one of run or exec/);
     expect(() => action({ run: () => 1, exec: () => ({ command: "x" }) } as never)).toThrow(
@@ -168,12 +175,14 @@ describe("definition snapshots", () => {
         }),
         act: shell({ exec: () => ({ command: "true" }) }),
         fn: action({ run: () => 1 }),
+        report: notify({ message: () => "done", kind: "final" }),
         stop: checkpoint({ summary: "pause here" }),
       },
       edges: [
         { from: "start", to: "act" },
         { from: "act", to: "fn" },
-        { from: "fn", to: "stop" },
+        { from: "fn", to: "report" },
+        { from: "report", to: "stop" },
       ],
     });
     const snapshot = createDefinitionSnapshot(workflow);
@@ -185,6 +194,7 @@ describe("definition snapshots", () => {
     });
     expect(snapshot.nodes.act).toEqual({ nodeType: "action", actionExecution: "shell" });
     expect(snapshot.nodes.fn).toEqual({ nodeType: "action", actionExecution: "function" });
+    expect(snapshot.nodes.report).toEqual({ nodeType: "notify", summary: "final" });
     expect(snapshot.nodes.stop).toEqual({ nodeType: "checkpoint", summary: "pause here" });
   });
 });

--- a/tui/src/render.rs
+++ b/tui/src/render.rs
@@ -99,6 +99,7 @@ fn node_type_glyph(node_type: &str) -> char {
     match node_type {
         "agent" => '●',
         "compute" => 'ƒ',
+        "notify" => '✉',
         "action" => '⚙',
         "checkpoint" => '◆',
         _ => '?',
@@ -111,6 +112,8 @@ fn node_type_style(node_type: &str, focused: bool) -> CanvasStyle {
         ("agent", true) => CanvasStyle::AgentFocus,
         ("compute", false) => CanvasStyle::Compute,
         ("compute", true) => CanvasStyle::ComputeFocus,
+        ("notify", false) => CanvasStyle::Action,
+        ("notify", true) => CanvasStyle::ActionFocus,
         ("action", false) => CanvasStyle::Action,
         ("action", true) => CanvasStyle::ActionFocus,
         ("checkpoint", false) => CanvasStyle::Checkpoint,


### PR DESCRIPTION
## Summary

Workflow reports could appear in an unrelated Pi conversation when several sessions used the same directory.
This change routes each report only to the Pi session that started its workflow.
It replaces project-wide hidden-message broadcasts with a durable session-addressed outbox and a runtime-owned `notify` node.

## What Changed

Workflow execution and user-facing delivery are now separate.
A standalone host can execute a workflow, but it cannot change the report destination.

- Added origin session ownership to queued interactive runs.
- Added durable, idempotent workflow notifications addressed to one Pi session.
- Added the `notify` workflow node.
- Changed the built-in monitor to use `notify` instead of asking an agent step to relay text.
- Prevented unrelated interactive sessions from claiming session-bound runs.
- Migrated active queue rows from run-bundle session bindings.
- Removed project-wide event-feed injection and its shared watermark.
- Added the missing known monitor hashes to the bounded legacy migration.

## Testing

The full TypeScript, end-to-end, Slophammer, package, and Rust TUI checks passed locally.
Tests cover unrelated-session isolation, origin-only claiming, outbox deduplication, host-produced notifications, monitor delivery, and migration.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `cargo fmt --check --manifest-path tui/Cargo.toml`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npm pack --dry-run`
- `git diff --check`

SimpleDoc still reports 10 older repository-wide files that need migration. The new plan file passes the required naming and frontmatter rules.

## Risks

The controller SQLite store changes in place and removes the obsolete session watermark table.
Existing audit events remain available, but they no longer inject text into conversations.

- Active interactive rows gain their origin from `session/binding.json` when available.
- Rows without a binding remain detached rather than guessing from the working directory.
- Existing old events are not converted to notifications, which prevents stale cross-session reports.
