### PR TITLE
feat: color workflow widget states

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Inside pi, a compact widget above the editor shows one line per workflow node.
 The first glyph is the node status. The second glyph is the node type: `●`
 agent, `ƒ` compute, `!` notification, `$` shell action, `*` function action, or
 `◆` checkpoint. Repeated visits, runtime details, and timing appear on the same
-line when they apply. Long workflows are windowed around the active node.
+line when they apply. Pi's current theme highlights the full active-node line,
+while status glyphs keep every state readable without color. Long workflows are
+windowed around the active node.
 Scroll the list with `shift+↑` / `shift+↓`; it snaps back to following the
 active node whenever the workflow advances a step. Use `piw` when you need the
 full boxed graph and its edges.

--- a/docs/plans/2026-08-13-responsive-workflow-widget-plan.md
+++ b/docs/plans/2026-08-13-responsive-workflow-widget-plan.md
@@ -18,6 +18,11 @@ The live workflow widget must remain easy to scan without using most of the conv
 - Put the status glyph first and a one-column node-type glyph second.
 - Use terminal-safe type glyphs: `●` agent, `ƒ` compute, `!` notification, `$` shell action, `*` function action, and `◆` checkpoint.
 - Show concise runtime details when space permits: repeated visits, active elapsed time, latest completed duration, current status detail, and node errors.
+- Use Pi's supplied theme for TUI colors. Keep RPC and other non-TUI widget output plain.
+- Make the active node unmistakable by coloring its full line with the theme accent and making its name bold.
+- Color a held or waiting focus line with the warning color.
+- Color only the status glyph for completed and failed nodes, color failed error text, and dim pending nodes and non-focused type glyphs.
+- Keep status glyphs as the non-color state signal.
 - Keep the widget within Pi's 10-line budget.
 - Ensure every line has a visible width less than or equal to the supplied width.
 - Preserve manual vertical scrolling for long node lists.
@@ -42,14 +47,14 @@ Optional fields are omitted when they do not apply and truncated from the right 
 
 Node-type glyphs come from one shared formatter used by both the compact widget and graph viewer. The node snapshot already distinguishes shell actions from function actions, so this change needs no workflow schema change. A shell action named `sleep` appears as `$ sleep`; it does not become a new wait-node type.
 
-The extension installs one Pi widget component for each active workflow. Its `render(width)` method reads the latest workflow state and calls `buildWidgetView` with that width. State changes request a normal Pi render by setting the component again. Pi calls the component with the current width after terminal resizes. The standalone viewer remains the place to inspect the full workflow graph.
+The extension installs one Pi widget component for each active workflow. The documented component factory supplies Pi's current `Theme`. Its `render(width)` method reads the latest workflow state and calls `buildWidgetView` with that width and theme. State changes request a normal Pi render by setting the component again. Pi calls the component with the current width after terminal resizes. RPC mode keeps using serializable string arrays and does not receive color codes. The standalone viewer remains the place to inspect the full workflow graph.
 
 ## Contract impact
 
 - Session state: no change.
 - Other persistent data: no change.
 - Pi internals: no change.
-- Public API: documented component-form `ctx.ui.setWidget` and `Component.render(width)`.
+- Public API: documented component-form `ctx.ui.setWidget`, its supplied `Theme`, and `Component.render(width)`.
 
 ## Acceptance criteria
 
@@ -59,7 +64,10 @@ The extension installs one Pi widget component for each active workflow. Its `re
 - Every rendered line satisfies `visibleWidth(line) <= width`.
 - Each real node and action subtype uses its documented one-column glyph.
 - A repeated node shows its visit count, and active and completed nodes show useful timing.
-- The active node remains visible in a long workflow.
+- The active node remains visible in a long workflow and its full line uses the theme accent with a bold name.
+- Completed, failed, waiting, and pending states use the specified theme roles without relying on color alone.
+- TUI lines remain width-safe after color codes are added.
+- RPC widget lines contain no ANSI color codes.
 - Existing scrolling and workflow execution behavior remain unchanged.
 
 ## Verification

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { builtinWorkflowCatalog } from "../builtins/catalog.js";
 import { projectControllerStorePath, SqliteControllerStore } from "../controllers/index.js";
 import type { JsonObject } from "../controllers/types.js";
@@ -209,7 +209,7 @@ type WorkflowWidgetComponent = {
   invalidate: () => void;
 };
 
-type WorkflowWidgetFactory = () => WorkflowWidgetComponent;
+type WorkflowWidgetFactory = (_tui: unknown, theme: Theme) => WorkflowWidgetComponent;
 type WorkflowWidgetContent = string[] | WorkflowWidgetFactory;
 
 export default function piWorkflows(pi: ExtensionAPI) {
@@ -377,7 +377,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (!widgetSource) {
       return;
     }
-    const render = (width = Number.POSITIVE_INFINITY): string[] => {
+    const render = (width = Number.POSITIVE_INFINITY, theme?: Theme): string[] => {
       if (!widgetSource) return [];
       const view = buildWidgetView(
         widgetSource.state,
@@ -386,6 +386,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         widgetScroll,
         runHeld(),
         width,
+        theme,
       );
       widgetShownScroll = view.scroll;
       widgetMaxScroll = view.maxScroll;
@@ -395,7 +396,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
       return view.lines;
     };
     if (ctx.mode === "tui") {
-      setWidget(ctx, () => ({ render, invalidate() {} }));
+      setWidget(ctx, (_tui, theme) => ({
+        render: (width) => render(width, theme),
+        invalidate() {},
+      }));
     } else {
       // RPC transports string widgets but cannot serialize TUI component factories.
       setWidget(ctx, render());

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -1,5 +1,5 @@
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
-import { ansi } from "../render/ansi.js";
 import { formatDuration } from "../render/format.js";
 import { nodeTypeGlyph } from "../render/node-type.js";
 import { sanitizeText } from "../workflows/text.js";
@@ -45,6 +45,8 @@ export function displayNodeIds(snapshot: WorkflowDefinitionSnapshot): string[] {
   return Object.keys(snapshot.nodes);
 }
 
+export type WidgetTheme = Pick<Theme, "bold" | "fg">;
+
 export type WidgetView = {
   lines: string[];
   /** The clamped first visible node row. */
@@ -65,6 +67,7 @@ export function buildWidgetView(
   scroll: number | null = null,
   held = false,
   width = Number.POSITIVE_INFINITY,
+  theme?: WidgetTheme,
 ): WidgetView {
   const availableWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : width;
   if (availableWidth === 0) return { lines: [], scroll: 0, maxScroll: 0 };
@@ -77,19 +80,22 @@ export function buildWidgetView(
   // Titles, status details, and errors can carry model- or shell-controlled
   // text; never let escape sequences or newlines reach the terminal.
   const title = state.runTitle ? ` — ${sanitizeText(state.runTitle)}` : "";
-  const header = `${glyph} workflow ${sanitizeText(state.workflowName)}${title} [${statusText}]`;
+  const headerTone = statusTone(paused ? "waiting" : state.status);
+  const header = `${paint(theme, headerTone, glyph)} workflow ${sanitizeText(state.workflowName)}${title} ${paint(theme, headerTone, `[${statusText}]`)}`;
 
   const footer: string[] = [];
   if (state.error) {
-    footer.push(`  error: ${truncate(sanitizeText(state.error), 120)}`);
+    footer.push(paint(theme, "error", `  error: ${truncate(sanitizeText(state.error), 120)}`));
   }
   if (state.status === "waiting" && state.waitingOn) {
-    footer.push(`  waiting on checkpoint: ${sanitizeText(state.waitingOn)}`);
+    footer.push(
+      paint(theme, "warning", `  waiting on checkpoint: ${sanitizeText(state.waitingOn)}`),
+    );
   }
 
   const budget = PI_MAX_WIDGET_LINES - 1 - footer.length;
   const nodes = displayNodeIds(snapshot).map((nodeId) =>
-    compactNodeLine(state, snapshot, nodeId, now),
+    compactNodeLine(state, snapshot, nodeId, now, paused, theme),
   );
   if (nodes.length === 0) {
     return {
@@ -100,7 +106,7 @@ export function buildWidgetView(
   }
 
   const anchor = scroll ?? compactFocusIndex(state, snapshot);
-  const windowed = windowLines(nodes, budget, anchor, scroll !== null);
+  const windowed = windowLines(nodes, budget, anchor, scroll !== null, theme);
   const indentation = availableWidth >= 3 ? "  " : "";
   return {
     lines: fitLines(
@@ -125,12 +131,41 @@ function compactNodeLine(
   snapshot: WorkflowDefinitionSnapshot,
   nodeId: string,
   now: Date,
+  paused: boolean,
+  theme?: WidgetTheme,
 ): string {
   const node = snapshot.nodes[nodeId];
-  const type = node ? ansi.dim(nodeTypeGlyph(node.nodeType, node.actionExecution)) : "?";
+  const glyph = nodeGlyph(state, nodeId);
+  const typeGlyph = node ? nodeTypeGlyph(node.nodeType, node.actionExecution) : "?";
+  const name = sanitizeText(nodeId);
   const segments = nodeRuntimeSegments(state, snapshot, nodeId, now);
-  const detail = segments.length > 0 ? ` · ${segments.join(" · ")}` : "";
-  return `${nodeGlyph(state, nodeId)} ${type} ${sanitizeText(nodeId)}${detail}`;
+  const isCurrent = state.currentNode === nodeId;
+  const isWaiting = state.waitingOn === nodeId;
+
+  if (isCurrent || isWaiting) {
+    const tone = paused || isWaiting ? "warning" : "accent";
+    const focusedName = theme ? theme.bold(name) : name;
+    const detail = segments.length > 0 ? ` · ${segments.join(" · ")}` : "";
+    return paint(theme, tone, `${glyph} ${typeGlyph} ${focusedName}${detail}`);
+  }
+
+  const result = state.results[nodeId];
+  if (!result) {
+    const detail = segments.length > 0 ? ` · ${segments.join(" · ")}` : "";
+    return paint(theme, "dim", `${glyph} ${typeGlyph} ${name}${detail}`);
+  }
+
+  const styledGlyph = paint(theme, result.outcome === "ok" ? "success" : "error", glyph);
+  const styledType = paint(theme, "dim", typeGlyph);
+  const styledSegments = segments.map((segment, index) =>
+    paint(
+      theme,
+      result.outcome !== "ok" && index === segments.length - 1 ? "error" : "dim",
+      segment,
+    ),
+  );
+  const detail = styledSegments.length > 0 ? ` · ${styledSegments.join(" · ")}` : "";
+  return `${styledGlyph} ${styledType} ${name}${detail}`;
 }
 
 function nodeRuntimeSegments(
@@ -188,6 +223,25 @@ function elapsedSince(startedAt: string | undefined, now: Date): string | null {
   return formatDuration(Math.max(0, now.getTime() - started));
 }
 
+function statusTone(status: WorkflowRunStatus): ThemeColor {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "failed":
+    case "timed_out":
+    case "cancelled":
+      return "error";
+    case "waiting":
+      return "warning";
+    case "running":
+      return "accent";
+  }
+}
+
+function paint(theme: WidgetTheme | undefined, color: ThemeColor, text: string): string {
+  return theme ? theme.fg(color, text) : text;
+}
+
 function fitLines(lines: string[], width: number): string[] {
   if (!Number.isFinite(width)) return lines;
   return lines.map((line) => truncateToWidth(line, width, width > 1 ? "…" : ""));
@@ -212,6 +266,7 @@ function windowLines(
   budget: number,
   anchor: number,
   anchorIsStart: boolean,
+  theme?: WidgetTheme,
 ): { lines: string[]; scroll: number; maxScroll: number } {
   if (lines.length <= budget) {
     return { lines, scroll: 0, maxScroll: 0 };
@@ -225,7 +280,7 @@ function windowLines(
   const directions = [above > 0 ? `↑ ${above}` : "", below > 0 ? `↓ ${below}` : ""]
     .filter(Boolean)
     .join(" · ");
-  out.push(ansi.dim(`${directions} more · shift+↑/↓ scroll`));
+  out.push(paint(theme, "dim", `${directions} more · shift+↑/↓ scroll`));
   return { lines: out, scroll: start, maxScroll: Math.max(0, lines.length - inner) };
 }
 

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -7,6 +7,7 @@ import { projectControllerStorePath } from "../src/controllers/store.js";
 import piWorkflows from "../src/extension/index.js";
 import type { WorkflowToolInput } from "../src/extension/workflow-tool.js";
 import { readRunBundle } from "../src/workflows/store.js";
+import { stripAnsi } from "../src/workflows/text.js";
 import { makeTempDir } from "./helpers.js";
 
 type ToolResult = {
@@ -50,7 +51,17 @@ type WidgetComponent = {
   invalidate: () => void;
 };
 
-type WidgetFactory = () => WidgetComponent;
+type WidgetTheme = {
+  bold: (text: string) => string;
+  fg: (color: string, text: string) => string;
+};
+
+type WidgetFactory = (_tui: unknown, theme: WidgetTheme) => WidgetComponent;
+
+const TEST_THEME: WidgetTheme = {
+  bold: (text) => `\u001b[1m${text}\u001b[22m`,
+  fg: (color, text) => `\u001b[${color === "accent" ? 36 : 32}m${text}\u001b[0m`,
+};
 
 type FakeContext = {
   cwd: string;
@@ -345,8 +356,11 @@ describe("pi-workflows extension", () => {
       const widget = [...harness.widgets].reverse().find((entry) => typeof entry === "function");
       expect(widget).toBeTypeOf("function");
       const renderedWidget =
-        typeof widget === "function" ? widget().render(120).join("\n") : undefined;
-      expect(renderedWidget).toContain("✓ ● reply");
+        typeof widget === "function"
+          ? widget(undefined, TEST_THEME).render(120).join("\n")
+          : undefined;
+      expect(stripAnsi(renderedWidget ?? "")).toContain("✓ ● reply");
+      expect(renderedWidget).toContain("\u001b[32m✓\u001b[0m");
       expect(renderedWidget).not.toMatch(/[┏┌┃]/u);
       expect(harness.sentMessages).toHaveLength(0);
 
@@ -948,9 +962,10 @@ export default defineWorkflow({
       // the waiting state so the human sees the parked checkpoint.
       const last = harness.widgets.at(-1);
       expect(last).toBeTypeOf("function");
-      const rendered = typeof last === "function" ? last().render(80).join("\n") : undefined;
-      expect(rendered).toContain("[waiting]");
-      expect(rendered).toContain("waiting on checkpoint: review");
+      const rendered =
+        typeof last === "function" ? last(undefined, TEST_THEME).render(80).join("\n") : undefined;
+      expect(stripAnsi(rendered ?? "")).toContain("[waiting]");
+      expect(stripAnsi(rendered ?? "")).toContain("waiting on checkpoint: review");
 
       // With no live run, cancel clears the parked widget instead of
       // claiming nothing exists.
@@ -1447,7 +1462,9 @@ export default defineWorkflow({
       const harness = makeHarness({ cwd, mode: "rpc", respond: () => {} });
       await harness.command.handler("mini say hi", harness.ctx);
       await waitFor(() => harness.widgets.some((widget) => Array.isArray(widget)));
-      expect(harness.widgets.some((widget) => Array.isArray(widget))).toBe(true);
+      const rpcWidget = harness.widgets.find((widget): widget is string[] => Array.isArray(widget));
+      expect(rpcWidget).toBeDefined();
+      expect(rpcWidget?.join("\n")).not.toContain("\u001b");
     } finally {
       vi.unstubAllEnvs();
     }

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -5,6 +5,7 @@ import {
   buildWidgetView,
   displayNodeIds,
   nodeGlyph,
+  type WidgetTheme,
 } from "../src/extension/widget.js";
 import { nodeTypeGlyph } from "../src/render/node-type.js";
 import {
@@ -37,6 +38,15 @@ const workflow = defineWorkflow({
     { from: "second", to: "third" },
   ],
 });
+const TEST_THEME: WidgetTheme = {
+  bold: (text) => `\u001b[1m${text}\u001b[22m`,
+  fg: (color, text) => {
+    const codes = { accent: 36, success: 32, error: 31, warning: 33, dim: 2 } as const;
+    const code = codes[color as keyof typeof codes] ?? 37;
+    return `\u001b[${code}m${text}\u001b[0m`;
+  },
+};
+
 const snapshot = createDefinitionSnapshot(workflow);
 const wideSnapshot = createDefinitionSnapshot(
   defineWorkflow({
@@ -174,7 +184,81 @@ describe("buildWidgetLines", () => {
     expect(joined).toContain("◐ ƒ second · verifying · 2.0s");
     expect(joined).toContain("· ƒ third");
     expect(joined).not.toMatch(/[┏┌┃]/u);
+    expect(lines.join("\n")).not.toContain("\u001b");
     expect(lines.length).toBeLessThanOrEqual(10);
+  });
+
+  it("uses the Pi theme to emphasize status without removing glyphs", () => {
+    const state = makeState({
+      currentNode: "second",
+      currentNodeStartedAt: "2026-01-01T00:00:00.000Z",
+      results: {
+        first: makeResult("first", "ok"),
+        third: makeResult("third", "failed", { error: "exit 1" }),
+      },
+      steps: [makeStep("first", 1), makeStep("third", 1)],
+    });
+    const lines = buildWidgetView(
+      state,
+      snapshot,
+      new Date("2026-01-01T00:00:02.000Z"),
+      null,
+      false,
+      120,
+      TEST_THEME,
+    ).lines;
+    const active = lines.find((line) => stripAnsi(line).includes("second")) ?? "";
+    const completed = lines.find((line) => stripAnsi(line).includes("first")) ?? "";
+    const failed = lines.find((line) => stripAnsi(line).includes("third")) ?? "";
+
+    expect(active).toContain("\u001b[36m◐ ƒ ");
+    expect(active).toContain("\u001b[1msecond\u001b[22m");
+    const heldLines = buildWidgetView(
+      state,
+      snapshot,
+      undefined,
+      null,
+      true,
+      120,
+      TEST_THEME,
+    ).lines;
+    const held = heldLines.find((line) => stripAnsi(line).includes("second")) ?? "";
+    expect(held).toContain("\u001b[33m◐ ƒ ");
+    expect(held).toContain("\u001b[1msecond\u001b[22m");
+    expect(completed).toContain("\u001b[32m✓\u001b[0m");
+    expect(completed).toContain("\u001b[2mƒ\u001b[0m");
+    expect(failed).toContain("\u001b[31m✗\u001b[0m");
+    expect(failed).toContain("\u001b[31mexit 1\u001b[0m");
+    expect(stripAnsi(lines.join("\n"))).toContain("◐ ƒ second");
+
+    const pendingLines = buildWidgetView(
+      makeState({ currentNode: "first" }),
+      snapshot,
+      undefined,
+      null,
+      false,
+      120,
+      TEST_THEME,
+    ).lines;
+    const pending = pendingLines.find((line) => stripAnsi(line).includes("second")) ?? "";
+    expect(pending).toContain("\u001b[2m· ƒ second\u001b[0m");
+
+    const waitingLines = buildWidgetView(
+      makeState({
+        status: "waiting",
+        waitingOn: "third",
+        results: { third: makeResult("third", "ok") },
+      }),
+      snapshot,
+      undefined,
+      null,
+      false,
+      120,
+      TEST_THEME,
+    ).lines;
+    const waiting = waitingLines.find((line) => stripAnsi(line).includes("third")) ?? "";
+    expect(waiting).toContain("\u001b[33m⏸ ƒ ");
+    expect(waiting).toContain("\u001b[1mthird\u001b[22m");
   });
 
   it("shows the real node types without the unsupported glyphs", () => {
@@ -282,6 +366,7 @@ describe("buildWidgetLines", () => {
         null,
         false,
         width,
+        TEST_THEME,
       );
 
       expect(view.lines.length).toBeLessThanOrEqual(10);


### PR DESCRIPTION
## Summary

The compact workflow widget made node state easy to scan, but the active node still did not stand out enough.
The TUI widget now uses Pi's current theme to highlight the full active line and bold its node name.
Other states use restrained status colors, while RPC output remains plain and every state still has a glyph.

## What Changed

The widget now uses the `Theme` supplied by Pi's documented component-form `setWidget` API.
Color is presentation-only and does not affect workflow execution or persisted data.

- Colored the full active-node line with the theme accent and made its name bold.
- Colored held and waiting focus lines with the warning color.
- Colored completed and failed status glyphs with success and error colors.
- Colored failed error text and dimmed pending rows, timing details, repeat counts, and non-focused type glyphs.
- Colored the header status and error or checkpoint footers with matching theme roles.
- Kept RPC widget arrays free of ANSI codes.
- Kept width-safe truncation after theme codes are applied, including widths down to one column.
- Updated the README and the existing responsive-widget plan.

## Testing

The color behavior, plain fallback, width handling, extension factory integration, and full package passed locally.

- `npm run check` — 43 files and 698 tests passed.
- `npm run test:e2e` — 7 tests passed.
- `npx slophammer-ts@latest dry .` — no candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — no findings.
- `cargo fmt --check --manifest-path tui/Cargo.toml` — passed.
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings` — passed.
- `cargo test --manifest-path tui/Cargo.toml` — 58 tests passed, including renderer parity.
- `npm pack --dry-run` — passed.
- `pi -ne --mode rpc --no-session -e ./src/extension/index.ts` with a `get_state` request — startup passed.
- `git diff --check` — passed.

`npx -y @simpledoc/simpledoc check` still reports the repository's same 10 legacy documentation paths. The changed plan is already valid.

## Risks

The change only affects TUI styling.
Status glyphs remain present, so color is never the only state signal.

- Pi themes control the exact colors, so appearance can vary by theme.
- RPC and other non-TUI modes keep plain serializable lines.
- No session state, workflow schema, or Pi internal changes are included.
