### PR TITLE
fix: make workflow widget responsive

### DIFF
--- a/docs/plans/2026-08-13-responsive-workflow-widget-plan.md
+++ b/docs/plans/2026-08-13-responsive-workflow-widget-plan.md
@@ -1,0 +1,64 @@
+---
+title: Make the workflow widget responsive
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-13
+---
+
+# Make the workflow widget responsive
+
+The live workflow graph breaks into wrapped fragments when a Pi terminal is narrow. This is reproducible in a 43-column Herdr pane. Pi requires every TUI component to return lines that do not exceed the width passed to `render(width)`.
+
+## Requirements
+
+- Render the live workflow widget from Pi's component-form `setWidget` API.
+- Use the width supplied to the component's `render(width)` method.
+- Keep the boxed graph when all displayed graph lines fit.
+- Use a compact node list when the boxed graph does not fit.
+- Keep the active or waiting node visible in the compact layout.
+- Keep the widget within Pi's 10-line budget.
+- Ensure every line has a visible width less than or equal to the supplied width.
+- Preserve manual vertical scrolling for the boxed graph.
+- Handle widths down to one column without terminal wrapping.
+
+## Non-goals
+
+- Do not modify Pi core.
+- Do not change workflow state or persisted schemas.
+- Do not add a global output truncation layer.
+- Do not change the standalone workflow viewer.
+
+## Design
+
+`buildWidgetView` will accept the available width. It will first build the current boxed graph view. If every displayed line fits after the widget indentation, it will keep that view. Otherwise, it will render a compact list with one node per line and a short overflow marker. The compact list follows the active or waiting node and uses the same status glyphs as the graph.
+
+The extension will install one Pi widget component for each active workflow. Its `render(width)` method will read the latest workflow state and call `buildWidgetView` with that width. State changes will request a normal Pi render by setting the component again. Pi will call the component with the current width after terminal resizes.
+
+## Contract impact
+
+- Session state: no change.
+- Other persistent data: no change.
+- Pi internals: no change.
+- Public API: documented component-form `ctx.ui.setWidget` and `Component.render(width)`.
+
+## Acceptance criteria
+
+- The reproduced 43-column monitor view does not wrap.
+- Widths 80, 43, 40, 20, 8, and 1 all return valid lines.
+- Every rendered line satisfies `visibleWidth(line) <= width`.
+- Wide views still show the boxed graph.
+- Narrow views show a readable compact list with the active node.
+- Existing scrolling and workflow behavior remain unchanged.
+
+## Verification
+
+- `npm run check`
+- `npm run test:e2e`
+- `npx slophammer-ts@latest dry .`
+- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
+- `git diff --check`
+- `npx -y @simpledoc/simpledoc check`
+- `cargo fmt --check --manifest-path tui/Cargo.toml`
+- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings`
+- `cargo test --manifest-path tui/Cargo.toml`
+- `pi-reviewer --base main`
+- Start Pi in a narrow terminal and confirm that the active monitor widget does not wrap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.10",
         "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^26.1.1",
         "@vitest/coverage-istanbul": "^4.1.10",
@@ -34,6 +35,7 @@
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
         "typebox": "*"
       }
     },
@@ -878,19 +880,6 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "18.0.5"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
@@ -1149,19 +1138,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -1245,19 +1221,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -1425,6 +1388,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4123,6 +4100,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
@@ -4631,6 +4621,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.80.10",
     "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^26.1.1",
     "@vitest/coverage-istanbul": "^4.1.10",
@@ -76,6 +77,7 @@
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
     "typebox": "*"
   },
   "engines": {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -36,7 +36,7 @@ import {
 } from "./controller-host.js";
 import { ConversationStepExecutor } from "./executor.js";
 import { SessionRecorder } from "./recorder.js";
-import { buildWidgetView } from "./widget.js";
+import { buildWidgetView, type WidgetLayout, type WidgetScrollState } from "./widget.js";
 import { WorkflowToolParameters, type WorkflowToolInput } from "./workflow-tool.js";
 
 const RUN_CLAIM_LEASE_MS = 30_000;
@@ -312,9 +312,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
   // Manual widget scroll: null follows the active node; a number is the
   // first visible graph row, set by shift+↑/↓ and reset on step advance.
   let widgetSource: WidgetSource | null = null;
-  let widgetScroll: number | null = null;
+  let widgetScroll: WidgetScrollState = { graph: null, compact: null };
   let widgetShownScroll = 0;
   let widgetMaxScroll = 0;
+  let widgetLayout: WidgetLayout | null = null;
   let widgetStepCount = 0;
   let sessionClosed = false;
   let runGeneration = 0;
@@ -384,10 +385,11 @@ export default function piWorkflows(pi: ExtensionAPI) {
           runHeld(),
           width,
         );
+        widgetLayout = view.layout;
         widgetShownScroll = view.scroll;
         widgetMaxScroll = view.maxScroll;
-        if (widgetScroll !== null) {
-          widgetScroll = view.scroll;
+        if (widgetScroll[view.layout] !== null) {
+          widgetScroll[view.layout] = view.scroll;
         }
         return view.lines;
       },
@@ -404,7 +406,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (state.steps.length !== widgetStepCount) {
       widgetStepCount = state.steps.length;
       // The workflow moved on; resume following the active node.
-      widgetScroll = null;
+      widgetScroll = { graph: null, compact: null };
     }
     widgetSource = { state, snapshot };
     renderWidget(ctx);
@@ -412,7 +414,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
 
   const clearWidget = (ctx: ExtensionContext) => {
     widgetSource = null;
-    widgetScroll = null;
+    widgetScroll = { graph: null, compact: null };
+    widgetLayout = null;
     setWidget(ctx, undefined);
     setStatus(ctx, undefined);
   };
@@ -421,7 +424,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (!widgetSource || widgetMaxScroll === 0) {
       return;
     }
-    widgetScroll = Math.max(0, Math.min(widgetShownScroll + delta, widgetMaxScroll));
+    if (widgetLayout === null) return;
+    widgetScroll[widgetLayout] = Math.max(0, Math.min(widgetShownScroll + delta, widgetMaxScroll));
     renderWidget(ctx);
   };
 
@@ -1802,7 +1806,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
     clearWidgetTimer();
     stopWidgetTicker();
     widgetSource = null;
-    widgetScroll = null;
+    widgetScroll = { graph: null, compact: null };
+    widgetLayout = null;
   });
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -204,6 +204,11 @@ type WidgetSource = {
   snapshot: WorkflowDefinitionSnapshot;
 };
 
+type WorkflowWidgetComponent = {
+  render: (width: number) => string[];
+  invalidate: () => void;
+};
+
 export default function piWorkflows(pi: ExtensionAPI) {
   // One runner identity per session; it names this session in run claims.
   const runnerId = randomUUID();
@@ -331,10 +336,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
   };
 
-  const setWidget = (ctx: ExtensionContext, lines: string[] | undefined) => {
+  const setWidget = (
+    ctx: ExtensionContext,
+    factory: (() => WorkflowWidgetComponent) | undefined,
+  ) => {
     try {
       if (ctx.hasUI) {
-        ctx.ui.setWidget(WIDGET_KEY, lines);
+        ctx.ui.setWidget(WIDGET_KEY, factory);
       }
     } catch {
       // Stale ctx; the widget no longer exists.
@@ -365,20 +373,26 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (!widgetSource) {
       return;
     }
-    const held = runHeld();
-    const view = buildWidgetView(
-      widgetSource.state,
-      widgetSource.snapshot,
-      new Date(),
-      widgetScroll,
-      held,
-    );
-    widgetShownScroll = view.scroll;
-    widgetMaxScroll = view.maxScroll;
-    if (widgetScroll !== null) {
-      widgetScroll = view.scroll;
-    }
-    setWidget(ctx, view.lines);
+    setWidget(ctx, () => ({
+      render(width: number): string[] {
+        if (!widgetSource) return [];
+        const view = buildWidgetView(
+          widgetSource.state,
+          widgetSource.snapshot,
+          new Date(),
+          widgetScroll,
+          runHeld(),
+          width,
+        );
+        widgetShownScroll = view.scroll;
+        widgetMaxScroll = view.maxScroll;
+        if (widgetScroll !== null) {
+          widgetScroll = view.scroll;
+        }
+        return view.lines;
+      },
+      invalidate() {},
+    }));
     setStatus(ctx, footerStatus(widgetSource.state));
   };
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -209,6 +209,9 @@ type WorkflowWidgetComponent = {
   invalidate: () => void;
 };
 
+type WorkflowWidgetFactory = () => WorkflowWidgetComponent;
+type WorkflowWidgetContent = string[] | WorkflowWidgetFactory;
+
 export default function piWorkflows(pi: ExtensionAPI) {
   // One runner identity per session; it names this session in run claims.
   const runnerId = randomUUID();
@@ -337,13 +340,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
   };
 
-  const setWidget = (
-    ctx: ExtensionContext,
-    factory: (() => WorkflowWidgetComponent) | undefined,
-  ) => {
+  const setWidget = (ctx: ExtensionContext, content: WorkflowWidgetContent | undefined) => {
     try {
       if (ctx.hasUI) {
-        ctx.ui.setWidget(WIDGET_KEY, factory);
+        if (typeof content === "function") {
+          ctx.ui.setWidget(WIDGET_KEY, content);
+        } else {
+          ctx.ui.setWidget(WIDGET_KEY, content);
+        }
       }
     } catch {
       // Stale ctx; the widget no longer exists.
@@ -374,27 +378,30 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (!widgetSource) {
       return;
     }
-    setWidget(ctx, () => ({
-      render(width: number): string[] {
-        if (!widgetSource) return [];
-        const view = buildWidgetView(
-          widgetSource.state,
-          widgetSource.snapshot,
-          new Date(),
-          widgetScroll,
-          runHeld(),
-          width,
-        );
-        widgetLayout = view.layout;
-        widgetShownScroll = view.scroll;
-        widgetMaxScroll = view.maxScroll;
-        if (widgetScroll[view.layout] !== null) {
-          widgetScroll[view.layout] = view.scroll;
-        }
-        return view.lines;
-      },
-      invalidate() {},
-    }));
+    const render = (width = Number.POSITIVE_INFINITY): string[] => {
+      if (!widgetSource) return [];
+      const view = buildWidgetView(
+        widgetSource.state,
+        widgetSource.snapshot,
+        new Date(),
+        widgetScroll,
+        runHeld(),
+        width,
+      );
+      widgetLayout = view.layout;
+      widgetShownScroll = view.scroll;
+      widgetMaxScroll = view.maxScroll;
+      if (widgetScroll[view.layout] !== null) {
+        widgetScroll[view.layout] = view.scroll;
+      }
+      return view.lines;
+    };
+    if (ctx.mode === "tui") {
+      setWidget(ctx, () => ({ render, invalidate() {} }));
+    } else {
+      // RPC transports string widgets but cannot serialize TUI component factories.
+      setWidget(ctx, render());
+    }
     setStatus(ctx, footerStatus(widgetSource.state));
   };
 

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -128,8 +128,12 @@ function compactWidgetView(
   }
   const anchor = scroll ?? compactFocusIndex(state, snapshot);
   const windowed = windowLines(nodes, budget, anchor, scroll !== null);
+  const indentation = width >= 3 ? "  " : "";
   return {
-    lines: fitLines([header, ...windowed.lines.map((line) => `  ${line}`), ...footer], width),
+    lines: fitLines(
+      [header, ...windowed.lines.map((line) => `${indentation}${line}`), ...footer],
+      width,
+    ),
     layout: "compact",
     scroll: windowed.scroll,
     maxScroll: windowed.maxScroll,

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -43,10 +43,14 @@ export function displayNodeIds(snapshot: WorkflowDefinitionSnapshot): string[] {
   return Object.keys(snapshot.nodes);
 }
 
+export type WidgetLayout = "graph" | "compact";
+
+export type WidgetScrollState = Record<WidgetLayout, number | null>;
+
 export type WidgetView = {
   lines: string[];
-  layout: "graph" | "compact";
-  /** The clamped first visible graph row; feed back in to scroll relatively. */
+  layout: WidgetLayout;
+  /** The clamped first visible row for the selected layout. */
   scroll: number;
   /** Largest useful scroll value; 0 when the whole graph fits. */
   maxScroll: number;
@@ -63,7 +67,7 @@ export function buildWidgetView(
   state: WorkflowRunState,
   snapshot: WorkflowDefinitionSnapshot,
   now: Date = new Date(),
-  scroll: number | null = null,
+  scroll: WidgetScrollState = { graph: null, compact: null },
   held = false,
   width = Number.POSITIVE_INFINITY,
 ): WidgetView {
@@ -93,7 +97,13 @@ export function buildWidgetView(
     nodeStyle: "box",
   });
   if (graph.length > 0) {
-    const windowed = windowLines(graph, budget, scroll ?? focusLine(graph, state), scroll !== null);
+    const graphScroll = scroll.graph;
+    const windowed = windowLines(
+      graph,
+      budget,
+      graphScroll ?? focusLine(graph, state),
+      graphScroll !== null,
+    );
     const graphLines = windowed.lines.map((line) => `  ${line}`);
     if (graphLines.every((line) => visibleWidth(line) <= availableWidth)) {
       return {
@@ -105,7 +115,7 @@ export function buildWidgetView(
     }
   }
 
-  return compactWidgetView(state, snapshot, header, footer, budget, availableWidth, scroll);
+  return compactWidgetView(state, snapshot, header, footer, budget, availableWidth, scroll.compact);
 }
 
 function compactWidgetView(

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -1,3 +1,4 @@
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { ansi, stripAnsi } from "../render/ansi.js";
 import { renderGraphLines } from "../render/graph-render.js";
 import { sanitizeText } from "../workflows/text.js";
@@ -44,6 +45,7 @@ export function displayNodeIds(snapshot: WorkflowDefinitionSnapshot): string[] {
 
 export type WidgetView = {
   lines: string[];
+  layout: "graph" | "compact";
   /** The clamped first visible graph row; feed back in to scroll relatively. */
   scroll: number;
   /** Largest useful scroll value; 0 when the whole graph fits. */
@@ -63,7 +65,11 @@ export function buildWidgetView(
   now: Date = new Date(),
   scroll: number | null = null,
   held = false,
+  width = Number.POSITIVE_INFINITY,
 ): WidgetView {
+  const availableWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : width;
+  if (availableWidth === 0) return { lines: [], layout: "compact", scroll: 0, maxScroll: 0 };
+
   // `held` covers pauses the state cannot see yet: an escape-interrupted
   // step or a pause requested while the current node is still finishing.
   const paused = held || state.paused === true;
@@ -79,26 +85,82 @@ export function buildWidgetView(
     footer.push(`  error: ${truncate(sanitizeText(state.error), 120)}`);
   }
   if (state.status === "waiting" && state.waitingOn) {
-    footer.push(`  waiting on checkpoint: ${state.waitingOn}`);
+    footer.push(`  waiting on checkpoint: ${sanitizeText(state.waitingOn)}`);
   }
 
   const budget = PI_MAX_WIDGET_LINES - 1 - footer.length;
   const graph = renderGraphLines({ state, snapshot }, state.steps.length - 1, now, {
     nodeStyle: "box",
   });
-  if (graph.length === 0) {
+  if (graph.length > 0) {
+    const windowed = windowLines(graph, budget, scroll ?? focusLine(graph, state), scroll !== null);
+    const graphLines = windowed.lines.map((line) => `  ${line}`);
+    if (graphLines.every((line) => visibleWidth(line) <= availableWidth)) {
+      return {
+        lines: fitLines([header, ...graphLines, ...footer], availableWidth),
+        layout: "graph",
+        scroll: windowed.scroll,
+        maxScroll: windowed.maxScroll,
+      };
+    }
+  }
+
+  return compactWidgetView(state, snapshot, header, footer, budget, availableWidth, scroll);
+}
+
+function compactWidgetView(
+  state: WorkflowRunState,
+  snapshot: WorkflowDefinitionSnapshot,
+  header: string,
+  footer: string[],
+  budget: number,
+  width: number,
+  scroll: number | null,
+): WidgetView {
+  const nodes = displayNodeIds(snapshot).map((nodeId) => compactNodeLine(state, snapshot, nodeId));
+  if (nodes.length === 0) {
     return {
-      lines: [header, `  ${compactNodeStrip(state, snapshot)}`, ...footer],
+      lines: fitLines([header, ...footer], width),
+      layout: "compact",
       scroll: 0,
       maxScroll: 0,
     };
   }
-  const windowed = windowLines(graph, budget, scroll ?? focusLine(graph, state), scroll !== null);
+  const anchor = scroll ?? compactFocusIndex(state, snapshot);
+  const windowed = windowLines(nodes, budget, anchor, scroll !== null);
   return {
-    lines: [header, ...windowed.lines.map((line) => `  ${line}`), ...footer],
+    lines: fitLines([header, ...windowed.lines.map((line) => `  ${line}`), ...footer], width),
+    layout: "compact",
     scroll: windowed.scroll,
     maxScroll: windowed.maxScroll,
   };
+}
+
+function compactFocusIndex(state: WorkflowRunState, snapshot: WorkflowDefinitionSnapshot): number {
+  const nodeIds = displayNodeIds(snapshot);
+  const focused = state.currentNode ?? state.waitingOn;
+  if (focused === undefined) return Math.max(0, nodeIds.length - 1);
+  const index = nodeIds.indexOf(focused);
+  return index === -1 ? Math.max(0, nodeIds.length - 1) : index;
+}
+
+function compactNodeLine(
+  state: WorkflowRunState,
+  snapshot: WorkflowDefinitionSnapshot,
+  nodeId: string,
+): string {
+  const node = snapshot.nodes[nodeId];
+  const type = node?.nodeType === undefined ? "" : ` · ${node.nodeType}`;
+  const detail =
+    state.currentNode === nodeId && state.statusDetail
+      ? ` · ${sanitizeText(state.statusDetail)}`
+      : "";
+  return `${nodeGlyph(state, nodeId)} ${sanitizeText(nodeId)}${type}${detail}`;
+}
+
+function fitLines(lines: string[], width: number): string[] {
+  if (!Number.isFinite(width)) return lines;
+  return lines.map((line) => truncateToWidth(line, width, width > 1 ? "…" : ""));
 }
 
 /** Back-compatible line view following the active node. */
@@ -165,19 +227,6 @@ function windowLines(
 function clampStart(anchor: number, inner: number, total: number, anchorIsStart: boolean): number {
   const start = anchorIsStart ? anchor : anchor - Math.floor(inner / 2);
   return Math.max(0, Math.min(start, total - inner));
-}
-
-function compactNodeStrip(state: WorkflowRunState, snapshot: WorkflowDefinitionSnapshot): string {
-  return displayNodeIds(snapshot)
-    .map((nodeId) => {
-      const marker = nodeGlyph(state, nodeId);
-      const detail =
-        state.currentNode === nodeId && state.statusDetail
-          ? ` (${sanitizeText(state.statusDetail)})`
-          : "";
-      return `${marker} ${nodeId}${detail}`;
-    })
-    .join("  ");
 }
 
 function truncate(text: string, maxLength: number): string {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -54,6 +54,7 @@ type WidgetFactory = () => WidgetComponent;
 
 type FakeContext = {
   cwd: string;
+  mode: "tui" | "rpc";
   hasUI: boolean;
   isIdle: () => boolean;
   abort: () => void;
@@ -65,7 +66,7 @@ type FakeContext = {
   };
   ui: {
     notify: (message: string, type?: string) => void;
-    setWidget: (key: string, factory: WidgetFactory | undefined) => void;
+    setWidget: (key: string, content: string[] | WidgetFactory | undefined) => void;
     setStatus: (key: string, text: string | undefined) => void;
   };
 };
@@ -79,9 +80,10 @@ function makeHarness(options: {
   cwd: string;
   respond: (prompt: string, tool: RegisteredTool) => void;
   sessionId?: string;
+  mode?: "tui" | "rpc";
 }) {
   const notifications: string[] = [];
-  const widgets: (WidgetFactory | undefined)[] = [];
+  const widgets: (string[] | WidgetFactory | undefined)[] = [];
   const statuses: (string | undefined)[] = [];
   const sentMessages: SentMessage[] = [];
   const listeners = new Map<
@@ -96,6 +98,7 @@ function makeHarness(options: {
 
   const ctx: FakeContext = {
     cwd: options.cwd,
+    mode: options.mode ?? "tui",
     hasUI: true,
     isIdle: () => idle,
     abort: () => {
@@ -110,7 +113,7 @@ function makeHarness(options: {
     },
     ui: {
       notify: (message) => notifications.push(message),
-      setWidget: (_key, factory) => widgets.push(factory),
+      setWidget: (_key, content) => widgets.push(content),
       setStatus: (_key, text) => statuses.push(text),
     },
   };
@@ -938,8 +941,8 @@ export default defineWorkflow({
       // The final widget update must still be present, not cleared, and show
       // the waiting state so the human sees the parked checkpoint.
       const last = harness.widgets.at(-1);
-      expect(last).toBeDefined();
-      const rendered = last?.().render(80).join("\n");
+      expect(last).toBeTypeOf("function");
+      const rendered = typeof last === "function" ? last().render(80).join("\n") : undefined;
       expect(rendered).toContain("[waiting]");
       expect(rendered).toContain("waiting on checkpoint: review");
 
@@ -1424,6 +1427,21 @@ export default defineWorkflow({
       check.close();
       await unrelated.emitAsync("session_shutdown");
       await origin.emitAsync("session_shutdown");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("keeps string-array widget updates in RPC mode", { timeout: 20_000 }, async () => {
+    const cwd = await makeTempDir("pi-workflows-ext-rpc-widget");
+    const runsDir = await makeTempDir("pi-workflows-ext-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({ cwd, mode: "rpc", respond: () => {} });
+      await harness.command.handler("mini say hi", harness.ctx);
+      await waitFor(() => harness.widgets.some((widget) => Array.isArray(widget)));
+      expect(harness.widgets.some((widget) => Array.isArray(widget))).toBe(true);
     } finally {
       vi.unstubAllEnvs();
     }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -45,6 +45,13 @@ type SentMessage = {
   options?: { deliverAs?: string; triggerTurn?: boolean };
 };
 
+type WidgetComponent = {
+  render: (width: number) => string[];
+  invalidate: () => void;
+};
+
+type WidgetFactory = () => WidgetComponent;
+
 type FakeContext = {
   cwd: string;
   hasUI: boolean;
@@ -58,7 +65,7 @@ type FakeContext = {
   };
   ui: {
     notify: (message: string, type?: string) => void;
-    setWidget: (key: string, lines: string[] | undefined) => void;
+    setWidget: (key: string, factory: WidgetFactory | undefined) => void;
     setStatus: (key: string, text: string | undefined) => void;
   };
 };
@@ -74,7 +81,7 @@ function makeHarness(options: {
   sessionId?: string;
 }) {
   const notifications: string[] = [];
-  const widgets: (string[] | undefined)[] = [];
+  const widgets: (WidgetFactory | undefined)[] = [];
   const statuses: (string | undefined)[] = [];
   const sentMessages: SentMessage[] = [];
   const listeners = new Map<
@@ -103,7 +110,7 @@ function makeHarness(options: {
     },
     ui: {
       notify: (message) => notifications.push(message),
-      setWidget: (_key, lines) => widgets.push(lines),
+      setWidget: (_key, factory) => widgets.push(factory),
       setStatus: (_key, text) => statuses.push(text),
     },
   };
@@ -932,8 +939,9 @@ export default defineWorkflow({
       // the waiting state so the human sees the parked checkpoint.
       const last = harness.widgets.at(-1);
       expect(last).toBeDefined();
-      expect(last?.join("\n")).toContain("[waiting]");
-      expect(last?.join("\n")).toContain("waiting on checkpoint: review");
+      const rendered = last?.().render(80).join("\n");
+      expect(rendered).toContain("[waiting]");
+      expect(rendered).toContain("waiting on checkpoint: review");
 
       // With no live run, cancel clears the parked widget instead of
       // claiming nothing exists.

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -157,6 +157,23 @@ describe("buildWidgetLines", () => {
     if (width === 43) expect(view.layout).toBe("compact");
   });
 
+  it.each([2, 1])("keeps the active glyph visible at width %i", (width) => {
+    const view = buildWidgetView(
+      makeState({
+        workflowName: "wide-demo",
+        currentNode: "compare-the-observation-with-the-requested-stop-condition",
+      }),
+      wideSnapshot,
+      undefined,
+      null,
+      false,
+      width,
+    );
+    expect(view.layout).toBe("compact");
+    expect(view.lines.some((line) => line.includes("◐"))).toBe(true);
+    expect(view.lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+  });
+
   it("keeps the boxed graph when its displayed lines fit", () => {
     const view = buildWidgetView(
       makeState({ currentNode: "second" }),

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import {
   buildWidgetLines,
@@ -23,6 +24,27 @@ const workflow = defineWorkflow({
   ],
 });
 const snapshot = createDefinitionSnapshot(workflow);
+const wideSnapshot = createDefinitionSnapshot(
+  defineWorkflow({
+    name: "wide-demo",
+    startAt: "collect-the-current-observation-from-the-external-system",
+    nodes: {
+      "collect-the-current-observation-from-the-external-system": compute({ run: () => 1 }),
+      "compare-the-observation-with-the-requested-stop-condition": compute({ run: () => 2 }),
+      "report-the-result-to-the-origin-session": compute({ run: () => 3 }),
+    },
+    edges: [
+      {
+        from: "collect-the-current-observation-from-the-external-system",
+        to: "compare-the-observation-with-the-requested-stop-condition",
+      },
+      {
+        from: "compare-the-observation-with-the-requested-stop-condition",
+        to: "report-the-result-to-the-origin-session",
+      },
+    ],
+  }),
+);
 
 function makeResult(nodeId: string, outcome: WorkflowNodeResult["outcome"]): WorkflowNodeResult {
   return {
@@ -111,6 +133,59 @@ describe("buildWidgetLines", () => {
     expect(joined).toContain("┃");
     expect(joined).toContain("┏");
     expect(lines.length).toBeLessThanOrEqual(10);
+  });
+
+  it.each([80, 43, 40, 20, 8, 1])("fits every line within a %i-column terminal", (width) => {
+    const state = makeState({
+      workflowName: "wide-demo",
+      currentNode: "compare-the-observation-with-the-requested-stop-condition",
+      currentNodeStartedAt: "2026-01-01T00:00:00.000Z",
+      statusDetail: "waiting for a long external operation to complete",
+      runTitle: "a long workflow title that cannot fit in a narrow terminal",
+    });
+    const view = buildWidgetView(
+      state,
+      wideSnapshot,
+      new Date("2026-01-01T00:00:02.000Z"),
+      null,
+      false,
+      width,
+    );
+
+    expect(view.lines.length).toBeLessThanOrEqual(10);
+    expect(view.lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+    if (width === 43) expect(view.layout).toBe("compact");
+  });
+
+  it("keeps the boxed graph when its displayed lines fit", () => {
+    const view = buildWidgetView(
+      makeState({ currentNode: "second" }),
+      snapshot,
+      undefined,
+      null,
+      false,
+      120,
+    );
+    expect(view.layout).toBe("graph");
+    expect(view.lines.join("\n")).toContain("┏");
+  });
+
+  it("uses a compact list at narrow widths and keeps the active node visible", () => {
+    const view = buildWidgetView(
+      makeState({
+        workflowName: "wide-demo",
+        currentNode: "compare-the-observation-with-the-requested-stop-condition",
+        statusDetail: "checking the latest result",
+      }),
+      wideSnapshot,
+      new Date("2026-01-01T00:00:02.000Z"),
+      null,
+      false,
+      43,
+    );
+    expect(view.layout).toBe("compact");
+    expect(view.lines.join("\n")).toContain("◐ compare-the-observation");
+    expect(view.lines.every((line) => visibleWidth(line) <= 43)).toBe(true);
   });
 
   it("windows tall graphs around the active node within pi's line budget", () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -147,7 +147,7 @@ describe("buildWidgetLines", () => {
       state,
       wideSnapshot,
       new Date("2026-01-01T00:00:02.000Z"),
-      null,
+      { graph: null, compact: null },
       false,
       width,
     );
@@ -165,7 +165,7 @@ describe("buildWidgetLines", () => {
       }),
       wideSnapshot,
       undefined,
-      null,
+      { graph: null, compact: null },
       false,
       width,
     );
@@ -179,7 +179,7 @@ describe("buildWidgetLines", () => {
       makeState({ currentNode: "second" }),
       snapshot,
       undefined,
-      null,
+      { graph: null, compact: null },
       false,
       120,
     );
@@ -196,13 +196,48 @@ describe("buildWidgetLines", () => {
       }),
       wideSnapshot,
       new Date("2026-01-01T00:00:02.000Z"),
-      null,
+      { graph: null, compact: null },
       false,
       43,
     );
     expect(view.layout).toBe("compact");
     expect(view.lines.join("\n")).toContain("◐ compare-the-observation");
     expect(view.lines.every((line) => visibleWidth(line) <= 43)).toBe(true);
+  });
+
+  it("does not apply a graph scroll offset to the compact layout", () => {
+    const nodes = Object.fromEntries(
+      Array.from({ length: 20 }, (_value, index) => [
+        `very-long-monitor-node-name-that-cannot-fit-${String(index)}`,
+        compute({ run: () => index }),
+      ]),
+    );
+    const edges = Array.from({ length: 19 }, (_value, index) => ({
+      from: `very-long-monitor-node-name-that-cannot-fit-${String(index)}`,
+      to: `very-long-monitor-node-name-that-cannot-fit-${String(index + 1)}`,
+    }));
+    const tallWide = createDefinitionSnapshot(
+      defineWorkflow({
+        name: "tall-wide",
+        startAt: "very-long-monitor-node-name-that-cannot-fit-0",
+        nodes,
+        edges,
+      }),
+    );
+    const state = makeState({
+      workflowName: "tall-wide",
+      currentNode: "very-long-monitor-node-name-that-cannot-fit-10",
+    });
+    const view = buildWidgetView(
+      state,
+      tallWide,
+      undefined,
+      { graph: 70, compact: null },
+      false,
+      43,
+    );
+    expect(view.layout).toBe("compact");
+    expect(view.lines.join("\n")).toContain("very-long-monitor-node-name");
   });
 
   it("windows tall graphs around the active node within pi's line budget", () => {
@@ -285,13 +320,13 @@ describe("buildWidgetLines", () => {
     expect(followed.lines.join("\n")).toContain("◐ running");
     expect(followed.lines.join("\n")).toContain("n10");
 
-    const top = buildWidgetView(state, tall, now, 0);
+    const top = buildWidgetView(state, tall, now, { graph: 0, compact: null });
     expect(top.scroll).toBe(0);
     expect(top.lines.join("\n")).toContain("n0");
     expect(top.lines.join("\n")).not.toMatch(/↑ \d+ more/);
     expect(top.lines.join("\n")).toMatch(/↓ \d+ more · shift\+↑\/↓ scroll/);
 
-    const bottom = buildWidgetView(state, tall, now, 9_999);
+    const bottom = buildWidgetView(state, tall, now, { graph: 9_999, compact: null });
     expect(bottom.scroll).toBeLessThanOrEqual(bottom.maxScroll);
     expect(bottom.lines.join("\n")).toContain("n19");
     expect(bottom.lines.join("\n")).not.toMatch(/↓ \d+ more/);


### PR DESCRIPTION
> Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

The live workflow graph broke into wrapped fragments in narrow Pi terminals.
This change makes the widget read the actual terminal width and switch to a compact node list when the boxed graph cannot fit.
It matters because active monitor workflows must remain readable in narrow Herdr panes.

## What Changed

The widget now follows Pi's documented width contract instead of sending fixed pre-rendered lines.
Wide terminals keep the full graph, while narrow terminals get a compact view that follows the active or waiting node.

- Use Pi's component-form `setWidget` API and its `render(width)` method.
- Keep the boxed graph when every displayed line fits.
- Switch to a compact node list when the graph is too wide.
- Truncate every line to the supplied visible width.
- Keep the existing 10-line limit and manual vertical scrolling.
- Add a documented implementation plan and width tests down to one column.

## Testing

The full TypeScript, end-to-end, Slophammer, package, and Rust checks passed.
The new tests cover widths 80, 43, 40, 20, 8, and 1 and assert that no line exceeds the supplied width.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `cargo fmt --check --manifest-path tui/Cargo.toml`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npm pack --dry-run`
- `git diff --check`

SimpleDoc still reports the repository's existing 10 legacy documentation paths and frontmatter items. The new plan follows the required dated format and frontmatter rules.

## Risks

The change is limited to the in-Pi live widget and does not alter workflow execution or stored data.
Very narrow terminals lose detail by design, but they remain valid and readable instead of wrapping unpredictably.
