### PR TITLE
feat: render compact workflow step messages

### DIFF
--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -2,7 +2,7 @@
 
 This specification defines how Pi Workflows shows agent-step instructions in an interactive Pi session. The model receives the complete step prompt, while the user sees a small workflow card that can be expanded.
 
-This contract is accepted design and is not implemented in release `0.5.3`.
+This contract is implemented for the release after `0.5.3`.
 
 ## Goal
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -360,8 +360,18 @@ results. Submissions are rejected (with a reason the model sees) when no step
 is pending, the step id is wrong, the attempt id belongs to an earlier attempt
 of the same node (loops revisit node ids, so each attempt gets a fresh id), or
 `validate` throws.
-Acceptance resolves the step and the engine advances; the next agent prompt
-arrives as a new user message in the same conversation.
+Acceptance resolves the step and the engine advances. In an interactive Pi
+session, each agent prompt arrives as a `pi-workflows-agent-step` custom message
+with `triggerTurn: true`. The model receives the complete prompt, while the
+conversation shows a compact workflow and node card. Expanding tool output with
+Ctrl+O shows the exact contract and full prompt. Reminders and resumed prompts
+use the same card and keep the active attempt id.
+
+Headless RPC execution receives the same complete prompt without TUI metadata.
+Workflow notifications use a separate message type with `triggerTurn: false`,
+so a notification does not start an assistant response. See
+[WORKFLOW_STEP_MESSAGES.md](WORKFLOW_STEP_MESSAGES.md) for the message contract
+and renderer rules.
 
 ## Result presentation
 

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -9,8 +9,13 @@ export type SubmissionResult =
   | { accepted: true; message: string }
   | { accepted: false; message: string };
 
+export type PromptDeliveryKind = "step" | "reminder" | "resume";
+
 export type PromptDelivery = {
   prompt: string;
+  contract: AgentStepRequest["contract"];
+  presentation?: AgentStepRequest["presentation"];
+  kind: PromptDeliveryKind;
   /** True when the agent is known to be mid-run, so delivery must be queued. */
   streaming: boolean;
 };
@@ -54,8 +59,8 @@ const DEFAULT_MAX_NUDGES = 2;
 
 /**
  * AgentStepExecutor that runs steps inside the current pi conversation. The
- * engine hands it a prompt; it delivers the prompt as a user message and
- * resolves once the model submits an accepted output through the `workflow`
+ * engine hands it a prompt; it delivers the prompt as a model-facing workflow
+ * message and resolves once the model submits an accepted output through the `workflow`
  * tool. If the agent settles without submitting, it nudges the model a
  * bounded number of times before failing the step.
  */
@@ -111,7 +116,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     }
     try {
       this.conversation?.beginAttempt?.(pending.request.contract);
-      this.sendPrompt({ prompt: pending.request.prompt, streaming: this.streaming });
+      this.sendPrompt(this.delivery(pending.request, pending.request.prompt, "resume"));
     } catch (error) {
       this.clearPending();
       pending.reject(error);
@@ -156,7 +161,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
         return;
       }
       try {
-        this.sendPrompt({ prompt: request.prompt, streaming: this.streaming });
+        this.sendPrompt(this.delivery(request, request.prompt, "step"));
       } catch (error) {
         // A failed delivery must not leave the step installed, or every
         // subsequent agent node would fail with "already awaiting output".
@@ -227,7 +232,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
       accepted: true,
       message: [
         `Output accepted for step ${JSON.stringify(stepId)}.`,
-        "If the workflow continues, the next step arrives as a new user message. End your turn now.",
+        "If the workflow continues, the next step arrives as a new workflow message. End your turn now.",
       ].join(" "),
     };
   }
@@ -262,15 +267,18 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     const { nodeId, attemptId } = pending.request.contract;
     try {
       this.conversation?.beginAttempt?.(pending.request.contract);
-      this.sendPrompt({
-        prompt: [
-          `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
-          "Complete it by calling the `workflow` tool with:",
-          `{"action": "submit", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
-          `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
-        ].join("\n"),
-        streaming: this.streaming,
-      });
+      this.sendPrompt(
+        this.delivery(
+          pending.request,
+          [
+            `Reminder: workflow step ${JSON.stringify(nodeId)} is still awaiting your output.`,
+            "Complete it by calling the `workflow` tool with:",
+            `{"action": "submit", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
+            `Expected output: ${pending.request.contract.expectedOutput ?? "a JSON object with your result"}`,
+          ].join("\n"),
+          "reminder",
+        ),
+      );
     } catch (error) {
       // No reminder turn was started, so nothing would settle the step; fail
       // it promptly instead of waiting out the node timeout.
@@ -279,6 +287,20 @@ export class ConversationStepExecutor implements AgentStepExecutor {
       return false;
     }
     return true;
+  }
+
+  private delivery(
+    request: AgentStepRequest,
+    prompt: string,
+    kind: PromptDeliveryKind,
+  ): PromptDelivery {
+    return {
+      prompt,
+      contract: request.contract,
+      ...(request.presentation !== undefined ? { presentation: request.presentation } : {}),
+      kind,
+      streaming: this.streaming,
+    };
   }
 
   private clearPending(): void {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -36,6 +36,12 @@ import {
 } from "./controller-host.js";
 import { ConversationStepExecutor } from "./executor.js";
 import { SessionRecorder } from "./recorder.js";
+import {
+  registerWorkflowAgentStepMessageRenderer,
+  WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
+  WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+  type WorkflowAgentStepMessageDetails,
+} from "./step-message.js";
 import { buildWidgetView } from "./widget.js";
 import { WorkflowToolParameters, type WorkflowToolInput } from "./workflow-tool.js";
 
@@ -213,6 +219,8 @@ type WorkflowWidgetFactory = (_tui: unknown, theme: Theme) => WorkflowWidgetComp
 type WorkflowWidgetContent = string[] | WorkflowWidgetFactory;
 
 export default function piWorkflows(pi: ExtensionAPI) {
+  registerWorkflowAgentStepMessageRenderer(pi);
+
   // One runner identity per session; it names this session in run claims.
   const runnerId = randomUUID();
   let runQueueStore: SqliteControllerStore | null = null;
@@ -267,16 +275,19 @@ export default function piWorkflows(pi: ExtensionAPI) {
         leaseMs: NOTIFICATION_DELIVERY_LEASE_MS,
       })) {
         if (!alreadyDelivered.has(notification.notificationId)) {
-          pi.sendMessage({
-            customType: "pi-workflows-notification",
-            content: notification.content,
-            display: true,
-            details: {
-              notificationId: notification.notificationId,
-              runId: notification.runId,
-              kind: notification.kind,
+          pi.sendMessage(
+            {
+              customType: "pi-workflows-notification",
+              content: notification.content,
+              display: true,
+              details: {
+                notificationId: notification.notificationId,
+                runId: notification.runId,
+                kind: notification.kind,
+              },
             },
-          });
+            { triggerTurn: false },
+          );
           alreadyDelivered.add(notification.notificationId);
         }
         runQueueStore.markWorkflowNotificationDelivered({
@@ -734,8 +745,25 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
 
     const executor = new ConversationStepExecutor({
-      sendPrompt: ({ prompt, streaming }) => {
-        pi.sendUserMessage(prompt, streaming ? { deliverAs: "steer" } : undefined);
+      sendPrompt: ({ prompt, contract, presentation, kind, streaming }) => {
+        const details: WorkflowAgentStepMessageDetails = {
+          schema: WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
+          kind,
+          contract,
+          ...(presentation !== undefined ? { presentation } : {}),
+        };
+        pi.sendMessage(
+          {
+            customType: WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+            content: prompt,
+            display: true,
+            details,
+          },
+          {
+            triggerTurn: true,
+            deliverAs: streaming ? "steer" : "followUp",
+          },
+        );
       },
       onAbort: (contract, reason) => {
         lastExpiredAttempt = {

--- a/src/extension/step-message.ts
+++ b/src/extension/step-message.ts
@@ -1,0 +1,145 @@
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import { Box, Text, TruncatedText } from "@earendil-works/pi-tui";
+import { sanitizeText } from "../workflows/text.js";
+import type { AgentStepContract, AgentStepPresentation } from "../workflows/types.js";
+import type { PromptDeliveryKind } from "./executor.js";
+
+export const WORKFLOW_AGENT_STEP_MESSAGE_TYPE = "pi-workflows-agent-step";
+export const WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA = "pi-workflows.agent-step-message.v1";
+
+export type WorkflowAgentStepMessageDetails = {
+  schema: typeof WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA;
+  kind: PromptDeliveryKind;
+  contract: AgentStepContract;
+  presentation?: AgentStepPresentation;
+};
+
+type WorkflowAgentStepMessage = {
+  content: unknown;
+  details?: unknown;
+};
+
+type WorkflowAgentStepView = {
+  title: string;
+  status?: string;
+  expandedText?: string;
+};
+
+export function registerWorkflowAgentStepMessageRenderer(pi: ExtensionAPI): void {
+  pi.registerMessageRenderer<WorkflowAgentStepMessageDetails>(
+    WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+    (message, { expanded }, theme) => {
+      const view = buildWorkflowAgentStepView(message, expanded, theme);
+      const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+      box.addChild(new TruncatedText(view.title));
+      if (view.status !== undefined) {
+        box.addChild(new TruncatedText(view.status));
+      }
+      if (view.expandedText !== undefined) {
+        box.addChild(new Text(`\n${view.expandedText}`));
+      }
+      return box;
+    },
+  );
+}
+
+/** Build renderer text without depending on Pi's session or TUI state. */
+export function buildWorkflowAgentStepView(
+  message: WorkflowAgentStepMessage,
+  expanded: boolean,
+  theme?: Pick<Theme, "fg">,
+): WorkflowAgentStepView {
+  const details = parseDetails(message.details);
+  const contract = details?.contract;
+  const kind = details?.kind ?? "step";
+  const workflowName = cleanSingleLine(contract?.workflowName ?? "Workflow");
+  const nodeId = cleanSingleLine(contract?.nodeId ?? "step");
+  const runTitle = cleanOptionalSingleLine(details?.presentation?.runTitle);
+  const statusDetail = cleanOptionalSingleLine(details?.presentation?.statusDetail);
+  const label = runTitle ?? workflowName;
+  const suffix = kind === "step" ? "" : ` · ${kind}`;
+  const glyph = kind === "step" ? "▶" : "↻";
+  const title = paint(theme, "accent", `${glyph} ${label} › ${nodeId}${suffix}`);
+
+  if (!expanded) {
+    return {
+      title,
+      ...(statusDetail !== undefined ? { status: paint(theme, "dim", statusDetail) } : {}),
+    };
+  }
+
+  const metadata = [
+    `Workflow: ${workflowName}`,
+    ...(runTitle !== undefined ? [`Run title: ${runTitle}`] : []),
+    `Run id: ${cleanSingleLine(contract?.runId ?? "unknown")}`,
+    `Node id: ${nodeId}`,
+    `Attempt id: ${cleanSingleLine(contract?.attemptId ?? "unknown")}`,
+    `Delivery: ${kind}`,
+    `Expected output: ${cleanSingleLine(contract?.expectedOutput ?? "a JSON object with your result")}`,
+  ];
+  const prompt = contentText(message.content);
+  return {
+    title,
+    ...(statusDetail !== undefined ? { status: paint(theme, "dim", statusDetail) } : {}),
+    expandedText: `${metadata.map((line) => paint(theme, "dim", line)).join("\n")}\n\n${prompt}`,
+  };
+}
+
+function parseDetails(value: unknown): WorkflowAgentStepMessageDetails | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const candidate = value as Partial<WorkflowAgentStepMessageDetails>;
+  if (candidate.schema !== WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA) return undefined;
+  if (candidate.kind !== "step" && candidate.kind !== "reminder" && candidate.kind !== "resume") {
+    return undefined;
+  }
+  const contract = candidate.contract;
+  if (
+    contract === null ||
+    typeof contract !== "object" ||
+    typeof contract.runId !== "string" ||
+    typeof contract.workflowName !== "string" ||
+    typeof contract.nodeId !== "string" ||
+    typeof contract.attemptId !== "string"
+  ) {
+    return undefined;
+  }
+  return candidate as WorkflowAgentStepMessageDetails;
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return cleanMultiline(content);
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (part === null || typeof part !== "object" || !("text" in part)) return "";
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" ? cleanMultiline(text) : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function cleanOptionalSingleLine(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? cleanSingleLine(value) : undefined;
+}
+
+function cleanSingleLine(value: string): string {
+  return sanitizeText(value);
+}
+
+function cleanMultiline(value: string): string {
+  return value
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .split("\n")
+    .map((line) => sanitizeText(line))
+    .join("\n");
+}
+
+function paint(
+  theme: Pick<Theme, "fg"> | undefined,
+  color: "accent" | "dim",
+  text: string,
+): string {
+  return theme?.fg(color, text) ?? text;
+}

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -955,6 +955,14 @@ export class WorkflowEngine {
           ...(node.expectedOutput !== undefined ? { expectedOutput: node.expectedOutput } : {}),
         },
         prompt,
+        ...(state.runTitle !== undefined || node.statusDetail !== undefined
+          ? {
+              presentation: {
+                ...(state.runTitle !== undefined ? { runTitle: state.runTitle } : {}),
+                ...(node.statusDetail !== undefined ? { statusDetail: node.statusDetail } : {}),
+              },
+            }
+          : {}),
         accept: async (output) => await this.acceptSubmission(node, context, output),
       },
       signal,

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -56,6 +56,7 @@ export type {
   AgentNodeDefinition,
   AgentStepContract,
   AgentStepExecutor,
+  AgentStepPresentation,
   AgentStepRequest,
   AgentStepSubmission,
   ActionNodeDefinition,

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -424,9 +424,16 @@ export type AgentStepContract = {
   expectedOutput?: string;
 };
 
+/** Optional human-facing labels for an agent step. They never affect execution. */
+export type AgentStepPresentation = {
+  runTitle?: string;
+  statusDetail?: string;
+};
+
 export type AgentStepRequest = {
   contract: AgentStepContract;
   prompt: string;
+  presentation?: AgentStepPresentation;
   /**
    * Validate a submission from the model. Returns the normalized output or an
    * error message the executor should surface to the model for retry.

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -19,6 +19,18 @@ const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const PI_BIN = path.join(REPO_ROOT, "node_modules", ".bin", "pi");
 const EXTENSION_PATH = path.join(REPO_ROOT, "src", "extension", "index.ts");
 
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (part === null || typeof part !== "object" || !("text" in part)) return "";
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
+    })
+    .join("\n");
+}
+
 const E2E_CONTROLLER = `import {
   conditionTrue,
   defineController,
@@ -106,6 +118,7 @@ export default defineWorkflow({
     propose: agent({
       prompt: ({ input }) => \`Propose a solution for: \${(input as { task?: string }).task}\`,
       expectedOutput: '{ "proposal": "one sentence" }',
+      statusDetail: "Proposing a solution",
     }),
     confirm: decision({
       choices,
@@ -519,10 +532,11 @@ describe.sequential("pi-workflows end to end", () => {
     expect(manifest.status).toBe("completed");
 
     const trace = await fs.readFile(path.join(runDir, "trace.ndjson"), "utf8");
-    const types = trace
+    const traceEvents = trace
       .trim()
       .split("\n")
-      .map((line) => (JSON.parse(line) as { type: string }).type);
+      .map((line) => JSON.parse(line) as { type: string; payload: Record<string, unknown> });
+    const types = traceEvents.map((event) => event.type);
     expect(types[0]).toBe("run_started");
     expect(types.at(-1)).toBe("run_completed");
     expect(types).toContain("agent_prompt_sent");
@@ -551,6 +565,51 @@ describe.sequential("pi-workflows end to end", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as WorkflowSessionEntryRecord);
     const entryIds = new Set(sessionEntries.map((record) => record.entry.id));
+    const agentPrompts = traceEvents
+      .filter((event) => event.type === "agent_prompt_sent")
+      .map((event) => event.payload.prompt)
+      .filter((prompt): prompt is string => typeof prompt === "string");
+    const stepEntries = sessionEntries.filter(
+      ({ entry }) =>
+        entry.type === "custom_message" && entry.customType === "pi-workflows-agent-step",
+    );
+    expect(stepEntries).toHaveLength(2);
+    expect(stepEntries.map(({ entry }) => entry.content)).toEqual(agentPrompts);
+    expect(stepEntries[0]?.entry.details).toMatchObject({
+      schema: "pi-workflows.agent-step-message.v1",
+      kind: "step",
+      contract: {
+        workflowName: "e2e",
+        nodeId: "propose",
+        attemptId: expect.any(String),
+      },
+      presentation: {
+        runTitle: "e2e: ship it",
+        statusDetail: "Proposing a solution",
+      },
+    });
+    for (const prompt of agentPrompts) {
+      expect(
+        mock.requests.some((request) =>
+          request.messages.some(
+            (message) => message.role === "user" && contentText(message.content) === prompt,
+          ),
+        ),
+      ).toBe(true);
+    }
+    const duplicateUserPrompts = sessionEntries.filter(({ entry }) => {
+      if (entry.type !== "message") return false;
+      const message = entry.message;
+      return (
+        message !== null &&
+        typeof message === "object" &&
+        (message as { role?: unknown }).role === "user" &&
+        agentPrompts.some(
+          (prompt) => contentText((message as { content?: unknown }).content) === prompt,
+        )
+      );
+    });
+    expect(duplicateUserPrompts).toHaveLength(0);
 
     const streamGroups = (deltaType: "text_delta" | "thinking_delta" | "toolcall_delta") => {
       const groups = new Map<string, WorkflowSessionEventRecord[]>();
@@ -670,7 +729,14 @@ describe.sequential("pi-workflows end to end", () => {
     ).toBe(true);
 
     const finishedMessages = sessionEvents.filter((event) => event.type === "message_finished");
-    expect(finishedMessages.every((event) => event.payload.settled === true)).toBe(true);
+    const customMessages = finishedMessages.filter((event) => event.payload.role === "custom");
+    expect(customMessages).toHaveLength(2);
+    expect(customMessages.every((event) => event.payload.settled === false)).toBe(true);
+    expect(
+      finishedMessages
+        .filter((event) => event.payload.role !== "custom")
+        .every((event) => event.payload.settled === true),
+    ).toBe(true);
     const linkedEntryIds = finishedMessages.flatMap((event) => {
       const id = event.payload.entryId;
       return typeof id === "string" ? [id] : [];

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -174,8 +174,15 @@ describe("WorkflowEngine", () => {
   it("appends the step contract to agent prompts", async () => {
     const workflow = defineWorkflow({
       name: "contract",
+      title: "Contract run",
       startAt: "ask",
-      nodes: { ask: agent({ prompt: () => "Base prompt", expectedOutput: `{ "x": 1 }` }) },
+      nodes: {
+        ask: agent({
+          prompt: () => "Base prompt",
+          expectedOutput: `{ "x": 1 }`,
+          statusDetail: "Checking the contract",
+        }),
+      },
       edges: [],
     });
     const executor = new ScriptedExecutor().respond("ask", { output: { x: 1 } });
@@ -192,6 +199,10 @@ describe("WorkflowEngine", () => {
       `{"action": "submit", "step": "ask", "attempt": "${attemptId}", "output": <your result>}`,
     );
     expect(prompt).toContain(`Expected output: { "x": 1 }`);
+    expect(request?.presentation).toEqual({
+      runTitle: "Contract run",
+      statusDetail: "Checking the contract",
+    });
     expect(prompt).toBe(
       appendStepContract("Base prompt", "contract", "ask", attemptId, `{ "x": 1 }`),
     );

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -12,6 +12,7 @@ function makeRequest(overrides: Partial<AgentStepRequest> = {}): AgentStepReques
       expectedOutput: `{ "x": 1 }`,
     },
     prompt: "Do the step",
+    presentation: { runTitle: "Run one", statusDetail: "Doing the step" },
     accept: async (output) => ({ ok: true, value: output }),
     ...overrides,
   };
@@ -31,7 +32,21 @@ describe("ConversationStepExecutor", () => {
     const { executor, sent } = makeExecutor();
     const stepPromise = executor.runAgentStep(makeRequest(), new AbortController().signal);
 
-    expect(sent).toEqual([{ prompt: "Do the step", streaming: false }]);
+    expect(sent).toEqual([
+      {
+        prompt: "Do the step",
+        contract: {
+          runId: "r1",
+          workflowName: "w",
+          nodeId: "step1",
+          attemptId: "a1",
+          expectedOutput: `{ "x": 1 }`,
+        },
+        presentation: { runTitle: "Run one", statusDetail: "Doing the step" },
+        kind: "step",
+        streaming: false,
+      },
+    ]);
     expect(executor.pendingStepId).toBe("step1");
 
     const result = await executor.submit("step1", "a1", { x: 1 });
@@ -182,6 +197,11 @@ describe("ConversationStepExecutor", () => {
     expect(sent).toHaveLength(3);
     expect(sent[1]?.prompt).toMatch(/Reminder: workflow step "step1"/);
     expect(sent[1]?.prompt).toContain(`{ "x": 1 }`);
+    expect(sent[1]).toMatchObject({
+      kind: "reminder",
+      contract: { nodeId: "step1", attemptId: "a1" },
+      presentation: { runTitle: "Run one", statusDetail: "Doing the step" },
+    });
 
     expect(executor.handleAgentSettled()).toBe(false);
     await expect(stepPromise).rejects.toThrow(/without submitting step "step1"/);
@@ -190,8 +210,9 @@ describe("ConversationStepExecutor", () => {
 
   it("re-establishes attempt ownership for nudge and resume deliveries", async () => {
     const owners: string[] = [];
+    const deliveries: PromptDelivery[] = [];
     const executor = new ConversationStepExecutor({
-      sendPrompt: () => undefined,
+      sendPrompt: (delivery) => deliveries.push(delivery),
       conversation: {
         beginAttempt: (contract) => owners.push(contract.attemptId),
         mark: () => 0,
@@ -204,6 +225,8 @@ describe("ConversationStepExecutor", () => {
     expect(executor.handleAgentSettled()).toBe(false);
     executor.release();
     expect(owners).toEqual(["a1", "a1", "a1"]);
+    expect(deliveries.map((delivery) => delivery.kind)).toEqual(["step", "reminder", "resume"]);
+    expect(deliveries.every((delivery) => delivery.contract.attemptId === "a1")).toBe(true);
     await executor.submit("step1", "a1", {});
     await stepPromise;
   });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -97,6 +97,8 @@ function makeHarness(options: {
   const widgets: (string[] | WidgetFactory | undefined)[] = [];
   const statuses: (string | undefined)[] = [];
   const sentMessages: SentMessage[] = [];
+  const sentUserMessages: string[] = [];
+  const messageRenderers = new Map<string, unknown>();
   const listeners = new Map<
     string,
     ((event?: unknown, ctx?: FakeContext) => void | Promise<void>)[]
@@ -149,13 +151,16 @@ function makeHarness(options: {
     registerShortcut: (key: string, spec: { handler: (ctx: FakeContext) => void }) => {
       shortcuts.set(key, spec.handler);
     },
+    registerMessageRenderer: (customType: string, renderer: unknown) => {
+      messageRenderers.set(customType, renderer);
+    },
     on: (event: string, listener: (event?: unknown, ctx?: FakeContext) => void | Promise<void>) => {
       const queue = listeners.get(event) ?? [];
       queue.push(listener);
       listeners.set(event, queue);
     },
     sendUserMessage: (prompt: string) => {
-      // Deliver asynchronously like the real runtime would.
+      sentUserMessages.push(prompt);
       idle = false;
       queueMicrotask(() => options.respond(prompt, tool as RegisteredTool));
     },
@@ -164,6 +169,13 @@ function makeHarness(options: {
         message,
         ...(messageOptions === undefined ? {} : { options: messageOptions }),
       });
+      if (
+        message.customType === "pi-workflows-agent-step" &&
+        messageOptions?.triggerTurn === true
+      ) {
+        idle = false;
+        queueMicrotask(() => options.respond(message.content, tool as RegisteredTool));
+      }
     },
   };
 
@@ -178,6 +190,8 @@ function makeHarness(options: {
     widgets,
     statuses,
     sentMessages,
+    sentUserMessages,
+    messageRenderers,
     get abortCalls() {
       return abortCalls;
     },
@@ -362,7 +376,9 @@ describe("pi-workflows extension", () => {
       expect(stripAnsi(renderedWidget ?? "")).toContain("✓ ● reply");
       expect(renderedWidget).toContain("\u001b[32m✓\u001b[0m");
       expect(renderedWidget).not.toMatch(/[┏┌┃]/u);
-      expect(harness.sentMessages).toHaveLength(0);
+      expect(harness.sentMessages).toHaveLength(1);
+      expect(harness.sentMessages[0]?.message.customType).toBe("pi-workflows-agent-step");
+      expect(harness.sentUserMessages).toHaveLength(0);
 
       const runDirs = await fs.readdir(runsDir);
       expect(runDirs).toHaveLength(1);
@@ -427,7 +443,30 @@ describe("pi-workflows extension", () => {
       );
 
       await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-agent-step",
+        ),
+      );
+      const stepMessage = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-agent-step",
+      );
+      expect(stepMessage).toMatchObject({
+        message: {
+          display: true,
+          details: {
+            schema: "pi-workflows.agent-step-message.v1",
+            kind: "step",
+            contract: { workflowName: "mini", nodeId: "reply" },
+          },
+        },
+        options: { deliverAs: "followUp", triggerTurn: true },
+      });
+      expect(harness.sentUserMessages).toHaveLength(0);
+      expect(harness.messageRenderers.has("pi-workflows-agent-step")).toBe(true);
+
       await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
+      await harness.emitAsync("agent_settled");
 
       const status = await harness.tool.execute("status-1", { action: "status" });
       expect(status.details).toMatchObject({ workflowName: "mini", status: "completed" });
@@ -581,9 +620,15 @@ export default defineWorkflow({
       });
 
       await harness.command.handler("present", harness.ctx);
-      await waitFor(() => harness.sentMessages.length === 1);
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-presentation",
+        ),
+      );
 
-      const sent = harness.sentMessages[0];
+      const sent = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-presentation",
+      );
       expect(sent?.message.customType).toBe("pi-workflows-presentation");
       expect(sent?.message.display).toBe(false);
       expect(sent?.message.content).toContain("Explain the answer plainly.");
@@ -811,7 +856,16 @@ export default defineWorkflow({
         false,
       );
       expect(harness.notifications.some((note) => note.includes("must not present"))).toBe(false);
-      expect(harness.sentMessages).toHaveLength(0);
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-presentation",
+        ),
+      ).toHaveLength(0);
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-agent-step",
+        ),
+      ).toHaveLength(1);
 
       const capturedContract = contract as unknown as {
         step: string;
@@ -890,7 +944,11 @@ export default defineWorkflow({
       await waitFor(() => harness.notifications.some((note) => note.includes("cancelled")));
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      expect(harness.sentMessages).toHaveLength(0);
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-presentation",
+        ),
+      ).toHaveLength(0);
     } finally {
       vi.unstubAllEnvs();
     }
@@ -1436,6 +1494,7 @@ export default defineWorkflow({
         display: true,
         details: { runId: "run-targeted", kind: "final" },
       });
+      expect(origin.sentMessages[0]?.options).toEqual({ triggerTurn: false });
 
       const check = new SqliteControllerStore(projectControllerStorePath(cwd));
       expect(
@@ -1512,8 +1571,15 @@ export default defineWorkflow({
       });
       await harness.emitAsync("session_start");
       await harness.command.handler("mini-present", harness.ctx);
-      await waitFor(() => harness.sentMessages.length > 0);
-      expect(harness.sentMessages[0]?.message.content).toContain("reply was");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-presentation",
+        ),
+      );
+      const presentation = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-presentation",
+      );
+      expect(presentation?.message.content).toContain("reply was");
       await harness.emitAsync("session_shutdown");
     } finally {
       vi.unstubAllEnvs();

--- a/test/step-message.test.ts
+++ b/test/step-message.test.ts
@@ -1,0 +1,111 @@
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkflowAgentStepView,
+  registerWorkflowAgentStepMessageRenderer,
+  WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
+  WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+  type WorkflowAgentStepMessageDetails,
+} from "../src/extension/step-message.js";
+
+const theme = {
+  bg: (_color: string, text: string) => text,
+  fg: (_color: string, text: string) => text,
+} as Theme;
+
+const details: WorkflowAgentStepMessageDetails = {
+  schema: WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
+  kind: "step",
+  contract: {
+    runId: "run-1",
+    workflowName: "monitor",
+    nodeId: "check",
+    attemptId: "attempt-1",
+    expectedOutput: `{ "route": "continue" }`,
+  },
+  presentation: {
+    runTitle: "Watch deploy",
+    statusDetail: "Checking the monitored target",
+  },
+};
+
+describe("workflow agent-step messages", () => {
+  it("builds a compact view without the model prompt", () => {
+    const view = buildWorkflowAgentStepView(
+      { content: "Large model instructions", details },
+      false,
+    );
+
+    expect(view).toEqual({
+      title: "▶ Watch deploy › check",
+      status: "Checking the monitored target",
+    });
+    expect(JSON.stringify(view)).not.toContain("Large model instructions");
+  });
+
+  it("shows exact contract fields and the full prompt when expanded", () => {
+    const view = buildWorkflowAgentStepView(
+      {
+        content: "First line\nSecond \u001b[31mline\u001b[0m",
+        details: { ...details, kind: "reminder" },
+      },
+      true,
+    );
+
+    expect(view.title).toBe("↻ Watch deploy › check · reminder");
+    expect(view.expandedText).toContain("Workflow: monitor");
+    expect(view.expandedText).toContain("Run id: run-1");
+    expect(view.expandedText).toContain("Attempt id: attempt-1");
+    expect(view.expandedText).toContain(`Expected output: { "route": "continue" }`);
+    expect(view.expandedText).toContain("First line\nSecond line");
+    expect(view.expandedText).not.toContain("\u001b");
+  });
+
+  it("renders malformed details safely", () => {
+    const view = buildWorkflowAgentStepView(
+      { content: "Do work", details: { schema: "wrong", contract: null } },
+      true,
+    );
+
+    expect(view.title).toBe("▶ Workflow › step");
+    expect(view.expandedText).toContain("Run id: unknown");
+    expect(view.expandedText).toContain("Do work");
+  });
+
+  it("registers a bounded renderer for collapsed and expanded views", () => {
+    let renderer:
+      | ((
+          message: never,
+          options: { expanded: boolean },
+          renderTheme: Theme,
+        ) => {
+          render(width: number): string[];
+        })
+      | undefined;
+    const pi = {
+      registerMessageRenderer: (customType: string, candidate: typeof renderer) => {
+        expect(customType).toBe(WORKFLOW_AGENT_STEP_MESSAGE_TYPE);
+        renderer = candidate;
+      },
+    } as unknown as ExtensionAPI;
+    registerWorkflowAgentStepMessageRenderer(pi);
+
+    const message = {
+      role: "custom",
+      customType: WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+      content: "Large model instructions",
+      display: true,
+      details,
+      timestamp: Date.now(),
+    };
+    const collapsed = renderer?.(message as never, { expanded: false }, theme).render(32) ?? [];
+    expect(collapsed.some((line) => line.includes("Watch deploy"))).toBe(true);
+    expect(collapsed.join("\n")).not.toContain("Large model instructions");
+    expect(collapsed.every((line) => visibleWidth(line) <= 32)).toBe(true);
+
+    const expanded = renderer?.(message as never, { expanded: true }, theme).render(40) ?? [];
+    expect(expanded.join("\n")).toContain("Large model instructions");
+    expect(expanded.every((line) => visibleWidth(line) <= 40)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Workflow step instructions were shown as large user messages, which made Pi conversations hard to read.
This change keeps the full prompt for the model but shows users a compact, expandable workflow card.
It uses Pi's public custom-message and renderer APIs, so no Pi core change is required.

## What Changed

Interactive agent steps now use a versioned custom message with structured workflow metadata.
The same model prompt still reaches interactive and headless execution.

- Added the `pi-workflows-agent-step` message contract and compact renderer.
- Added step, reminder, and resume delivery kinds.
- Passed optional run-title and status-detail metadata through the engine boundary.
- Kept workflow notifications separate and explicitly set `triggerTurn: false`.
- Replaced the interactive `sendUserMessage` path without adding a duplicate fallback.
- Updated the workflow authoring documentation and message specification.

## Testing

The automated tests cover the renderer, delivery metadata, stale attempts, session replay, provider-facing prompts, and duplicate-message prevention.
I also loaded the source extension in a new Pi 0.84.2 session in Herdr and completed a real workflow step.
The collapsed card showed only the workflow, node, and status; Ctrl+O showed the exact contract and full prompt.

- `npm run check` (44 files, 702 tests passed)
- `npm run test:e2e` (7 tests passed)
- `npx slophammer-ts@latest dry .` (0 candidates)
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` (no findings)
- `git diff --check`
- `python3 ~/.pi/agent/skills/kill-ai-smell/check.py docs/WORKFLOW_STEP_MESSAGES.md` (0 violations)
- New Herdr tab `Step Message Test`, running `pi --no-session --no-extensions -e /home/onur/repos/pi-workflows/src/extension/index.ts`

SimpleDoc still reports the repository's 10 existing filename and frontmatter migrations. This change does not add another SimpleDoc finding.

## Risks

The main risk is a mismatch between the compact display and the prompt sent to the model.
The renderer reads structured metadata, while the original complete prompt remains the custom message content.
End-to-end tests compare that content with the recorded engine prompt and provider-facing prompt.

Old session entries remain readable. New entries use the documented Pi custom-message format and need no separate persistent store.
