### PR TITLE
feat: add durable workflow progress updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ the model keeps everything it already knows from the discussion. The model
 completes each step by calling a JSON `workflow` tool, which gives the engine
 structured, validated output to route on. See the
 [design philosophy](docs/DESIGN_PHILOSOPHY.md) for the principles behind the
-engine and its public parts. Accepted future contracts are documented in
-[workflow updates](docs/WORKFLOW_UPDATES.md), [workflow step
-messages](docs/WORKFLOW_STEP_MESSAGES.md), and the revised [built-in
-monitor](docs/MONITOR.md).
+engine and its public parts. Running steps can publish durable [workflow
+updates](docs/WORKFLOW_UPDATES.md), including progress counts and ETA data.
+Agent instructions use compact [workflow step
+messages](docs/WORKFLOW_STEP_MESSAGES.md), and the built-in
+[monitor](docs/MONITOR.md) reports every check without starting an extra
+assistant turn.
 
 ## Install
 
@@ -254,7 +256,8 @@ example set. Copy any of them into `.pi/workflows/` to use them:
 - `branch` classifies a task with a `decision` and routes to either a
   continue lane or a clarification checkpoint.
 - `shell` runs a runtime-owned shell command and parses its output, with no
-  agent step at all.
+  agent step at all. Shell and function actions can publish durable progress
+  while they run.
 - `two-turn` chains three agent steps that build on each other's outputs in
   the same conversation.
 - `elegant-solution` is the mid-conversation trigger described above.

--- a/docs/MONITOR.md
+++ b/docs/MONITOR.md
@@ -1,10 +1,8 @@
 # Built-in monitor
 
-This specification defines the built-in `monitor` workflow after the workflow-update feature in [WORKFLOW_UPDATES.md](WORKFLOW_UPDATES.md) is available.
+This specification defines the built-in `monitor` workflow and its use of [workflow updates](WORKFLOW_UPDATES.md).
 
 The monitor checks a target, sends one status notification after every accepted check, publishes optional progress tracks, waits, and repeats until its stop rule or safety limit is reached.
-
-This contract is accepted design and is not implemented in release `0.5.3`.
 
 ## Minimal input
 

--- a/docs/WORKFLOW_UPDATES.md
+++ b/docs/WORKFLOW_UPDATES.md
@@ -2,8 +2,6 @@
 
 This specification defines durable, non-terminal updates from running Pi Workflows nodes. An update reports current state without finishing a node or choosing a graph route.
 
-This contract is accepted design and is not implemented in release `0.5.3`.
-
 ## Minimal examples
 
 A function action publishes current state while it runs:

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,9 @@ tui/             Rust piw viewer and live replay server
 ```
 
 The dependency direction is enforced by `slophammer.yml`. `src/workflows`
-imports nothing outside itself and never imports Pi. `src/builtins` contains
+imports nothing outside itself and never imports Pi. Durable updates,
+progress validation, estimation, and text formatting stay in this layer so the
+engine, extension, hosts, and viewers share one contract. `src/builtins` contains
 package-owned definitions and imports only the public workflow engine.
 `src/controllers` may import the public workflow engine for child-run
 scheduling. `src/extension` and `src/host` may also import the built-in catalog.
@@ -38,8 +40,10 @@ in `src/viewer`
 composes the full detail view (header, graph, step timeline, step inspector)
 and stays pure so tests can assert on rendered lines.
 
-The Rust viewer keeps graph layout and plain rendering in parity with
-`src/render`, then applies ratatui-only presentation through semantic canvas
+The TypeScript and Rust viewers both show progress tracks, sample counts,
+confidence, update time, and ETA from bundle data. The Rust viewer also keeps
+graph layout and plain rendering in parity with `src/render`, then applies
+ratatui-only presentation through semantic canvas
 roles and `tui/src/theme`. Catppuccin is the default. Theme colors must be
 chosen in the theme layer rather than directly in UI components. Graph node
 surfaces are intentional styled spaces, so changing the sparse canvas must

--- a/docs/run-bundles.md
+++ b/docs/run-bundles.md
@@ -294,8 +294,8 @@ One event per line, monotonically sequenced per run, schema
 }
 ```
 
-`scope` is one of `run`, `node`, `agent`, `action`, `session`, or `update`.
-An `update_published` event carries the runtime update ID, type, key, and data;
+`scope` is one of `run`, `node`, `agent`, `action`, or `session`.
+A node-scoped `update_published` event carries the runtime update ID, type, key, and data;
 its event sequence and timestamp are the update sequence and timestamp. See
 [WORKFLOW_UPDATES.md](WORKFLOW_UPDATES.md) for the full contract. `nodeId` and
 `attemptId` are present on node-scoped and agent-scoped events. Consumers must

--- a/docs/run-bundles.md
+++ b/docs/run-bundles.md
@@ -210,7 +210,8 @@ The full run projection (`WorkflowRunState` in
   "input": { "task": "fix the flaky test" },
   "outputs": {},
   "results": {},
-  "steps": []
+  "steps": [],
+  "updates": []
 }
 ```
 
@@ -235,6 +236,10 @@ The full run projection (`WorkflowRunState` in
 - Per-node data lives in `outputs` (the accepted output of each finished node,
   latest attempt wins on loops) and `results` (the full result record of the
   latest attempt, including outcome and timing).
+- `updates` contains the latest durable record for each `(type, key)` pair,
+  sorted by trace sequence. New runs start with an empty array. Older bundles
+  can omit it. Resume keeps it; checkpoint continuation starts a new empty
+  projection. The trace keeps the complete update history.
 - `steps` is the ordered history, one record per node attempt:
 
 ```json
@@ -289,7 +294,10 @@ One event per line, monotonically sequenced per run, schema
 }
 ```
 
-`scope` is one of `run`, `node`, `agent`, `action`, or `session`. `nodeId` and
+`scope` is one of `run`, `node`, `agent`, `action`, `session`, or `update`.
+An `update_published` event carries the runtime update ID, type, key, and data;
+its event sequence and timestamp are the update sequence and timestamp. See
+[WORKFLOW_UPDATES.md](WORKFLOW_UPDATES.md) for the full contract. `nodeId` and
 `attemptId` are present on node-scoped and agent-scoped events. Consumers must
 ignore unknown event types and unknown payload fields so new ones can be added
 within the same schema version.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -90,6 +90,9 @@ Long-running compute, action, and checkpoint callbacks should observe
 steps). When the node times out or the run is cancelled, the engine stops
 waiting immediately, but only cooperative callbacks stop doing work.
 
+Function actions receive `WorkflowActionContext`, which adds
+`publishUpdate(update)`. Other callbacks keep the read-only node context.
+
 ## Durable runs, parking, and resume
 
 Every interactive `/workflow` run is tracked in the project run queue (see
@@ -218,6 +221,32 @@ commands cannot exhaust memory. Both action forms record a receipt (command,
 exit code, duration) in the step record for auditability, including when the
 command fails.
 
+A function action can publish a durable update without completing the node:
+
+```typescript
+action({
+  run: async ({ publishUpdate }) => {
+    await publishUpdate({
+      type: "progress",
+      key: "overall",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        status: "running",
+        completed: 40,
+        total: 100,
+        unit: "rows",
+      },
+    });
+  },
+});
+```
+
+A shell action can parse complete lines from stdout or stderr and return one
+or more updates through `updates.parseLine`. Parsing applies backpressure and
+keeps normal output capture. Lines and update data are each limited to 64 KiB.
+See [WORKFLOW_UPDATES.md](WORKFLOW_UPDATES.md) for the envelope, progress
+schema, limits, estimation, and error rules.
+
 ### checkpoint
 
 Ends the run in a `waiting` state for human review. The checkpoint bundle is
@@ -294,13 +323,15 @@ The model sees one `workflow` tool. Its `action` field supports:
 - `status` for the active run or a supplied run ID.
 - `pause`, `resume`, and `cancel` for the active run.
 - `answer` with checkpoint input and an optional run ID.
+- `update` for a non-completing update from the current agent attempt.
 - `submit` for the current workflow step contract.
 
 A model-started run is queued until the model's current turn settles. The first
 workflow prompt then starts a new turn. This keeps the requesting turn outside
 the workflow's first attempt and prevents an early missing-submission reminder.
 The normal extension offers all actions. The headless RPC bridge offers only
-`submit`, so a workflow child cannot recursively control other runs.
+`update` and `submit`, so a workflow child cannot recursively control other
+runs.
 
 ### Built-in monitor
 
@@ -310,24 +341,23 @@ one looping workflow run. Its input is:
 ```json
 {
   "task": "Check pull request 123",
-  "everyMinutes": 30,
-  "reportWhen": "Checks fail or the state changes materially",
-  "stopWhen": "The pull request is merged or closed",
-  "maxChecks": 1000,
-  "checkTimeoutMinutes": 60
+  "stopWhen": "The pull request is merged or closed"
 }
 ```
 
-The first check runs immediately. Each accepted check records a bounded current
-observation and chooses whether to continue, report, or stop. A report uses a
-separate agent node so its structured check result is validated before the user
-sees the message. The next check can read the previous accepted observation.
+The first check runs immediately. `everyMinutes` defaults to 30. Each accepted
+check must provide one concise report and choose `continue` or `stop`. The
+runtime queues that report as a workflow notification with `triggerTurn:
+false`, so it does not cause an assistant reply. A check can also provide
+independent progress tracks. Pi Workflows validates the counts and calculates
+rates, confidence, and ETA without a model.
 
-Intervals must be whole minutes from 1 through 1,440. `maxChecks` defaults to
-1,000 and cannot exceed 1,000. `checkTimeoutMinutes` is optional and applies to
-check and report agent nodes. It must be from 5 through 1,440 minutes. Its
-default is the larger of 60 minutes and `everyMinutes`. The workflow also has
-a finite step limit and bounded observation and report sizes.
+Intervals must be whole minutes from 1 through 1,440. When `stopWhen` is
+omitted, the monitor stops only after an explicit user request. `maxChecks`
+defaults to the disclosed safety ceiling of 1,000 and cannot exceed it. Callers
+omit `maxChecks` unless the user requests a fixed count. `checkTimeoutMinutes`
+is from 5 through 1,440 and defaults to the larger of 60 and `everyMinutes`.
+See [MONITOR.md](MONITOR.md) for the check and progress schemas.
 
 The interval uses the existing shell action to launch the current Node
 executable with a timer. This works on every platform supported by Pi. The node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/src/builtins/catalog.ts
+++ b/src/builtins/catalog.ts
@@ -4,7 +4,7 @@ import monitorWorkflow from "./monitor.workflow.js";
 export const builtinWorkflowCatalog = new BuiltinWorkflowCatalog([
   {
     id: "monitor",
-    revision: "2",
+    revision: "3",
     definition: monitorWorkflow,
     legacySources: [
       {

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -62,6 +62,21 @@ function requireBoundedString(value: unknown, label: string, maxChars: number): 
   return trimmed;
 }
 
+async function waitForUpdateSlot(signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new Error("monitor progress publication was cancelled"));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, 55);
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export function prepareMonitorInput(input: unknown): MonitorConfig {
   const value = requireRecord(input, "monitor input") as Partial<MonitorInput>;
   const allowed = new Set(["task", "everyMinutes", "stopWhen", "maxChecks", "checkTimeoutMinutes"]);
@@ -245,10 +260,11 @@ const monitorWorkflow: WorkflowDefinition = defineWorkflow({
     estimate: compute({ run: ({ outputs }) => estimateTracks(outputs) }),
     publish_progress: action({
       statusDetail: "publishing monitor progress",
-      run: async ({ outputs, publishUpdate }) => {
+      run: async ({ outputs, publishUpdate, signal }) => {
         const check = outputs.check as MonitorCheck;
         if (check.progress === undefined) return { published: 0 };
         for (const track of check.progress.tracks) {
+          await waitForUpdateSlot(signal);
           await publishUpdate({ type: "progress", key: track.key, data: track.data });
         }
         return { published: check.progress.tracks.length };

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -171,16 +171,23 @@ function estimateTracks(outputs: Record<string, unknown>): MonitorEstimate {
   };
 }
 
-function reportMessage(outputs: Record<string, unknown>): string {
-  const check = outputs.check as MonitorCheck;
-  const estimate = outputs.estimate as MonitorEstimate;
-  if (estimate.tracks.length === 0) return check.report;
-  const config = configFrom(outputs);
-  const structured = formatProgressReport(
-    estimate.tracks.map((track) => track.estimate),
-    check.route === "continue" ? config.everyMinutes : undefined,
-  );
-  return `${check.report}\n${structured}`.slice(0, MAX_REPORT_CHARS);
+function reportMessage(context: WorkflowNodeContext): string {
+  const check = context.outputs.check as MonitorCheck;
+  const estimate = context.outputs.estimate as MonitorEstimate;
+  const config = configFrom(context.outputs);
+  const parts = [check.report];
+  if (estimate.tracks.length > 0) {
+    parts.push(
+      formatProgressReport(
+        estimate.tracks.map((track) => track.estimate),
+        check.route === "continue" ? config.everyMinutes : undefined,
+      ),
+    );
+  }
+  if (check.route === "continue" && completedChecks(context) >= config.maxChecks) {
+    parts.push(`Reached the ${config.maxChecks}-check safety limit.`);
+  }
+  return parts.join("\n").slice(0, MAX_REPORT_CHARS);
 }
 
 const monitorWorkflow: WorkflowDefinition = defineWorkflow({
@@ -236,7 +243,7 @@ const monitorWorkflow: WorkflowDefinition = defineWorkflow({
     }),
     report: notify({
       statusDetail: "queueing monitor update",
-      message: ({ outputs }) => reportMessage(outputs),
+      message: (context) => reportMessage(context),
       kind: "progress",
     }),
     decide: compute({

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -64,6 +64,10 @@ function requireBoundedString(value: unknown, label: string, maxChars: number): 
 
 export function prepareMonitorInput(input: unknown): MonitorConfig {
   const value = requireRecord(input, "monitor input") as Partial<MonitorInput>;
+  const allowed = new Set(["task", "everyMinutes", "stopWhen", "maxChecks", "checkTimeoutMinutes"]);
+  for (const field of Object.keys(value)) {
+    if (!allowed.has(field)) throw new Error(`monitor input field ${field} is not supported`);
+  }
   const task = requireBoundedString(value.task, "task", 8_000);
   const everyMinutes = value.everyMinutes ?? DEFAULT_INTERVAL_MINUTES;
   if (
@@ -175,19 +179,28 @@ function reportMessage(context: WorkflowNodeContext): string {
   const check = context.outputs.check as MonitorCheck;
   const estimate = context.outputs.estimate as MonitorEstimate;
   const config = configFrom(context.outputs);
-  const parts = [check.report];
+  const suffix: string[] = [];
   if (estimate.tracks.length > 0) {
-    parts.push(
+    suffix.push(
       formatProgressReport(
         estimate.tracks.map((track) => track.estimate),
         check.route === "continue" ? config.everyMinutes : undefined,
+        new Date(),
+        2_000,
       ),
     );
   }
   if (check.route === "continue" && completedChecks(context) >= config.maxChecks) {
-    parts.push(`Reached the ${config.maxChecks}-check safety limit.`);
+    suffix.push(`Reached the ${config.maxChecks}-check safety limit.`);
   }
-  return parts.join("\n").slice(0, MAX_REPORT_CHARS);
+  const suffixText = suffix.filter(Boolean).join("\n");
+  if (suffixText.length === 0) return check.report;
+  const reportBudget = Math.max(1, MAX_REPORT_CHARS - suffixText.length - 1);
+  const report =
+    check.report.length <= reportBudget
+      ? check.report
+      : `${check.report.slice(0, Math.max(0, reportBudget - 1))}…`;
+  return `${report}\n${suffixText}`;
 }
 
 const monitorWorkflow: WorkflowDefinition = defineWorkflow({

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -1,52 +1,51 @@
-import { agent, compute, defineWorkflow, notify, shell } from "../workflows/definition.js";
-import type { WorkflowNodeContext } from "../workflows/types.js";
+import { action, agent, compute, defineWorkflow, notify, shell } from "../workflows/definition.js";
+import {
+  estimateProgress,
+  formatProgressReport,
+  type ProgressSample,
+  type ProgressTrackState,
+} from "../workflows/progress.js";
+import type {
+  WorkflowDefinition,
+  WorkflowNodeContext,
+  WorkflowProgressData,
+} from "../workflows/types.js";
+import { validateProgressData } from "../workflows/updates.js";
 
 const MIN_INTERVAL_MINUTES = 1;
 const MAX_INTERVAL_MINUTES = 24 * 60;
+const DEFAULT_INTERVAL_MINUTES = 30;
 const MIN_CHECK_TIMEOUT_MINUTES = 5;
 const MAX_CHECK_TIMEOUT_MINUTES = 24 * 60;
 const DEFAULT_MIN_CHECK_TIMEOUT_MINUTES = 60;
 const DEFAULT_MAX_CHECKS = 1_000;
 const MAX_CHECKS = 1_000;
+const MAX_TRACKS = 256;
 const MAX_OBSERVATION_CHARS = 8_000;
 const MAX_REPORT_CHARS = 4_000;
 const MAX_REASON_CHARS = 2_000;
 const SLEEP_TIMEOUT_MARGIN_MS = 60_000;
 const NODE_TIMEOUT_MARGIN_MS = 2 * 60_000;
 
-type MonitorInput = {
+export type MonitorInput = {
   task: string;
-  everyMinutes: number;
-  reportWhen?: string;
+  everyMinutes?: number;
   stopWhen?: string;
   maxChecks?: number;
   checkTimeoutMinutes?: number;
 };
 
-type MonitorConfig = {
-  task: string;
-  everyMinutes: number;
-  reportWhen: string;
-  stopWhen: string;
-  maxChecks: number;
-  checkTimeoutMinutes: number;
-};
-
-type MonitorRoute = "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report";
-
+type MonitorConfig = Required<MonitorInput>;
+type MonitorRoute = "continue" | "stop";
+type MonitorTrack = { key: string; data: WorkflowProgressData };
 type MonitorCheck = {
   route: MonitorRoute;
   observation: string;
-  report?: string;
+  report: string;
+  progress?: { tracks: MonitorTrack[] };
   reason: string;
 };
-
-const MONITOR_ROUTES = new Set<MonitorRoute>([
-  "continue_quiet",
-  "continue_report",
-  "stop_quiet",
-  "stop_report",
-]);
+type MonitorEstimate = { tracks: ProgressTrackState[] };
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -56,27 +55,21 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
 }
 
 function requireBoundedString(value: unknown, label: string, maxChars: number): string {
-  if (typeof value !== "string") {
-    throw new Error(`${label} must be a string`);
-  }
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
   const trimmed = value.trim();
-  if (trimmed.length === 0) {
-    throw new Error(`${label} must not be empty`);
-  }
-  if (trimmed.length > maxChars) {
-    throw new Error(`${label} must be at most ${maxChars} characters`);
-  }
+  if (trimmed.length === 0) throw new Error(`${label} must not be empty`);
+  if (trimmed.length > maxChars) throw new Error(`${label} must be at most ${maxChars} characters`);
   return trimmed;
 }
 
-function prepareInput(input: unknown): MonitorConfig {
+export function prepareMonitorInput(input: unknown): MonitorConfig {
   const value = requireRecord(input, "monitor input") as Partial<MonitorInput>;
   const task = requireBoundedString(value.task, "task", 8_000);
+  const everyMinutes = value.everyMinutes ?? DEFAULT_INTERVAL_MINUTES;
   if (
-    typeof value.everyMinutes !== "number" ||
-    !Number.isInteger(value.everyMinutes) ||
-    value.everyMinutes < MIN_INTERVAL_MINUTES ||
-    value.everyMinutes > MAX_INTERVAL_MINUTES
+    !Number.isInteger(everyMinutes) ||
+    everyMinutes < MIN_INTERVAL_MINUTES ||
+    everyMinutes > MAX_INTERVAL_MINUTES
   ) {
     throw new Error(
       `everyMinutes must be an integer from ${MIN_INTERVAL_MINUTES} through ${MAX_INTERVAL_MINUTES}`,
@@ -87,7 +80,7 @@ function prepareInput(input: unknown): MonitorConfig {
     throw new Error(`maxChecks must be an integer from 1 through ${MAX_CHECKS}`);
   }
   const checkTimeoutMinutes =
-    value.checkTimeoutMinutes ?? Math.max(DEFAULT_MIN_CHECK_TIMEOUT_MINUTES, value.everyMinutes);
+    value.checkTimeoutMinutes ?? Math.max(DEFAULT_MIN_CHECK_TIMEOUT_MINUTES, everyMinutes);
   if (
     !Number.isInteger(checkTimeoutMinutes) ||
     checkTimeoutMinutes < MIN_CHECK_TIMEOUT_MINUTES ||
@@ -99,14 +92,10 @@ function prepareInput(input: unknown): MonitorConfig {
   }
   return {
     task,
-    everyMinutes: value.everyMinutes,
-    reportWhen:
-      value.reportWhen === undefined
-        ? "The observed state changes materially or needs the user's attention."
-        : requireBoundedString(value.reportWhen, "reportWhen", 4_000),
+    everyMinutes,
     stopWhen:
       value.stopWhen === undefined
-        ? "The user cancels the monitor or it reaches its maximum check count."
+        ? "Stop only when the user explicitly asks to stop."
         : requireBoundedString(value.stopWhen, "stopWhen", 4_000),
     maxChecks,
     checkTimeoutMinutes,
@@ -117,124 +106,181 @@ function configFrom(outputs: Record<string, unknown>): MonitorConfig {
   return outputs.prepare as MonitorConfig;
 }
 
-function agentTimeoutMs({ outputs }: WorkflowNodeContext): number {
-  return configFrom(outputs).checkTimeoutMinutes * 60_000;
-}
-
 function completedChecks(context: WorkflowNodeContext): number {
   return context.state.steps.filter((step) => step.nodeId === "check" && step.outcome === "ok")
     .length;
 }
 
-function validateCheck(output: unknown): MonitorCheck {
+export function validateMonitorCheck(output: unknown): MonitorCheck {
   const value = requireRecord(output, "monitor check output");
-  if (typeof value.route !== "string" || !MONITOR_ROUTES.has(value.route as MonitorRoute)) {
-    throw new Error(`route must be one of ${[...MONITOR_ROUTES].join(", ")}`);
+  const allowed = new Set(["route", "observation", "report", "progress", "reason"]);
+  for (const key of Object.keys(value))
+    if (!allowed.has(key)) throw new Error(`monitor check field ${key} is not supported`);
+  if (value.route !== "continue" && value.route !== "stop")
+    throw new Error("route must be continue or stop");
+  const check: MonitorCheck = {
+    route: value.route,
+    observation: requireBoundedString(value.observation, "observation", MAX_OBSERVATION_CHARS),
+    report: requireBoundedString(value.report, "report", MAX_REPORT_CHARS),
+    reason: requireBoundedString(value.reason, "reason", MAX_REASON_CHARS),
+  };
+  if (value.progress !== undefined) check.progress = validateMonitorProgress(value.progress);
+  return check;
+}
+
+function validateMonitorProgress(input: unknown): { tracks: MonitorTrack[] } {
+  const value = requireRecord(input, "progress");
+  if (Object.keys(value).some((key) => key !== "tracks"))
+    throw new Error("progress only supports tracks");
+  if (!Array.isArray(value.tracks) || value.tracks.length < 1 || value.tracks.length > MAX_TRACKS) {
+    throw new Error(`progress.tracks must contain 1 through ${MAX_TRACKS} entries`);
   }
-  const route = value.route as MonitorRoute;
-  const observation = requireBoundedString(value.observation, "observation", MAX_OBSERVATION_CHARS);
-  const reason = requireBoundedString(value.reason, "reason", MAX_REASON_CHARS);
-  const reports = route === "continue_report" || route === "stop_report";
-  const report =
-    value.report === undefined
-      ? undefined
-      : requireBoundedString(value.report, "report", MAX_REPORT_CHARS);
-  if (reports && report === undefined) {
-    throw new Error(`route ${route} requires a report`);
-  }
+  const keys = new Set<string>();
+  const tracks = value.tracks.map((raw, index) => {
+    const track = requireRecord(raw, `progress.tracks[${index}]`);
+    if (Object.keys(track).some((key) => key !== "key" && key !== "data")) {
+      throw new Error(`progress.tracks[${index}] has an unsupported field`);
+    }
+    const key = requireBoundedString(track.key, `progress.tracks[${index}].key`, 128);
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/.test(key))
+      throw new Error(`progress.tracks[${index}].key is invalid`);
+    if (keys.has(key)) throw new Error(`progress track key ${key} is duplicated`);
+    keys.add(key);
+    return {
+      key,
+      data: validateProgressData(requireRecord(track.data, `progress.tracks[${index}].data`)),
+    };
+  });
+  return { tracks };
+}
+
+function estimateTracks(outputs: Record<string, unknown>): MonitorEstimate {
+  const check = outputs.check as MonitorCheck;
+  if (check.progress === undefined) return { tracks: [] };
+  const previous = outputs.estimate as MonitorEstimate | undefined;
+  const previousByKey = new Map((previous?.tracks ?? []).map((track) => [track.key, track]));
+  const at = new Date().toISOString();
   return {
-    route,
-    observation,
-    ...(report !== undefined ? { report } : {}),
-    reason,
+    tracks: check.progress.tracks.map((track) => {
+      const samples: ProgressSample[] = [
+        ...(previousByKey.get(track.key)?.samples ?? []),
+        { at, data: track.data },
+      ].slice(-9);
+      return { key: track.key, samples, estimate: estimateProgress(track.key, samples) };
+    }),
   };
 }
 
 function reportMessage(outputs: Record<string, unknown>): string {
   const check = outputs.check as MonitorCheck;
-  return check.report ?? check.observation;
+  const estimate = outputs.estimate as MonitorEstimate;
+  if (estimate.tracks.length === 0) return check.report;
+  const config = configFrom(outputs);
+  const structured = formatProgressReport(
+    estimate.tracks.map((track) => track.estimate),
+    check.route === "continue" ? config.everyMinutes : undefined,
+  );
+  return `${check.report}\n${structured}`.slice(0, MAX_REPORT_CHARS);
 }
 
-export default defineWorkflow({
+const monitorWorkflow: WorkflowDefinition = defineWorkflow({
   name: "monitor",
   title: ({ input }) => {
     try {
-      const task = prepareInput(input).task;
-      return `monitor: ${task.slice(0, 80)}`;
+      return `monitor: ${prepareMonitorInput(input).task.slice(0, 80)}`;
     } catch {
       return "monitor";
     }
   },
-  presentationPrompt: ({ finalOutput }) => {
-    const result = requireRecord(finalOutput, "monitor result");
-    if (result.reported === true) {
-      return undefined;
-    }
-    return `Tell the user concisely why this monitor stopped: ${String(result.reason ?? "monitor ended")}`;
-  },
   startAt: "prepare",
-  maxSteps: 5_010,
+  maxSteps: 9_010,
   nodes: {
-    prepare: compute({
-      run: ({ input }) => prepareInput(input),
-    }),
-    guard: compute({
-      run: (context) => {
-        const config = configFrom(context.outputs);
-        const checks = completedChecks(context);
-        return checks >= config.maxChecks
-          ? { route: "stop", checks, reason: `Reached the ${config.maxChecks}-check limit.` }
-          : { route: "check", checks };
-      },
-    }),
-    continue_guard: compute({
-      run: (context) => {
-        const config = configFrom(context.outputs);
-        const checks = completedChecks(context);
-        return checks >= config.maxChecks
-          ? { route: "stop", checks, reason: `Reached the ${config.maxChecks}-check limit.` }
-          : { route: "sleep", checks };
-      },
-    }),
+    prepare: compute({ run: ({ input }) => prepareMonitorInput(input) }),
     check: agent({
       statusDetail: "checking monitored target",
-      timeoutMs: agentTimeoutMs,
+      timeoutMs: ({ outputs }) => configFrom(outputs).checkTimeoutMinutes * 60_000,
       prompt: (context) => {
         const config = configFrom(context.outputs);
         const previous = context.outputs.check as MonitorCheck | undefined;
-        const checkNumber = completedChecks(context) + 1;
+        const priorEstimate = context.outputs.estimate as MonitorEstimate | undefined;
         return [
-          `Perform monitoring check ${checkNumber} of at most ${config.maxChecks}.`,
+          `Perform monitoring check ${completedChecks(context) + 1} of at most ${config.maxChecks}.`,
           `Task: ${config.task}`,
-          `Report when: ${config.reportWhen}`,
           `Stop when: ${config.stopWhen}`,
           previous === undefined
-            ? "There is no previous observation. Report the initial state only when the report condition calls for it."
+            ? "There is no previous observation."
             : `Previous accepted observation: ${previous.observation}`,
-          "Use available tools to inspect the current state. Observe only unless the task explicitly authorizes a mutation.",
-          "Choose continue_quiet, continue_report, stop_quiet, or stop_report. A report route requires concise report text.",
+          priorEstimate?.tracks.length
+            ? `Previous progress: ${formatProgressReport(priorEstimate.tracks.map((track) => track.estimate))}`
+            : "There is no previous measured progress.",
+          "Use available tools to inspect the current source of truth. Observe only unless the task explicitly authorizes a mutation.",
+          "Every accepted check must include a concise user-facing report. Add progress tracks only when the target provides measurable facts. Submit observed counts and target-provided finish times; do not invent rates or an ETA.",
+          "Choose route continue or stop.",
         ].join("\n\n");
       },
       expectedOutput:
-        '{ "route": "continue_quiet" | "continue_report" | "stop_quiet" | "stop_report", "observation": "current factual state", "report": "required for report routes", "reason": "short reason" }',
-      validate: (output) => validateCheck(output),
+        '{ "route": "continue" | "stop", "observation": "current factual state", "report": "concise status update", "progress": { "tracks": [{ "key": "stable-key", "data": { "schema": "pi-workflows.progress.v1", "status": "running", "completed": 1, "total": 2, "unit": "items" } }] } (optional), "reason": "short reason" }',
+      validate: (output) => validateMonitorCheck(output),
     }),
-    report_continue: notify({
+    estimate: compute({ run: ({ outputs }) => estimateTracks(outputs) }),
+    publish_progress: action({
+      statusDetail: "publishing monitor progress",
+      run: async ({ outputs, publishUpdate }) => {
+        const check = outputs.check as MonitorCheck;
+        if (check.progress === undefined) return { published: 0 };
+        for (const track of check.progress.tracks) {
+          await publishUpdate({ type: "progress", key: track.key, data: track.data });
+        }
+        return { published: check.progress.tracks.length };
+      },
+    }),
+    report: notify({
       statusDetail: "queueing monitor update",
       message: ({ outputs }) => reportMessage(outputs),
       kind: "progress",
     }),
-    report_stop: notify({
-      statusDetail: "queueing final monitor update",
-      message: ({ outputs }) => reportMessage(outputs),
-      kind: "final",
+    decide: compute({
+      run: (context) => {
+        const check = context.outputs.check as MonitorCheck;
+        const config = configFrom(context.outputs);
+        const checks = completedChecks(context);
+        if (check.route === "stop") return { route: "stop", reason: check.reason, checks };
+        if (checks >= config.maxChecks) {
+          return {
+            route: "stop",
+            reason: `Reached the ${config.maxChecks}-check safety limit.`,
+            checks,
+          };
+        }
+        return { route: "continue", reason: check.reason, checks };
+      },
+    }),
+    schedule: action({
+      statusDetail: "scheduling next monitor check",
+      run: async ({ outputs, publishUpdate }) => {
+        const config = configFrom(outputs);
+        const lastCheckAt = new Date().toISOString();
+        const nextCheckAt = new Date(
+          Date.parse(lastCheckAt) + config.everyMinutes * 60_000,
+        ).toISOString();
+        await publishUpdate({
+          type: "monitor.schedule",
+          key: "next-check",
+          data: {
+            schema: "pi-workflows.monitor-schedule.v1",
+            lastCheckAt,
+            nextCheckAt,
+            everyMinutes: config.everyMinutes,
+          },
+        });
+        return { lastCheckAt, nextCheckAt, everyMinutes: config.everyMinutes };
+      },
     }),
     sleep: shell({
       statusDetail: "waiting for next monitor check",
       timeoutMs: MAX_INTERVAL_MINUTES * 60_000 + NODE_TIMEOUT_MARGIN_MS,
       exec: ({ outputs }) => {
-        const config = configFrom(outputs);
-        const sleepMs = config.everyMinutes * 60_000;
+        const sleepMs = configFrom(outputs).everyMinutes * 60_000;
         return {
           command: process.execPath,
           args: ["-e", "setTimeout(() => {}, Number(process.argv[1]))", String(sleepMs)],
@@ -246,40 +292,27 @@ export default defineWorkflow({
     }),
     finish: compute({
       run: ({ outputs }) => {
-        const check = outputs.check as MonitorCheck | undefined;
-        const guard = outputs.guard as { reason?: string } | undefined;
-        const continueGuard = outputs.continue_guard as { reason?: string } | undefined;
+        const check = outputs.check as MonitorCheck;
+        const decision = outputs.decide as { reason?: string; checks?: number } | undefined;
         return {
-          reason: continueGuard?.reason ?? guard?.reason ?? check?.reason ?? "Monitor finished.",
-          observation: check?.observation ?? null,
-          reported:
-            outputs.report_stop !== undefined ||
-            (check !== undefined && check.route === "stop_report"),
+          reason: decision?.reason ?? check.reason,
+          observation: check.observation,
+          checks: decision?.checks ?? 1,
+          reported: true,
         };
       },
     }),
   },
   edges: [
-    { from: "prepare", to: "guard" },
-    { from: "guard", switch: { on: "$.route", cases: { check: "check", stop: "finish" } } },
-    {
-      from: "check",
-      switch: {
-        on: "$.route",
-        cases: {
-          continue_quiet: "continue_guard",
-          continue_report: "report_continue",
-          stop_quiet: "finish",
-          stop_report: "report_stop",
-        },
-      },
-    },
-    { from: "report_continue", to: "continue_guard" },
-    { from: "report_stop", to: "finish" },
-    {
-      from: "continue_guard",
-      switch: { on: "$.route", cases: { sleep: "sleep", stop: "finish" } },
-    },
-    { from: "sleep", to: "guard" },
+    { from: "prepare", to: "check" },
+    { from: "check", to: "estimate" },
+    { from: "estimate", to: "publish_progress" },
+    { from: "publish_progress", to: "report" },
+    { from: "report", to: "decide" },
+    { from: "decide", switch: { on: "$.route", cases: { stop: "finish", continue: "schedule" } } },
+    { from: "schedule", to: "sleep" },
+    { from: "sleep", to: "check" },
   ],
 });
+
+export default monitorWorkflow;

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -14,7 +14,7 @@ import {
 } from "../workflows/errors.js";
 import { discoverWorkflows, resolveWorkflowRef } from "../workflows/loader.js";
 import { migrateLegacyWorkflowSources } from "../workflows/migrate-sources.js";
-import { progressRecordsFromTrace } from "../workflows/progress.js";
+import { appendProgressHistory, progressRecordsFromTrace } from "../workflows/progress.js";
 import {
   createRunId,
   listRunBundles,
@@ -843,7 +843,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
       },
       onEvent: (event, state: WorkflowRunState) => {
         run.lastState = state;
-        run.updateHistory.push(...progressRecordsFromTrace([event]));
+        run.updateHistory = appendProgressHistory(
+          run.updateHistory,
+          progressRecordsFromTrace([event]),
+        );
         updateWidget(ctx, state, snapshot, run.updateHistory);
       },
     });

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -14,6 +14,7 @@ import {
 } from "../workflows/errors.js";
 import { discoverWorkflows, resolveWorkflowRef } from "../workflows/loader.js";
 import { migrateLegacyWorkflowSources } from "../workflows/migrate-sources.js";
+import { progressRecordsFromTrace } from "../workflows/progress.js";
 import {
   createRunId,
   listRunBundles,
@@ -28,6 +29,7 @@ import type {
   WorkflowDefinitionSnapshot,
   WorkflowRunResult,
   WorkflowRunState,
+  WorkflowUpdateRecord,
 } from "../workflows/types.js";
 import {
   PiControllerHost,
@@ -77,6 +79,7 @@ type ActiveRun = {
   presentationPrompt: WorkflowDefinition["presentationPrompt"];
   generation: number;
   lastState: WorkflowRunState | null;
+  updateHistory: WorkflowUpdateRecord[];
   childKey?: string;
   onFinish?: (result: WorkflowSchedulerResult) => void;
   completion?: Promise<void>;
@@ -212,6 +215,7 @@ function workflowStateSummary(state: WorkflowRunState): JsonObject {
 type WidgetSource = {
   state: WorkflowRunState;
   snapshot: WorkflowDefinitionSnapshot;
+  updateHistory?: WorkflowUpdateRecord[];
 };
 
 type WorkflowWidgetComponent = {
@@ -402,6 +406,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         runHeld(),
         width,
         theme,
+        widgetSource.updateHistory,
       );
       widgetShownScroll = view.scroll;
       widgetMaxScroll = view.maxScroll;
@@ -426,13 +431,18 @@ export default function piWorkflows(pi: ExtensionAPI) {
     ctx: ExtensionContext,
     state: WorkflowRunState,
     snapshot: WorkflowDefinitionSnapshot,
+    updateHistory?: WorkflowUpdateRecord[],
   ) => {
     if (state.steps.length !== widgetStepCount) {
       widgetStepCount = state.steps.length;
       // The workflow moved on; resume following the active node.
       widgetScroll = null;
     }
-    widgetSource = { state, snapshot };
+    widgetSource = {
+      state,
+      snapshot,
+      ...(updateHistory !== undefined ? { updateHistory: [...updateHistory] } : {}),
+    };
     renderWidget(ctx);
   };
 
@@ -611,7 +621,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     void run.recorder?.stop();
     stopWidgetTicker();
     const { state } = result;
-    updateWidget(ctx, state, run.snapshot);
+    updateWidget(ctx, state, run.snapshot, run.updateHistory);
     clearWidgetTimer();
     // A waiting run is parked at a checkpoint for a human; keep its widget up
     // until a new workflow replaces it. Terminal runs fade after a grace TTL.
@@ -831,9 +841,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
       onRunFinishing: async () => {
         await run.recorder?.finish();
       },
-      onEvent: (_event, state: WorkflowRunState) => {
+      onEvent: (event, state: WorkflowRunState) => {
         run.lastState = state;
-        updateWidget(ctx, state, snapshot);
+        run.updateHistory.push(...progressRecordsFromTrace([event]));
+        updateWidget(ctx, state, snapshot, run.updateHistory);
       },
     });
     const run: ActiveRun = {
@@ -846,6 +857,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
       presentationPrompt: options.presentation === false ? undefined : workflow.presentationPrompt,
       generation,
       lastState: null,
+      updateHistory: [],
       ...(options.childKey !== undefined ? { childKey: options.childKey } : {}),
       ...(options.onFinish !== undefined ? { onFinish: options.onFinish } : {}),
       ...(claimToken !== undefined ? { claimToken } : {}),

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -197,6 +197,10 @@ function workflowStateSummary(state: WorkflowRunState): JsonObject {
     workflowName: state.workflowName,
     status: state.status,
     steps: state.steps.length,
+    updates: (state.updates ?? []).map(({ data, ...record }) => ({
+      ...record,
+      data: data as JsonObject,
+    })),
     ...(state.currentNode !== undefined ? { currentNode: state.currentNode } : {}),
     ...(state.waitingOn !== undefined ? { waitingOn: state.waitingOn } : {}),
     ...(state.startedAt !== undefined ? { startedAt: state.startedAt } : {}),
@@ -1590,13 +1594,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
     name: "workflow",
     label: "Workflow",
     description: [
-      "List, start, inspect, pause, resume, cancel, answer, or complete Pi Workflows runs.",
-      "When the user asks to monitor, watch, poll, or check something repeatedly, start the built-in monitor workflow with input keys task, everyMinutes, reportWhen, stopWhen, and optional maxChecks.",
-      "Use submit only when a workflow step contract asks for it, and pass the exact step and attempt ids.",
+      "List, start, inspect, pause, resume, cancel, answer, update, or complete Pi Workflows runs.",
+      "When the user asks to monitor, watch, poll, or check something repeatedly, start the built-in monitor workflow with input keys task, everyMinutes, stopWhen, and optional maxChecks.",
+      "Use update or submit only when a workflow step contract asks for it, and pass the exact step and attempt ids.",
       "Do not start repeated work without the user's request, and keep monitoring observation-only unless the user authorizes mutations.",
     ].join(" "),
     parameters: WorkflowToolParameters,
-    async execute(_toolCallId, params: WorkflowToolInput, _signal, _onUpdate, ctx) {
+    async execute(toolCallId, params: WorkflowToolInput, _signal, _onUpdate, ctx) {
       let control: WorkflowControlResult;
       switch (params.action) {
         case "list":
@@ -1623,6 +1627,21 @@ export default function piWorkflows(pi: ExtensionAPI) {
             parentRunId: waiting.parentRunId,
           });
           break;
+        }
+        case "update": {
+          if (!activeRun) throw new Error("No workflow step is active.");
+          const receipt = await activeRun.engine.publishUpdate(
+            params.step,
+            params.attempt,
+            params.update,
+            toolCallId,
+          );
+          return {
+            content: [
+              { type: "text", text: "Workflow update published; the step remains active." },
+            ],
+            details: { action: "update", ...receipt },
+          };
         }
         case "submit": {
           if (!activeRun) {

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -146,9 +146,8 @@ function progressLines(
     updateHistory === undefined
       ? undefined
       : progressTracksFromRecords(updateHistory, now).map((track) => track.estimate);
-  const estimates =
-    monitorEstimates(state) ??
-    mergeProgressEstimates(latestProgressEstimates(state, now), measured ?? []);
+  const projected = mergeProgressEstimates(latestProgressEstimates(state, now), measured ?? []);
+  const estimates = mergeProgressEstimates(projected, monitorEstimates(state) ?? []);
   const lines = prioritizeProgressEstimates(estimates).map((estimate) =>
     formatProgressLine(estimate, now),
   );

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -148,9 +148,7 @@ function progressLines(
       : progressTracksFromRecords(updateHistory, now).map((track) => track.estimate);
   const estimates =
     monitorEstimates(state) ??
-    (measured !== undefined && measured.length > 0
-      ? measured
-      : latestProgressEstimates(state, now));
+    mergeProgressEstimates(latestProgressEstimates(state, now), measured ?? []);
   const lines = prioritizeProgressEstimates(estimates).map((estimate) =>
     formatProgressLine(estimate, now),
   );
@@ -182,6 +180,17 @@ function monitorEstimates(state: WorkflowRunState): ProgressEstimate[] | undefin
     )
     .filter((estimate): estimate is ProgressEstimate => estimate !== undefined);
   return estimates.length > 0 ? estimates : undefined;
+}
+
+function mergeProgressEstimates(
+  latest: ProgressEstimate[],
+  measured: ProgressEstimate[],
+): ProgressEstimate[] {
+  const measuredByKey = new Map(measured.map((estimate) => [estimate.key, estimate]));
+  const merged = latest.map((estimate) => measuredByKey.get(estimate.key) ?? estimate);
+  const latestKeys = new Set(latest.map((estimate) => estimate.key));
+  merged.push(...measured.filter((estimate) => !latestKeys.has(estimate.key)));
+  return merged;
 }
 
 function latestProgressEstimates(state: WorkflowRunState, now: Date): ProgressEstimate[] {

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -6,6 +6,7 @@ import {
   estimateProgress,
   formatProgressLine,
   formatRemaining,
+  progressTracksFromRecords,
   type ProgressEstimate,
 } from "../workflows/progress.js";
 import { sanitizeText } from "../workflows/text.js";
@@ -13,6 +14,7 @@ import type {
   WorkflowDefinitionSnapshot,
   WorkflowRunState,
   WorkflowRunStatus,
+  WorkflowUpdateRecord,
 } from "../workflows/types.js";
 
 const STATUS_GLYPHS: Record<WorkflowRunStatus, string> = {
@@ -74,6 +76,7 @@ export function buildWidgetView(
   held = false,
   width = Number.POSITIVE_INFINITY,
   theme?: WidgetTheme,
+  updateHistory?: WorkflowUpdateRecord[],
 ): WidgetView {
   const availableWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : width;
   if (availableWidth === 0) return { lines: [], scroll: 0, maxScroll: 0 };
@@ -99,7 +102,7 @@ export function buildWidgetView(
     );
   }
 
-  const progress = progressLines(state, now).slice(0, 4);
+  const progress = progressLines(state, now, updateHistory).slice(0, 4);
   const budget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
   const nodes = displayNodeIds(snapshot).map((nodeId) =>
     compactNodeLine(state, snapshot, nodeId, now, paused, theme),
@@ -133,8 +136,20 @@ export function buildWidgetView(
   };
 }
 
-function progressLines(state: WorkflowRunState, now: Date): string[] {
-  const estimates = monitorEstimates(state) ?? latestProgressEstimates(state, now);
+function progressLines(
+  state: WorkflowRunState,
+  now: Date,
+  updateHistory?: WorkflowUpdateRecord[],
+): string[] {
+  const measured =
+    updateHistory === undefined
+      ? undefined
+      : progressTracksFromRecords(updateHistory, now).map((track) => track.estimate);
+  const estimates =
+    monitorEstimates(state) ??
+    (measured !== undefined && measured.length > 0
+      ? measured
+      : latestProgressEstimates(state, now));
   const lines = estimates.map((estimate) => formatProgressLine(estimate, now));
   const schedule = (state.updates ?? []).find(
     (record) => record.type === "monitor.schedule" && record.key === "next-check",

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -2,6 +2,12 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { formatDuration } from "../render/format.js";
 import { nodeTypeGlyph } from "../render/node-type.js";
+import {
+  estimateProgress,
+  formatProgressLine,
+  formatRemaining,
+  type ProgressEstimate,
+} from "../workflows/progress.js";
 import { sanitizeText } from "../workflows/text.js";
 import type {
   WorkflowDefinitionSnapshot,
@@ -93,13 +99,17 @@ export function buildWidgetView(
     );
   }
 
-  const budget = PI_MAX_WIDGET_LINES - 1 - footer.length;
+  const progress = progressLines(state, now).slice(0, 4);
+  const budget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
   const nodes = displayNodeIds(snapshot).map((nodeId) =>
     compactNodeLine(state, snapshot, nodeId, now, paused, theme),
   );
-  if (nodes.length === 0) {
+  if (nodes.length === 0 || budget <= 0) {
     return {
-      lines: fitLines([header, ...footer], availableWidth),
+      lines: fitLines(
+        [header, ...progress, ...footer].slice(0, PI_MAX_WIDGET_LINES),
+        availableWidth,
+      ),
       scroll: 0,
       maxScroll: 0,
     };
@@ -110,12 +120,65 @@ export function buildWidgetView(
   const indentation = availableWidth >= 3 ? "  " : "";
   return {
     lines: fitLines(
-      [header, ...windowed.lines.map((line) => `${indentation}${line}`), ...footer],
+      [
+        header,
+        ...windowed.lines.map((line) => `${indentation}${line}`),
+        ...progress.map((line) => `${indentation}${line}`),
+        ...footer,
+      ],
       availableWidth,
     ),
     scroll: windowed.scroll,
     maxScroll: windowed.maxScroll,
   };
+}
+
+function progressLines(state: WorkflowRunState, now: Date): string[] {
+  const estimates = monitorEstimates(state) ?? latestProgressEstimates(state, now);
+  const lines = estimates.map((estimate) => formatProgressLine(estimate, now));
+  const schedule = (state.updates ?? []).find(
+    (record) => record.type === "monitor.schedule" && record.key === "next-check",
+  );
+  if (schedule !== undefined && typeof schedule.data.nextCheckAt === "string") {
+    const next = Date.parse(schedule.data.nextCheckAt);
+    if (Number.isFinite(next)) {
+      const age = Math.max(0, now.getTime() - Date.parse(schedule.at));
+      lines.push(
+        `Last update ${formatRemaining(age)} ago  next check ${formatRemaining(next - now.getTime())}`,
+      );
+    }
+  }
+  return lines;
+}
+
+function monitorEstimates(state: WorkflowRunState): ProgressEstimate[] | undefined {
+  const output = state.outputs.estimate;
+  if (output === null || typeof output !== "object" || Array.isArray(output)) return undefined;
+  const tracks = (output as { tracks?: unknown }).tracks;
+  if (!Array.isArray(tracks)) return undefined;
+  const estimates = tracks
+    .map((track) =>
+      track !== null && typeof track === "object" && !Array.isArray(track)
+        ? (track as { estimate?: ProgressEstimate }).estimate
+        : undefined,
+    )
+    .filter((estimate): estimate is ProgressEstimate => estimate !== undefined);
+  return estimates.length > 0 ? estimates : undefined;
+}
+
+function latestProgressEstimates(state: WorkflowRunState, now: Date): ProgressEstimate[] {
+  const estimates: ProgressEstimate[] = [];
+  for (const record of state.updates ?? []) {
+    if (record.type !== "progress") continue;
+    try {
+      estimates.push(
+        estimateProgress(record.key, [{ at: record.at, data: record.data as never }], now),
+      );
+    } catch {
+      // A malformed historical update must not break the workflow widget.
+    }
+  }
+  return estimates;
 }
 
 function compactFocusIndex(state: WorkflowRunState, snapshot: WorkflowDefinitionSnapshot): number {

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -6,6 +6,7 @@ import {
   estimateProgress,
   formatProgressLine,
   formatRemaining,
+  prioritizeProgressEstimates,
   progressTracksFromRecords,
   type ProgressEstimate,
 } from "../workflows/progress.js";
@@ -150,7 +151,9 @@ function progressLines(
     (measured !== undefined && measured.length > 0
       ? measured
       : latestProgressEstimates(state, now));
-  const lines = estimates.map((estimate) => formatProgressLine(estimate, now));
+  const lines = prioritizeProgressEstimates(estimates).map((estimate) =>
+    formatProgressLine(estimate, now),
+  );
   const schedule = (state.updates ?? []).find(
     (record) => record.type === "monitor.schedule" && record.key === "next-check",
   );

--- a/src/extension/workflow-tool.ts
+++ b/src/extension/workflow-tool.ts
@@ -39,6 +39,22 @@ export const WorkflowToolParameters: TSchema = Type.Union([
   ),
   Type.Object(
     {
+      action: StringEnum(["update"] as const),
+      step: Type.String({ description: "Active step id" }),
+      attempt: Type.String({ description: "Active attempt id" }),
+      update: Type.Object(
+        {
+          type: Type.String(),
+          key: Type.String(),
+          data: Type.Record(Type.String(), Type.Unknown()),
+        },
+        noExtraProperties,
+      ),
+    },
+    noExtraProperties,
+  ),
+  Type.Object(
+    {
       action: StringEnum(["submit"] as const),
       step: Type.String({ description: "Step id from the workflow step contract" }),
       attempt: Type.String({ description: "Attempt id from the workflow step contract" }),
@@ -56,4 +72,10 @@ export type WorkflowToolInput =
   | { action: "resume" }
   | { action: "cancel" }
   | { action: "answer"; input: unknown; runId?: string }
+  | {
+      action: "update";
+      step: string;
+      attempt: string;
+      update: { type: string; key: string; data: Record<string, unknown> };
+    }
   | { action: "submit"; step: string; attempt: string; output: unknown };

--- a/src/host/rpc-bridge.ts
+++ b/src/host/rpc-bridge.ts
@@ -15,26 +15,49 @@ export default function piWorkflowsRpcBridge(pi: ExtensionAPI) {
     name: "workflow",
     label: "Workflow",
     description: [
-      "Submit the output for the pending workflow step with action submit.",
+      "Publish an update or submit the output for the pending workflow step.",
       "Only call this tool when a workflow step contract in the conversation asks you to.",
-      "Pass the exact step id from the contract and your result as the output.",
+      "Pass the exact step and attempt ids from the contract.",
     ].join(" "),
-    parameters: Type.Object(
-      {
-        action: StringEnum(["submit"] as const),
-        step: Type.String({ description: "Step id from the workflow step contract" }),
-        attempt: Type.String({ description: "Attempt id from the workflow step contract" }),
-        output: Type.Unknown({ description: "Step output matching the expected shape" }),
-      },
-      { additionalProperties: false },
-    ),
-    async execute(_toolCallId, params) {
-      process.stderr.write(`${RPC_SUBMISSION_PREFIX}${JSON.stringify(params)}\n`);
+    parameters: Type.Union([
+      Type.Object(
+        {
+          action: StringEnum(["update"] as const),
+          step: Type.String(),
+          attempt: Type.String(),
+          update: Type.Object(
+            {
+              type: Type.String(),
+              key: Type.String(),
+              data: Type.Record(Type.String(), Type.Unknown()),
+            },
+            { additionalProperties: false },
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      Type.Object(
+        {
+          action: StringEnum(["submit"] as const),
+          step: Type.String({ description: "Step id from the workflow step contract" }),
+          attempt: Type.String({ description: "Attempt id from the workflow step contract" }),
+          output: Type.Unknown({ description: "Step output matching the expected shape" }),
+        },
+        { additionalProperties: false },
+      ),
+    ]),
+    async execute(toolCallId, params) {
+      process.stderr.write(
+        `${RPC_SUBMISSION_PREFIX}${JSON.stringify({ ...params, idempotencyKey: toolCallId })}\n`,
+      );
       return {
         content: [
           {
             type: "text",
-            text: "Submission recorded. Continue only when the workflow sends the next step.",
+            text:
+              params.action === "update"
+                ? "Workflow update recorded; continue the current step."
+                : "Submission recorded. Continue only when the workflow sends the next step.",
           },
         ],
         details: {},

--- a/src/host/rpc-executor.ts
+++ b/src/host/rpc-executor.ts
@@ -23,6 +23,16 @@ type StepSubmission = {
   output: unknown;
 };
 
+type StepUpdate = {
+  action: "update";
+  step: string;
+  attempt: string;
+  update: { type: string; key: string; data: Record<string, unknown> };
+  idempotencyKey?: string;
+};
+
+type StepAction = StepSubmission | StepUpdate;
+
 export type RpcStepExecutorOptions = {
   cwd: string;
   registry: HostProcessRegistry;
@@ -46,7 +56,7 @@ export class RpcStepExecutor implements AgentStepExecutor {
   private child: ChildProcess | null = null;
   private childExited: { code: number | null; signal: string | null } | null = null;
   private stderrBuffer = "";
-  private submissions: StepSubmission[] = [];
+  private actions: StepAction[] = [];
   private submissionWaiters: Array<() => void> = [];
   private stdoutBuffer = "";
 
@@ -179,13 +189,13 @@ export class RpcStepExecutor implements AgentStepExecutor {
           continue;
         }
         try {
-          const parsed = JSON.parse(line.slice(RPC_SUBMISSION_PREFIX.length)) as StepSubmission;
+          const parsed = JSON.parse(line.slice(RPC_SUBMISSION_PREFIX.length)) as StepAction;
           if (
-            parsed.action === "submit" &&
+            (parsed.action === "submit" || parsed.action === "update") &&
             typeof parsed.step === "string" &&
             typeof parsed.attempt === "string"
           ) {
-            this.submissions.push(parsed);
+            this.actions.push(parsed);
           }
         } catch {
           // A malformed marker line is ignored; the step times out instead.
@@ -209,10 +219,6 @@ export class RpcStepExecutor implements AgentStepExecutor {
     if (child === null || this.childExited !== null) {
       throw new Error("Headless pi session is not running");
     }
-    const matching = this.takeMatchingSubmission(request);
-    if (matching !== undefined) {
-      return matching;
-    }
     child.stdin?.write(`${JSON.stringify({ type: "prompt", message: prompt })}\n`);
     for (;;) {
       throwIfAborted(signal);
@@ -220,9 +226,14 @@ export class RpcStepExecutor implements AgentStepExecutor {
       if (exited !== null) {
         throw new Error(`Headless pi session exited mid-step (code ${exited.code})`);
       }
-      const found = this.takeMatchingSubmission(request);
-      if (found !== undefined) {
-        return found;
+      const found = this.takeMatchingAction(request);
+      if (found?.action === "submit") return found;
+      if (found?.action === "update") {
+        if (request.publishUpdate === undefined) {
+          throw new Error("This workflow host does not support step updates");
+        }
+        await request.publishUpdate(found.update, found.idempotencyKey);
+        continue;
       }
       await new Promise<void>((resolve, reject) => {
         const waiter = () => {
@@ -239,13 +250,13 @@ export class RpcStepExecutor implements AgentStepExecutor {
     }
   }
 
-  private takeMatchingSubmission(request: AgentStepRequest): StepSubmission | undefined {
-    const index = this.submissions.findIndex(
+  private takeMatchingAction(request: AgentStepRequest): StepAction | undefined {
+    const index = this.actions.findIndex(
       (candidate) =>
         candidate.step === request.contract.nodeId &&
         candidate.attempt === request.contract.attemptId,
     );
-    return index === -1 ? undefined : (this.submissions.splice(index, 1)[0] as StepSubmission);
+    return index === -1 ? undefined : (this.actions.splice(index, 1)[0] as StepAction);
   }
 
   private sendAbortQuietly(): void {

--- a/src/host/rpc-executor.ts
+++ b/src/host/rpc-executor.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
+import { errorMessage } from "../workflows/errors.js";
 import type {
   AgentStepExecutor,
   AgentStepRequest,
@@ -232,7 +233,16 @@ export class RpcStepExecutor implements AgentStepExecutor {
         if (request.publishUpdate === undefined) {
           throw new Error("This workflow host does not support step updates");
         }
-        await request.publishUpdate(found.update, found.idempotencyKey);
+        try {
+          await request.publishUpdate(found.update, found.idempotencyKey);
+        } catch (error) {
+          child.stdin?.write(
+            `${JSON.stringify({
+              type: "prompt",
+              message: `Workflow update rejected: ${errorMessage(error)}. Correct the update and continue the same step.`,
+            })}\n`,
+          );
+        }
         continue;
       }
       await new Promise<void>((resolve, reject) => {

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -138,7 +138,7 @@ async function printOnce(dir: string, runId: string | undefined): Promise<void> 
   if (!match) {
     throw new Error(`Run not found: ${runId}`);
   }
-  const bundle = await readRunBundle(match.runDir);
+  const bundle = await readRunBundle(match.runDir, { includeTrace: true });
   if (!bundle) {
     throw new Error(`Run bundle unreadable: ${match.runDir}`);
   }

--- a/src/viewer/render.ts
+++ b/src/viewer/render.ts
@@ -2,7 +2,11 @@ import { ansi, fitWidth, sanitizeText } from "../render/ansi.js";
 import { formatDuration, runElapsedMs } from "../render/format.js";
 import { renderGraphLines } from "../render/graph-render.js";
 import { decodeValueWith } from "../workflows/artifacts.js";
-import { estimateProgress, formatProgressLine } from "../workflows/progress.js";
+import {
+  formatProgressLine,
+  progressRecordsFromTrace,
+  progressTracksFromRecords,
+} from "../workflows/progress.js";
 import type { LoadedRunBundle } from "../workflows/store.js";
 import type { WorkflowRunStatus, WorkflowStepRecord } from "../workflows/types.js";
 
@@ -205,27 +209,25 @@ export function renderRunDetailLines(
     }
   }
 
-  const progress = (state.updates ?? []).filter((update) => update.type === "progress");
+  const progressRecords =
+    bundle.traceEvents === undefined
+      ? (state.updates ?? []).filter((update) => update.type === "progress")
+      : progressRecordsFromTrace(bundle.traceEvents);
+  const progress = progressTracksFromRecords(progressRecords, now);
   if (progress.length > 0) {
     lines.push("");
     lines.push(ansi.bold("progress"));
-    for (const update of progress) {
-      try {
-        const estimate = estimateProgress(
-          update.key,
-          [{ at: update.at, data: update.data as never }],
-          now,
-        );
-        lines.push(fitWidth(formatProgressLine(estimate, now), size.width));
-        lines.push(
-          fitWidth(
-            ansi.dim(`  update ${update.seq} · ${update.at} · attempt ${update.attemptId}`),
-            size.width,
+    for (const track of progress) {
+      lines.push(fitWidth(formatProgressLine(track.estimate, now), size.width));
+      const latest = track.samples.at(-1);
+      lines.push(
+        fitWidth(
+          ansi.dim(
+            `  ${track.estimate.sampleCount} samples · ${track.estimate.confidence ?? "no"} confidence · updated ${latest?.at ?? "unknown"}`,
           ),
-        );
-      } catch {
-        lines.push(fitWidth(`${sanitizeText(update.key)}  invalid progress data`, size.width));
-      }
+          size.width,
+        ),
+      );
     }
   }
 

--- a/src/viewer/render.ts
+++ b/src/viewer/render.ts
@@ -2,6 +2,7 @@ import { ansi, fitWidth, sanitizeText } from "../render/ansi.js";
 import { formatDuration, runElapsedMs } from "../render/format.js";
 import { renderGraphLines } from "../render/graph-render.js";
 import { decodeValueWith } from "../workflows/artifacts.js";
+import { estimateProgress, formatProgressLine } from "../workflows/progress.js";
 import type { LoadedRunBundle } from "../workflows/store.js";
 import type { WorkflowRunStatus, WorkflowStepRecord } from "../workflows/types.js";
 
@@ -201,6 +202,30 @@ export function renderRunDetailLines(
     // No definition snapshot: fall back to a flat executed-node list.
     for (const nodeId of Object.keys(state.results)) {
       lines.push(nodeStatusLine(bundle, nodeId, size.width, now));
+    }
+  }
+
+  const progress = (state.updates ?? []).filter((update) => update.type === "progress");
+  if (progress.length > 0) {
+    lines.push("");
+    lines.push(ansi.bold("progress"));
+    for (const update of progress) {
+      try {
+        const estimate = estimateProgress(
+          update.key,
+          [{ at: update.at, data: update.data as never }],
+          now,
+        );
+        lines.push(fitWidth(formatProgressLine(estimate, now), size.width));
+        lines.push(
+          fitWidth(
+            ansi.dim(`  update ${update.seq} · ${update.at} · attempt ${update.attemptId}`),
+            size.width,
+          ),
+        );
+      } catch {
+        lines.push(fitWidth(`${sanitizeText(update.key)}  invalid progress data`, size.width));
+      }
     }
   }
 

--- a/src/viewer/tui.ts
+++ b/src/viewer/tui.ts
@@ -62,7 +62,7 @@ export async function runViewer(options: ViewerOptions): Promise<void> {
   };
 
   const renderDetail = async (runDir: string, size: ViewportSize): Promise<string[]> => {
-    const bundle = await readRunBundle(runDir);
+    const bundle = await readRunBundle(runDir, { includeTrace: true });
     if (!bundle) {
       return ["Run bundle disappeared. Press q to go back."];
     }

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -23,6 +23,7 @@ import type {
   ConversationRange,
   ShellActionNodeDefinition,
   ShellActionResult,
+  WorkflowActionContext,
   WorkflowActionReceipt,
   WorkflowDefinition,
   WorkflowEngineOptions,
@@ -36,7 +37,15 @@ import type {
   WorkflowSource,
   WorkflowStepRecord,
   WorkflowTraceEventDraft,
+  WorkflowUpdateInput,
+  WorkflowUpdateReceipt,
 } from "./types.js";
+import {
+  MAX_CURRENT_UPDATES,
+  UpdateRateLimiter,
+  updateReceipt,
+  validateWorkflowUpdate,
+} from "./updates.js";
 
 const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_MAX_STEPS = 100;
@@ -83,6 +92,17 @@ export class WorkflowEngine {
   private readonly onRunStarted?: WorkflowEngineOptions["onRunStarted"];
   private readonly onRunFinishing?: WorkflowEngineOptions["onRunFinishing"];
   private activeAbort: AbortController | null = null;
+  private activeAttempt:
+    | {
+        runDir: string;
+        state: WorkflowRunState;
+        nodeId: string;
+        attemptId: string;
+        signal: AbortSignal;
+      }
+    | undefined;
+  private readonly updateLimiters = new Map<string, UpdateRateLimiter>();
+  private readonly updateReceipts = new Map<string, WorkflowUpdateReceipt>();
   private cancelled = false;
   private parked = false;
   private paused = false;
@@ -101,6 +121,60 @@ export class WorkflowEngine {
 
   get outputRoot(): string {
     return this.store.outputRoot;
+  }
+
+  /** Publish a durable update for the currently active attempt without completing it. */
+  async publishUpdate(
+    step: string,
+    attempt: string,
+    input: WorkflowUpdateInput,
+    idempotencyKey?: string,
+  ): Promise<WorkflowUpdateReceipt> {
+    const active = this.activeAttempt;
+    if (
+      active === undefined ||
+      active.nodeId !== step ||
+      active.attemptId !== attempt ||
+      active.signal.aborted
+    ) {
+      throw new Error(
+        `Workflow step ${JSON.stringify(step)} attempt ${JSON.stringify(attempt)} is not active`,
+      );
+    }
+    const receiptKey =
+      idempotencyKey === undefined ? undefined : `${active.state.runId}:${idempotencyKey}`;
+    if (receiptKey !== undefined) {
+      const prior = this.updateReceipts.get(receiptKey);
+      if (prior !== undefined) return prior;
+    }
+    const update = validateWorkflowUpdate(input);
+    const exists = (active.state.updates ?? []).some(
+      (record) => record.type === update.type && record.key === update.key,
+    );
+    if (!exists && (active.state.updates?.length ?? 0) >= MAX_CURRENT_UPDATES) {
+      throw new Error(`workflow run supports at most ${MAX_CURRENT_UPDATES} current updates`);
+    }
+    let limiter = this.updateLimiters.get(active.state.runId);
+    if (limiter === undefined) {
+      limiter = new UpdateRateLimiter();
+      this.updateLimiters.set(active.state.runId, limiter);
+    }
+    limiter.take();
+    const { event, record } = await this.store.publishUpdate(
+      active.runDir,
+      active.state,
+      active.nodeId,
+      active.attemptId,
+      update,
+    );
+    try {
+      this.onEvent?.(event, active.state);
+    } catch {
+      // UI and logging observers never determine workflow correctness.
+    }
+    const receipt = updateReceipt(record);
+    if (receiptKey !== undefined) this.updateReceipts.set(receiptKey, receipt);
+    return receipt;
   }
 
   /** Abort the currently running node and mark the run cancelled. */
@@ -492,6 +566,7 @@ export class WorkflowEngine {
       outputs: {},
       results: {},
       steps: [],
+      updates: [],
     };
   }
 
@@ -775,6 +850,7 @@ export class WorkflowEngine {
       timer = setTimeout(() => {
         abort.abort(new TimeoutError(timeoutMs));
       }, timeoutMs);
+      this.activeAttempt = { runDir, state, nodeId, attemptId, signal: abort.signal };
       const dispatched = this.dispatchNode(
         workflow,
         state,
@@ -817,6 +893,9 @@ export class WorkflowEngine {
       }
       if (this.activeAbort === abort) {
         this.activeAbort = null;
+      }
+      if (this.activeAttempt?.attemptId === attemptId) {
+        this.activeAttempt = undefined;
       }
     }
   }
@@ -895,7 +974,7 @@ export class WorkflowEngine {
         return { output: receipt, promptText: null };
       }
       case "action":
-        return await this.runActionNode(node, context, signal, meta);
+        return await this.runActionNode(node, context, nodeId, attemptId, signal, meta);
       case "checkpoint":
         return await runCheckpointNode(node, context);
     }
@@ -964,6 +1043,8 @@ export class WorkflowEngine {
             }
           : {}),
         accept: async (output) => await this.acceptSubmission(node, context, output),
+        publishUpdate: async (update, idempotencyKey) =>
+          await this.publishUpdate(nodeId, attemptId, update, idempotencyKey),
       },
       signal,
     );
@@ -995,14 +1076,20 @@ export class WorkflowEngine {
   private async runActionNode(
     node: ActionNodeDefinition,
     context: WorkflowNodeContext,
+    nodeId: string,
+    attemptId: string,
     signal: AbortSignal,
     meta: NodeExecutionMeta,
   ): Promise<NodeExecution> {
+    const actionContext: WorkflowActionContext = {
+      ...context,
+      publishUpdate: async (update) => await this.publishUpdate(nodeId, attemptId, update),
+    };
     if ("exec" in node) {
-      return await runShellActionNode(node, context, signal, meta);
+      return await runShellActionNode(node, context, actionContext, signal, meta);
     }
     meta.action = { actionType: "function" };
-    const output = await node.run(context);
+    const output = await node.run(actionContext);
     return { output, promptText: null, action: { actionType: "function" } };
   }
 
@@ -1086,13 +1173,28 @@ function shellReceipt(result: ShellActionResult): WorkflowActionReceipt {
 async function runShellActionNode(
   node: ShellActionNodeDefinition,
   context: WorkflowNodeContext,
+  actionContext: WorkflowActionContext,
   signal: AbortSignal,
   meta: NodeExecutionMeta,
 ): Promise<NodeExecution> {
   const spec = await node.exec(context);
+  const streams = new Set(node.updates?.streams ?? ["stdout"]);
   let result: ShellActionResult;
   try {
-    result = await runShellAction(spec, signal);
+    result = await runShellAction(
+      spec,
+      signal,
+      node.updates === undefined
+        ? undefined
+        : async (line) => {
+            if (!streams.has(line.stream)) return;
+            const parsed = await node.updates?.parseLine(line, actionContext);
+            if (parsed === undefined) return;
+            for (const update of Array.isArray(parsed) ? parsed : [parsed]) {
+              await actionContext.publishUpdate(update);
+            }
+          },
+    );
   } catch (error) {
     const failed = shellResultFromError(error);
     if (failed) {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -158,6 +158,7 @@ export class WorkflowEngine {
         active.nodeId,
         active.attemptId,
         update,
+        { signal: active.signal },
       );
       try {
         this.onEvent?.(event, active.state);
@@ -883,6 +884,9 @@ export class WorkflowEngine {
     } finally {
       if (timer !== undefined) {
         clearTimeout(timer);
+      }
+      if (!abort.signal.aborted) {
+        abort.abort(new Error(`Workflow node ${nodeId} is no longer active`));
       }
       if (this.activeAbort === abort) {
         this.activeAbort = null;

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -40,12 +40,7 @@ import type {
   WorkflowUpdateInput,
   WorkflowUpdateReceipt,
 } from "./types.js";
-import {
-  MAX_CURRENT_UPDATES,
-  UpdateRateLimiter,
-  updateReceipt,
-  validateWorkflowUpdate,
-} from "./updates.js";
+import { UpdateRateLimiter, updateReceipt, validateWorkflowUpdate } from "./updates.js";
 
 const DEFAULT_NODE_TIMEOUT_MS = 15 * 60_000;
 const DEFAULT_MAX_STEPS = 100;
@@ -142,18 +137,14 @@ export class WorkflowEngine {
       );
     }
     const receiptKey =
-      idempotencyKey === undefined ? undefined : `${active.state.runId}:${idempotencyKey}`;
+      idempotencyKey === undefined
+        ? undefined
+        : `${active.state.runId}:${active.attemptId}:${idempotencyKey}`;
     if (receiptKey !== undefined) {
       const prior = this.updateReceipts.get(receiptKey);
       if (prior !== undefined) return prior;
     }
     const update = validateWorkflowUpdate(input);
-    const exists = (active.state.updates ?? []).some(
-      (record) => record.type === update.type && record.key === update.key,
-    );
-    if (!exists && (active.state.updates?.length ?? 0) >= MAX_CURRENT_UPDATES) {
-      throw new Error(`workflow run supports at most ${MAX_CURRENT_UPDATES} current updates`);
-    }
     let limiter = this.updateLimiters.get(active.state.runId);
     if (limiter === undefined) {
       limiter = new UpdateRateLimiter();
@@ -896,6 +887,10 @@ export class WorkflowEngine {
       }
       if (this.activeAttempt?.attemptId === attemptId) {
         this.activeAttempt = undefined;
+      }
+      const receiptPrefix = `${state.runId}:${attemptId}:`;
+      for (const key of this.updateReceipts.keys()) {
+        if (key.startsWith(receiptPrefix)) this.updateReceipts.delete(key);
       }
     }
   }

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -97,7 +97,7 @@ export class WorkflowEngine {
       }
     | undefined;
   private readonly updateLimiters = new Map<string, UpdateRateLimiter>();
-  private readonly updateReceipts = new Map<string, WorkflowUpdateReceipt>();
+  private readonly updatePublications = new Map<string, Promise<WorkflowUpdateReceipt>>();
   private cancelled = false;
   private parked = false;
   private paused = false;
@@ -141,31 +141,33 @@ export class WorkflowEngine {
         ? undefined
         : `${active.state.runId}:${active.attemptId}:${idempotencyKey}`;
     if (receiptKey !== undefined) {
-      const prior = this.updateReceipts.get(receiptKey);
-      if (prior !== undefined) return prior;
+      const prior = this.updatePublications.get(receiptKey);
+      if (prior !== undefined) return await prior;
     }
-    const update = validateWorkflowUpdate(input);
-    let limiter = this.updateLimiters.get(active.state.runId);
-    if (limiter === undefined) {
-      limiter = new UpdateRateLimiter();
-      this.updateLimiters.set(active.state.runId, limiter);
-    }
-    limiter.take();
-    const { event, record } = await this.store.publishUpdate(
-      active.runDir,
-      active.state,
-      active.nodeId,
-      active.attemptId,
-      update,
-    );
-    try {
-      this.onEvent?.(event, active.state);
-    } catch {
-      // UI and logging observers never determine workflow correctness.
-    }
-    const receipt = updateReceipt(record);
-    if (receiptKey !== undefined) this.updateReceipts.set(receiptKey, receipt);
-    return receipt;
+    const publication = (async () => {
+      const update = validateWorkflowUpdate(input);
+      let limiter = this.updateLimiters.get(active.state.runId);
+      if (limiter === undefined) {
+        limiter = new UpdateRateLimiter();
+        this.updateLimiters.set(active.state.runId, limiter);
+      }
+      limiter.take();
+      const { event, record } = await this.store.publishUpdate(
+        active.runDir,
+        active.state,
+        active.nodeId,
+        active.attemptId,
+        update,
+      );
+      try {
+        this.onEvent?.(event, active.state);
+      } catch {
+        // UI and logging observers never determine workflow correctness.
+      }
+      return updateReceipt(record);
+    })();
+    if (receiptKey !== undefined) this.updatePublications.set(receiptKey, publication);
+    return await publication;
   }
 
   /** Abort the currently running node and mark the run cancelled. */
@@ -889,8 +891,8 @@ export class WorkflowEngine {
         this.activeAttempt = undefined;
       }
       const receiptPrefix = `${state.runId}:${attemptId}:`;
-      for (const key of this.updateReceipts.keys()) {
-        if (key.startsWith(receiptPrefix)) this.updateReceipts.delete(key);
+      for (const key of this.updatePublications.keys()) {
+        if (key.startsWith(receiptPrefix)) this.updatePublications.delete(key);
       }
     }
   }

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -1301,6 +1301,8 @@ export function appendStepContract(
     "---",
     `Workflow step contract (workflow: ${workflowName}, step: ${nodeId}, attempt: ${attemptId})`,
     "",
+    "While this step is active, you may publish non-completing updates with:",
+    `{"action": "update", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "update": {"type": "...", "key": "...", "data": {...}}}`,
     "Complete this step by calling the `workflow` tool exactly once with:",
     `{"action": "submit", "step": ${JSON.stringify(nodeId)}, "attempt": ${JSON.stringify(attemptId)}, "output": <your result>}`,
     `Expected output: ${expectedOutput ?? "a JSON object with your result"}`,

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -34,6 +34,7 @@ export {
   formatProgressLine,
   formatProgressReport,
   formatRemaining,
+  prioritizeProgressEstimates,
   progressRecordsFromTrace,
   progressTracksFromRecords,
   type ProgressConfidence,

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -29,6 +29,26 @@ export {
   type WorkflowSearchPaths,
 } from "./loader.js";
 export { renderShellCommand, runShellAction } from "./shell.js";
+export {
+  estimateProgress,
+  formatProgressLine,
+  formatProgressReport,
+  formatRemaining,
+  progressTracksFromRecords,
+  type ProgressConfidence,
+  type ProgressEstimate,
+  type ProgressSample,
+  type ProgressTrackState,
+} from "./progress.js";
+export {
+  MAX_CURRENT_UPDATES,
+  MAX_UPDATE_DATA_BYTES,
+  UPDATE_RATE_BURST,
+  UPDATE_RATE_PER_SECOND,
+  updateProjection,
+  validateProgressData,
+  validateWorkflowUpdate,
+} from "./updates.js";
 export { sanitizeText, stripAnsi } from "./text.js";
 export {
   ARTIFACT_THRESHOLD_BYTES,
@@ -71,6 +91,7 @@ export type {
   ShellActionExecution,
   ShellActionNodeDefinition,
   ShellActionResult,
+  WorkflowActionContext,
   WorkflowActionReceipt,
   WorkflowDefinition,
   WorkflowDefinitionSnapshot,
@@ -86,6 +107,8 @@ export type {
   WorkflowNotificationRequest,
   WorkflowNotificationSink,
   WorkflowPresentationContext,
+  WorkflowProgressData,
+  WorkflowProgressStatus,
   WorkflowRunManifest,
   WorkflowRunResult,
   WorkflowRunState,
@@ -96,4 +119,9 @@ export type {
   WorkflowStepRecord,
   WorkflowTraceEvent,
   WorkflowTraceEventDraft,
+  WorkflowUpdateInput,
+  WorkflowUpdateReceipt,
+  WorkflowUpdateRecord,
+  ShellActionUpdates,
+  ShellUpdateLine,
 } from "./types.js";

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -34,6 +34,7 @@ export {
   formatProgressLine,
   formatProgressReport,
   formatRemaining,
+  progressRecordsFromTrace,
   progressTracksFromRecords,
   type ProgressConfidence,
   type ProgressEstimate,

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -73,6 +73,7 @@ export {
   readRunBundle,
   workflowRunsBaseDir,
   type LoadedRunBundle,
+  type ReadRunBundleOptions,
 } from "./store.js";
 export type {
   AgentNodeDefinition,

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -1,4 +1,4 @@
-import type { WorkflowProgressData, WorkflowUpdateRecord } from "./types.js";
+import type { WorkflowProgressData, WorkflowTraceEvent, WorkflowUpdateRecord } from "./types.js";
 import { validateProgressData } from "./updates.js";
 
 export type ProgressConfidence = "low" | "medium" | "high";
@@ -117,6 +117,40 @@ export function estimateProgress(
   };
 }
 
+export function progressRecordsFromTrace(events: WorkflowTraceEvent[]): WorkflowUpdateRecord[] {
+  const records: WorkflowUpdateRecord[] = [];
+  for (const event of events) {
+    if (
+      event.type !== "update_published" ||
+      event.nodeId === undefined ||
+      event.attemptId === undefined
+    )
+      continue;
+    const payload = event.payload;
+    if (
+      typeof payload.updateId !== "string" ||
+      typeof payload.type !== "string" ||
+      typeof payload.key !== "string" ||
+      payload.data === null ||
+      typeof payload.data !== "object" ||
+      Array.isArray(payload.data)
+    )
+      continue;
+    records.push({
+      updateId: payload.updateId,
+      seq: event.seq,
+      at: event.at,
+      runId: event.runId,
+      nodeId: event.nodeId,
+      attemptId: event.attemptId,
+      type: payload.type,
+      key: payload.key,
+      data: payload.data as Record<string, unknown>,
+    });
+  }
+  return records;
+}
+
 export function progressTracksFromRecords(
   records: WorkflowUpdateRecord[],
   now = new Date(),
@@ -124,10 +158,14 @@ export function progressTracksFromRecords(
   const grouped = new Map<string, ProgressSample[]>();
   for (const record of records) {
     if (record.type !== "progress") continue;
-    const data = validateProgressData(record.data);
-    const samples = grouped.get(record.key) ?? [];
-    samples.push({ at: record.at, data });
-    grouped.set(record.key, samples);
+    try {
+      const data = validateProgressData(record.data);
+      const samples = grouped.get(record.key) ?? [];
+      samples.push({ at: record.at, data });
+      grouped.set(record.key, samples);
+    } catch {
+      // Readers skip malformed historical update data instead of failing.
+    }
   }
   return [...grouped.entries()].map(([key, samples]) => ({
     key,
@@ -150,7 +188,9 @@ export function formatProgressLine(estimate: ProgressEstimate, now = new Date())
     eta = `source ETA ${formatRemaining(Date.parse(estimate.sourceEstimatedFinishAt) - now.getTime())}`;
   } else if (estimate.remainingMedianMs !== undefined) {
     const range =
-      estimate.remainingLowMs !== undefined && estimate.remainingHighMs !== undefined
+      estimate.remainingLowMs !== undefined &&
+      estimate.remainingHighMs !== undefined &&
+      Math.abs(estimate.remainingHighMs - estimate.remainingLowMs) >= 1_000
         ? `${formatRemaining(estimate.remainingLowMs)}–${formatRemaining(estimate.remainingHighMs)}`
         : formatRemaining(estimate.remainingMedianMs);
     eta = `ETA ${range}`;
@@ -178,7 +218,7 @@ export function formatProgressReport(
 }
 
 export function formatRemaining(ms: number): string {
-  const value = Math.max(0, ms);
+  const value = Math.ceil(Math.max(0, ms) / 1_000) * 1_000;
   if (value < 60_000) return `${Math.ceil(value / 1_000)}s`;
   if (value < 3_600_000) return `${Math.ceil(value / 60_000)}m`;
   if (value < 86_400_000) return `${(value / 3_600_000).toFixed(value < 36_000_000 ? 1 : 0)}h`;

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -1,0 +1,240 @@
+import type { WorkflowProgressData, WorkflowUpdateRecord } from "./types.js";
+import { validateProgressData } from "./updates.js";
+
+export type ProgressConfidence = "low" | "medium" | "high";
+
+export type ProgressEstimate = {
+  key: string;
+  data: WorkflowProgressData;
+  sampleCount: number;
+  delta?: number;
+  rateLow?: number;
+  rateMedian?: number;
+  rateHigh?: number;
+  remainingLowMs?: number;
+  remainingMedianMs?: number;
+  remainingHighMs?: number;
+  confidence?: ProgressConfidence;
+  sourceEstimatedFinishAt?: string;
+  unavailableReason?: string;
+};
+
+export type ProgressSample = {
+  at: string;
+  data: WorkflowProgressData;
+};
+
+export type ProgressTrackState = {
+  key: string;
+  samples: ProgressSample[];
+  estimate: ProgressEstimate;
+};
+
+const TERMINAL = new Set(["completed", "failed", "cancelled"]);
+
+export function estimateProgress(
+  key: string,
+  samples: ProgressSample[],
+  now = new Date(),
+): ProgressEstimate {
+  if (samples.length === 0) throw new Error("progress estimation requires at least one sample");
+  for (const sample of samples) validateProgressData(sample.data as Record<string, unknown>);
+  const latest = samples.at(-1) as ProgressSample;
+  const data = latest.data;
+  const sourceFinish = validSourceFinish(latest, now);
+  const base: ProgressEstimate = {
+    key,
+    data,
+    sampleCount: 1,
+    ...(sourceFinish !== undefined ? { sourceEstimatedFinishAt: sourceFinish } : {}),
+  };
+  if (TERMINAL.has(data.status)) return base;
+  if (data.status === "waiting" || data.status === "blocked") {
+    return sourceFinish === undefined
+      ? { ...base, unavailableReason: `progress is ${data.status}` }
+      : base;
+  }
+  if (data.completed === undefined || data.total === undefined) {
+    return sourceFinish === undefined ? { ...base, unavailableReason: "total is unknown" } : base;
+  }
+
+  const epoch = currentEpoch(samples);
+  const intervals: Array<{ rate: number; delta: number }> = [];
+  for (let index = Math.max(1, epoch.length - 8); index < epoch.length; index += 1) {
+    const previous = epoch[index - 1] as ProgressSample;
+    const current = epoch[index] as ProgressSample;
+    const elapsedMs = Date.parse(current.at) - Date.parse(previous.at);
+    const previousCompleted = previous.data.completed;
+    const currentCompleted = current.data.completed;
+    if (elapsedMs <= 0 || previousCompleted === undefined || currentCompleted === undefined)
+      continue;
+    intervals.push({
+      rate: (currentCompleted - previousCompleted) / elapsedMs,
+      delta: currentCompleted - previousCompleted,
+    });
+  }
+  base.sampleCount = intervals.length + 1;
+  const latestDelta = intervals.at(-1)?.delta;
+  if (latestDelta !== undefined) base.delta = latestDelta;
+  if (intervals.length === 0) {
+    return sourceFinish === undefined
+      ? { ...base, unavailableReason: "needs another progress sample" }
+      : base;
+  }
+  const rates = intervals.map((item) => item.rate).sort((a, b) => a - b);
+  const median = quantile(rates, 0.5);
+  const p25 = quantile(rates, 0.25);
+  const p75 = quantile(rates, 0.75);
+  const remaining = Math.max(0, data.total - data.completed);
+  const positive = rates.filter((rate) => rate > 0);
+  if (median <= 0 || positive.length === 0) {
+    return sourceFinish === undefined
+      ? { ...base, unavailableReason: "no positive progress rate" }
+      : base;
+  }
+  const spread = (p75 - p25) / median;
+  const confidence: ProgressConfidence =
+    intervals.length >= 5
+      ? spread <= 0.25
+        ? "high"
+        : spread <= 0.5
+          ? "medium"
+          : "low"
+      : intervals.length >= 2 && spread <= 0.5
+        ? "medium"
+        : "low";
+  const slow = p25 > 0 ? p25 : undefined;
+  const fast = p75 > 0 ? p75 : median;
+  return {
+    ...base,
+    ...(slow !== undefined ? { rateLow: slow } : {}),
+    rateMedian: median,
+    rateHigh: fast,
+    remainingLowMs: remaining / fast,
+    remainingMedianMs: remaining / median,
+    ...(slow !== undefined ? { remainingHighMs: remaining / slow } : {}),
+    confidence,
+  };
+}
+
+export function progressTracksFromRecords(
+  records: WorkflowUpdateRecord[],
+  now = new Date(),
+): ProgressTrackState[] {
+  const grouped = new Map<string, ProgressSample[]>();
+  for (const record of records) {
+    if (record.type !== "progress") continue;
+    const data = validateProgressData(record.data);
+    const samples = grouped.get(record.key) ?? [];
+    samples.push({ at: record.at, data });
+    grouped.set(record.key, samples);
+  }
+  return [...grouped.entries()].map(([key, samples]) => ({
+    key,
+    samples,
+    estimate: estimateProgress(key, samples, now),
+  }));
+}
+
+export function formatProgressLine(estimate: ProgressEstimate, now = new Date()): string {
+  const { data } = estimate;
+  const label = data.label ?? estimate.key;
+  const count =
+    data.completed === undefined
+      ? data.status
+      : data.total === undefined
+        ? `${formatNumber(data.completed)} ${data.unit ?? ""}`.trim()
+        : `${formatNumber(data.completed)}/${formatNumber(data.total)} ${data.unit ?? ""}`.trim();
+  let eta = "";
+  if (estimate.sourceEstimatedFinishAt !== undefined) {
+    eta = `source ETA ${formatRemaining(Date.parse(estimate.sourceEstimatedFinishAt) - now.getTime())}`;
+  } else if (estimate.remainingMedianMs !== undefined) {
+    const range =
+      estimate.remainingLowMs !== undefined && estimate.remainingHighMs !== undefined
+        ? `${formatRemaining(estimate.remainingLowMs)}–${formatRemaining(estimate.remainingHighMs)}`
+        : formatRemaining(estimate.remainingMedianMs);
+    eta = `ETA ${range}`;
+  } else if (!TERMINAL.has(data.status)) {
+    eta = `ETA unavailable${estimate.unavailableReason ? ` (${estimate.unavailableReason})` : ""}`;
+  }
+  return [label, count, eta].filter(Boolean).join("  ");
+}
+
+export function formatProgressReport(
+  estimates: ProgressEstimate[],
+  nextCheckMinutes?: number,
+  now = new Date(),
+): string {
+  const lines: string[] = [];
+  for (const estimate of prioritize(estimates)) {
+    lines.push(`Progress: ${formatProgressLine(estimate, now)}`);
+    if (estimate.rateMedian !== undefined && estimate.data.unit !== undefined) {
+      const perMinute = estimate.rateMedian * 60_000;
+      lines.push(`Rate: ${formatNumber(perMinute)} ${estimate.data.unit}/min`);
+    }
+  }
+  if (nextCheckMinutes !== undefined) lines.push(`Next check: ${nextCheckMinutes} min`);
+  return lines.join("\n");
+}
+
+export function formatRemaining(ms: number): string {
+  const value = Math.max(0, ms);
+  if (value < 60_000) return `${Math.ceil(value / 1_000)}s`;
+  if (value < 3_600_000) return `${Math.ceil(value / 60_000)}m`;
+  if (value < 86_400_000) return `${(value / 3_600_000).toFixed(value < 36_000_000 ? 1 : 0)}h`;
+  return `${(value / 86_400_000).toFixed(1)}d`;
+}
+
+function currentEpoch(samples: ProgressSample[]): ProgressSample[] {
+  const epoch: ProgressSample[] = [];
+  for (const sample of samples) {
+    const prior = epoch.at(-1);
+    if (prior !== undefined && resetsEpoch(prior.data, sample.data)) epoch.length = 0;
+    epoch.push(sample);
+  }
+  return epoch;
+}
+
+function resetsEpoch(previous: WorkflowProgressData, next: WorkflowProgressData): boolean {
+  return (
+    previous.phase !== next.phase ||
+    previous.unit !== next.unit ||
+    previous.total !== next.total ||
+    (previous.completed !== undefined &&
+      next.completed !== undefined &&
+      next.completed < previous.completed) ||
+    (TERMINAL.has(previous.status) && !TERMINAL.has(next.status))
+  );
+}
+
+function validSourceFinish(sample: ProgressSample, now: Date): string | undefined {
+  const finish = sample.data.sourceEstimatedFinishAt;
+  if (finish === undefined) return undefined;
+  const finishMs = Date.parse(finish);
+  const sourceMs = Date.parse(sample.data.sourceUpdatedAt ?? sample.at);
+  return finishMs > sourceMs && finishMs > now.getTime() ? finish : undefined;
+}
+
+function quantile(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0] as number;
+  const position = (sorted.length - 1) * p;
+  const lower = Math.floor(position);
+  const fraction = position - lower;
+  const a = sorted[lower] as number;
+  const b = sorted[Math.min(lower + 1, sorted.length - 1)] as number;
+  return a + (b - a) * fraction;
+}
+
+function prioritize(estimates: ProgressEstimate[]): ProgressEstimate[] {
+  const weight = (item: ProgressEstimate) =>
+    item.key === "overall"
+      ? -2
+      : item.data.status === "failed" || item.data.status === "blocked"
+        ? -1
+        : 0;
+  return [...estimates].sort((a, b) => weight(a) - weight(b));
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(value);
+}

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -1,3 +1,4 @@
+import { sanitizeText } from "./text.js";
 import type { WorkflowProgressData, WorkflowTraceEvent, WorkflowUpdateRecord } from "./types.js";
 import { validateProgressData } from "./updates.js";
 
@@ -196,13 +197,14 @@ export function progressTracksFromRecords(
 
 export function formatProgressLine(estimate: ProgressEstimate, now = new Date()): string {
   const { data } = estimate;
-  const label = data.label ?? estimate.key;
+  const label = sanitizeText(data.label ?? estimate.key);
+  const unit = data.unit === undefined ? "" : sanitizeText(data.unit);
   const count =
     data.completed === undefined
       ? data.status
       : data.total === undefined
-        ? `${formatNumber(data.completed)} ${data.unit ?? ""}`.trim()
-        : `${formatNumber(data.completed)}/${formatNumber(data.total)} ${data.unit ?? ""}`.trim();
+        ? `${formatNumber(data.completed)} ${unit}`.trim()
+        : `${formatNumber(data.completed)}/${formatNumber(data.total)} ${unit}`.trim();
   let eta = "";
   if (estimate.sourceEstimatedFinishAt !== undefined) {
     eta = `source ETA ${formatRemaining(Date.parse(estimate.sourceEstimatedFinishAt) - now.getTime())}`;

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -42,14 +42,10 @@ export function estimateProgress(
   for (const sample of samples) validateProgressData(sample.data as Record<string, unknown>);
   const latest = samples.at(-1) as ProgressSample;
   const data = latest.data;
-  const sourceFinish = validSourceFinish(latest, now);
-  const base: ProgressEstimate = {
-    key,
-    data,
-    sampleCount: 1,
-    ...(sourceFinish !== undefined ? { sourceEstimatedFinishAt: sourceFinish } : {}),
-  };
+  const base: ProgressEstimate = { key, data, sampleCount: 1 };
   if (TERMINAL.has(data.status)) return base;
+  const sourceFinish = validSourceFinish(latest, now);
+  if (sourceFinish !== undefined) base.sourceEstimatedFinishAt = sourceFinish;
   if (data.status === "waiting" || data.status === "blocked") {
     return sourceFinish === undefined
       ? { ...base, unavailableReason: `progress is ${data.status}` }

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -204,17 +204,43 @@ export function formatProgressReport(
   estimates: ProgressEstimate[],
   nextCheckMinutes?: number,
   now = new Date(),
+  maxChars = 4_000,
 ): string {
+  const footer = nextCheckMinutes === undefined ? undefined : `Next check: ${nextCheckMinutes} min`;
   const lines: string[] = [];
-  for (const estimate of prioritize(estimates)) {
-    lines.push(`Progress: ${formatProgressLine(estimate, now)}`);
+  let omitted = 0;
+  for (const estimate of prioritizeProgressEstimates(estimates)) {
+    const block = [`Progress: ${formatProgressLine(estimate, now)}`];
     if (estimate.rateMedian !== undefined && estimate.data.unit !== undefined) {
-      const perMinute = estimate.rateMedian * 60_000;
-      lines.push(`Rate: ${formatNumber(perMinute)} ${estimate.data.unit}/min`);
+      const median = estimate.rateMedian * 60_000;
+      const low = estimate.rateLow === undefined ? undefined : estimate.rateLow * 60_000;
+      const high = estimate.rateHigh === undefined ? undefined : estimate.rateHigh * 60_000;
+      const rate =
+        low !== undefined && high !== undefined && Math.abs(high - low) >= 0.01
+          ? `${formatNumber(low)}–${formatNumber(high)}`
+          : formatNumber(median);
+      block.push(`Rate: ${rate} ${estimate.data.unit}/min`);
+      block.push(
+        `Estimate: ${estimate.confidence ?? "low"} confidence, ${estimate.sampleCount} samples`,
+      );
+    }
+    const candidate = [...lines, ...block, ...(footer === undefined ? [] : [footer])].join("\n");
+    if (candidate.length > maxChars) {
+      omitted += 1;
+      continue;
+    }
+    lines.push(...block);
+  }
+  if (omitted > 0) {
+    const marker = `${omitted} progress track${omitted === 1 ? "" : "s"} omitted.`;
+    if (
+      [...lines, marker, ...(footer === undefined ? [] : [footer])].join("\n").length <= maxChars
+    ) {
+      lines.push(marker);
     }
   }
-  if (nextCheckMinutes !== undefined) lines.push(`Next check: ${nextCheckMinutes} min`);
-  return lines.join("\n");
+  if (footer !== undefined && [...lines, footer].join("\n").length <= maxChars) lines.push(footer);
+  return lines.join("\n").slice(0, maxChars);
 }
 
 export function formatRemaining(ms: number): string {
@@ -265,13 +291,15 @@ function quantile(sorted: number[], p: number): number {
   return a + (b - a) * fraction;
 }
 
-function prioritize(estimates: ProgressEstimate[]): ProgressEstimate[] {
+export function prioritizeProgressEstimates(estimates: ProgressEstimate[]): ProgressEstimate[] {
   const weight = (item: ProgressEstimate) =>
     item.key === "overall"
-      ? -2
+      ? -3
       : item.data.status === "failed" || item.data.status === "blocked"
-        ? -1
-        : 0;
+        ? -2
+        : item.data.status === "waiting"
+          ? -1
+          : 0;
   return [...estimates].sort((a, b) => weight(a) - weight(b));
 }
 

--- a/src/workflows/progress.ts
+++ b/src/workflows/progress.ts
@@ -151,6 +151,26 @@ export function progressRecordsFromTrace(events: WorkflowTraceEvent[]): Workflow
   return records;
 }
 
+export function appendProgressHistory(
+  history: WorkflowUpdateRecord[],
+  additions: WorkflowUpdateRecord[],
+  maxPerTrack = 9,
+  maxRecords = 576,
+): WorkflowUpdateRecord[] {
+  const retained: WorkflowUpdateRecord[] = [];
+  const counts = new Map<string, number>();
+  const combined = [...history, ...additions];
+  for (let index = combined.length - 1; index >= 0 && retained.length < maxRecords; index -= 1) {
+    const record = combined[index] as WorkflowUpdateRecord;
+    if (record.type !== "progress") continue;
+    const count = counts.get(record.key) ?? 0;
+    if (count >= maxPerTrack) continue;
+    counts.set(record.key, count + 1);
+    retained.push(record);
+  }
+  return retained.reverse();
+}
+
 export function progressTracksFromRecords(
   records: WorkflowUpdateRecord[],
   now = new Date(),

--- a/src/workflows/schema.ts
+++ b/src/workflows/schema.ts
@@ -86,7 +86,9 @@ export function assertValidActionNode(node: ActionNodeDefinition, nodeId = "acti
     if (typeof node.exec !== "function") {
       fail(`node ${nodeId} exec must be a function`);
     }
-    assertOptionalFunction((node as ShellActionNodeDefinition).parse, `node ${nodeId} parse`);
+    const shell = node as ShellActionNodeDefinition;
+    assertOptionalFunction(shell.parse, `node ${nodeId} parse`);
+    assertShellUpdates(shell, nodeId);
   } else if (typeof (node as FunctionActionNodeDefinition).run !== "function") {
     fail(`node ${nodeId} run must be a function`);
   }
@@ -101,7 +103,27 @@ export function assertValidShellActionNode(
     fail(`node ${nodeId} requires an exec function`);
   }
   assertOptionalFunction(node.parse, `node ${nodeId} parse`);
+  assertShellUpdates(node, nodeId);
   assertCommonNodeFields(node, nodeId);
+}
+
+function assertShellUpdates(node: ShellActionNodeDefinition, nodeId: string): void {
+  if (node.updates === undefined) return;
+  if (node.updates === null || typeof node.updates !== "object") {
+    fail(`node ${nodeId} updates must be an object`);
+  }
+  if (typeof node.updates.parseLine !== "function") {
+    fail(`node ${nodeId} updates.parseLine must be a function`);
+  }
+  if (node.updates.streams !== undefined) {
+    if (
+      !Array.isArray(node.updates.streams) ||
+      node.updates.streams.length === 0 ||
+      node.updates.streams.some((stream) => stream !== "stdout" && stream !== "stderr")
+    ) {
+      fail(`node ${nodeId} updates.streams must contain stdout or stderr`);
+    }
+  }
 }
 
 export function assertValidCheckpointNode(

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { CancelledError, TimeoutError } from "./errors.js";
-import type { ShellActionExecution, ShellActionResult } from "./types.js";
+import type { ShellActionExecution, ShellActionResult, ShellUpdateLine } from "./types.js";
 
 /** Default cap on captured stdout/stderr, each. */
 const DEFAULT_MAX_OUTPUT_CHARS = 1_000_000;
@@ -51,6 +51,7 @@ function shellFailure(
 export async function runShellAction(
   spec: ShellActionExecution,
   signal?: AbortSignal,
+  onLine?: (line: ShellUpdateLine) => Promise<void>,
 ): Promise<ShellActionResult> {
   // The node may have been cancelled while an async `exec` callback resolved;
   // never start side effects for an already-abandoned attempt.
@@ -75,6 +76,7 @@ export async function runShellAction(
   let stdout = "";
   let stderr = "";
   let killedBy: "timeout" | "abort" | null = null;
+  let lineError: Error | undefined;
   let timeout: NodeJS.Timeout | undefined;
 
   // Cap retained output so a verbose or unending command cannot exhaust
@@ -114,15 +116,53 @@ export async function runShellAction(
   };
   const onAbort = () => kill("abort");
 
+  const lineBuffers: Record<"stdout" | "stderr", string> = { stdout: "", stderr: "" };
+  let lineWork = Promise.resolve();
+  const processChunk = (
+    stream: "stdout" | "stderr",
+    chunk: string,
+    source: NodeJS.ReadableStream & { pause(): unknown; resume(): unknown },
+  ) => {
+    if (stream === "stdout") stdout = appendCapped(stdout, chunk);
+    else stderr = appendCapped(stderr, chunk);
+    if (onLine === undefined || lineError !== undefined) return;
+    source.pause();
+    lineWork = lineWork
+      .then(async () => {
+        const parts = `${lineBuffers[stream]}${chunk}`.split("\n");
+        lineBuffers[stream] = parts.pop() ?? "";
+        if (Buffer.byteLength(lineBuffers[stream], "utf8") > 64 * 1024) {
+          throw new Error(`shell ${stream} update line exceeded 65536 bytes`);
+        }
+        for (const raw of parts) {
+          const text = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+          if (Buffer.byteLength(text, "utf8") > 64 * 1024) {
+            throw new Error(`shell ${stream} update line exceeded 65536 bytes`);
+          }
+          await onLine({ stream, text });
+        }
+      })
+      .catch((error: unknown) => {
+        lineError = error instanceof Error ? error : new Error(String(error));
+        kill("abort");
+      })
+      .finally(() => source.resume());
+  };
+  const flushLines = async () => {
+    await lineWork;
+    if (onLine === undefined || lineError !== undefined) return;
+    for (const stream of ["stdout", "stderr"] as const) {
+      const text = lineBuffers[stream];
+      if (text.length > 0)
+        await onLine({ stream, text: text.endsWith("\r") ? text.slice(0, -1) : text });
+    }
+  };
+
   const finish = new Promise<ShellActionResult>((resolve, reject) => {
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout = appendCapped(stdout, chunk);
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr = appendCapped(stderr, chunk);
-    });
+    child.stdout.on("data", (chunk: string) => processChunk("stdout", chunk, child.stdout));
+    child.stderr.on("data", (chunk: string) => processChunk("stderr", chunk, child.stderr));
 
     child.once("error", (error) => {
       // Spawn failures (missing executable, EACCES) still get a receipt so
@@ -143,24 +183,32 @@ export async function runShellAction(
     // `close` (unlike `exit`) fires only after stdio has fully closed, so
     // captured output is never truncated.
     child.once("close", (exitCode, signalName) => {
-      const result: ShellActionResult = {
-        command: spec.command,
-        args,
-        cwd,
-        stdout,
-        stderr,
-        exitCode,
-        signal: signalName,
-        durationMs: Date.now() - startMs,
-      };
-      const error = shellFailure(spec, args, result, killedBy);
-      if (error) {
-        // Attach the result so callers can persist the action receipt.
-        (error as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT] = result;
-        reject(error);
-        return;
-      }
-      resolve(result);
+      void flushLines()
+        .then(() => {
+          const result: ShellActionResult = {
+            command: spec.command,
+            args,
+            cwd,
+            stdout,
+            stderr,
+            exitCode,
+            signal: signalName,
+            durationMs: Date.now() - startMs,
+          };
+          const error = lineError ?? shellFailure(spec, args, result, killedBy);
+          if (error) {
+            // Attach the result so callers can persist the action receipt.
+            (error as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT] = result;
+            reject(error);
+            return;
+          }
+          resolve(result);
+        })
+        .catch((error: unknown) => {
+          const failure = error instanceof Error ? error : new Error(String(error));
+          lineError = failure;
+          reject(failure);
+        });
     });
   });
 

--- a/src/workflows/shell.ts
+++ b/src/workflows/shell.ts
@@ -117,6 +117,10 @@ export async function runShellAction(
   const onAbort = () => kill("abort");
 
   const lineBuffers: Record<"stdout" | "stderr", string> = { stdout: "", stderr: "" };
+  const decoders = {
+    stdout: new TextDecoder("utf-8", { fatal: onLine !== undefined }),
+    stderr: new TextDecoder("utf-8", { fatal: onLine !== undefined }),
+  };
   let lineWork = Promise.resolve();
   const processChunk = (
     stream: "stdout" | "stderr",
@@ -153,16 +157,30 @@ export async function runShellAction(
     if (onLine === undefined || lineError !== undefined) return;
     for (const stream of ["stdout", "stderr"] as const) {
       const text = lineBuffers[stream];
+      if (Buffer.byteLength(text, "utf8") > 64 * 1024) {
+        throw new Error(`shell ${stream} update line exceeded 65536 bytes`);
+      }
       if (text.length > 0)
         await onLine({ stream, text: text.endsWith("\r") ? text.slice(0, -1) : text });
     }
   };
 
+  const decodeChunk = (
+    stream: "stdout" | "stderr",
+    chunk: Buffer,
+    source: NodeJS.ReadableStream & { pause(): unknown; resume(): unknown },
+  ) => {
+    try {
+      processChunk(stream, decoders[stream].decode(chunk, { stream: true }), source);
+    } catch (error) {
+      lineError = error instanceof Error ? error : new Error(String(error));
+      kill("abort");
+    }
+  };
+
   const finish = new Promise<ShellActionResult>((resolve, reject) => {
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => processChunk("stdout", chunk, child.stdout));
-    child.stderr.on("data", (chunk: string) => processChunk("stderr", chunk, child.stderr));
+    child.stdout.on("data", (chunk: Buffer) => decodeChunk("stdout", chunk, child.stdout));
+    child.stderr.on("data", (chunk: Buffer) => decodeChunk("stderr", chunk, child.stderr));
 
     child.once("error", (error) => {
       // Spawn failures (missing executable, EACCES) still get a receipt so
@@ -183,6 +201,12 @@ export async function runShellAction(
     // `close` (unlike `exit`) fires only after stdio has fully closed, so
     // captured output is never truncated.
     child.once("close", (exitCode, signalName) => {
+      try {
+        processChunk("stdout", decoders.stdout.decode(), child.stdout);
+        processChunk("stderr", decoders.stderr.decode(), child.stderr);
+      } catch (error) {
+        lineError = error instanceof Error ? error : new Error(String(error));
+      }
       void flushLines()
         .then(() => {
           const result: ShellActionResult = {
@@ -207,6 +231,17 @@ export async function runShellAction(
         .catch((error: unknown) => {
           const failure = error instanceof Error ? error : new Error(String(error));
           lineError = failure;
+          const result: ShellActionResult = {
+            command: spec.command,
+            args,
+            cwd,
+            stdout,
+            stderr,
+            exitCode,
+            signal: signalName,
+            durationMs: Date.now() - startMs,
+          };
+          (failure as Error & { [SHELL_RESULT]?: ShellActionResult })[SHELL_RESULT] = result;
           reject(failure);
         });
     });

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1035,6 +1035,8 @@ export type LoadedRunBundle = {
   manifest: WorkflowRunManifest;
   state: WorkflowRunState;
   snapshot: WorkflowDefinitionSnapshot | null;
+  /** Full durable trace when loaded by the current reader. */
+  traceEvents?: WorkflowTraceEvent[];
   sessionBinding: WorkflowSessionBinding | null;
   sessionEntries: WorkflowSessionEntryRecord[];
   sessionEvents: WorkflowSessionEventRecord[];
@@ -1073,6 +1075,9 @@ export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | n
   }
   const snapshot = await readJsonFile<WorkflowDefinitionSnapshot>(
     resolveBundlePath(runDir, paths.workflow, WORKFLOW_SNAPSHOT_PATH),
+  );
+  const trace = await readNdjsonFile<WorkflowTraceEvent>(
+    resolveBundlePath(runDir, paths.trace, TRACE_PATH),
   );
   const sessionDir = resolveBundlePath(runDir, paths.session, SESSION_DIR);
   const sessionBinding = await readJsonFile<WorkflowSessionBinding>(
@@ -1148,6 +1153,7 @@ export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | n
     manifest,
     state,
     snapshot,
+    traceEvents: trace.records,
     sessionBinding,
     sessionEntries: entries.records,
     sessionEvents: events.records,

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -439,8 +439,12 @@ export class WorkflowRunStore {
     nodeId: string,
     attemptId: string,
     update: WorkflowUpdateInput,
+    options: { signal?: AbortSignal } = {},
   ): Promise<{ event: WorkflowTraceEvent; record: WorkflowUpdateRecord }> {
     return await this.withRunLock(runDir, async () => {
+      if (options.signal?.aborted === true) {
+        throw options.signal.reason ?? new Error("workflow update attempt is no longer active");
+      }
       const exists = (state.updates ?? []).some(
         (record) => record.type === update.type && record.key === update.key,
       );
@@ -1092,11 +1096,9 @@ export async function readRunBundle(
     resolveBundlePath(runDir, paths.workflow, WORKFLOW_SNAPSHOT_PATH),
   );
   const trace =
-    options.includeTrace === false
-      ? undefined
-      : await readNdjsonFile<WorkflowTraceEvent>(
-          resolveBundlePath(runDir, paths.trace, TRACE_PATH),
-        );
+    options.includeTrace === true
+      ? await readNdjsonFile<WorkflowTraceEvent>(resolveBundlePath(runDir, paths.trace, TRACE_PATH))
+      : undefined;
   const sessionDir = resolveBundlePath(runDir, paths.session, SESSION_DIR);
   const sessionBinding = await readJsonFile<WorkflowSessionBinding>(
     path.join(sessionDir, "binding.json"),

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -16,7 +16,10 @@ import type {
   WorkflowSessionEventRecord,
   WorkflowTraceEvent,
   WorkflowTraceEventDraft,
+  WorkflowUpdateInput,
+  WorkflowUpdateRecord,
 } from "./types.js";
+import { createUpdateId, updateProjection } from "./updates.js";
 
 export const RUN_BUNDLE_SCHEMA = "pi-workflows.run-bundle.v1" as const;
 export const RUN_STATE_SCHEMA = "pi-workflows.run-state.v1" as const;
@@ -427,6 +430,42 @@ export class WorkflowRunStore {
       await this.writeLoadedProjections(runDir, state);
     });
     return await readRunBundle(runDir);
+  }
+
+  /** Publish one durable update under the run's serialized claim-fenced writer. */
+  async publishUpdate(
+    runDir: string,
+    state: WorkflowRunState,
+    nodeId: string,
+    attemptId: string,
+    update: WorkflowUpdateInput,
+  ): Promise<{ event: WorkflowTraceEvent; record: WorkflowUpdateRecord }> {
+    return await this.withRunLock(runDir, async () => {
+      const updateId = createUpdateId();
+      const event = await this.appendTraceEvent(runDir, state.runId, {
+        scope: "update",
+        type: "update_published",
+        nodeId,
+        attemptId,
+        payload: { updateId, type: update.type, key: update.key, data: update.data },
+      });
+      const record: WorkflowUpdateRecord = {
+        updateId,
+        seq: event.seq,
+        at: event.at,
+        runId: state.runId,
+        nodeId,
+        attemptId,
+        type: update.type,
+        key: update.key,
+        data: update.data,
+      };
+      state.updates = updateProjection(state.updates, record);
+      state.traceSeq = event.seq;
+      state.updatedAt = event.at;
+      await this.writeProjections(runDir, state);
+      return { event, record };
+    });
   }
 
   /**

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -448,12 +448,13 @@ export class WorkflowRunStore {
         throw new Error(`workflow run supports at most ${MAX_CURRENT_UPDATES} current updates`);
       }
       const updateId = createUpdateId();
+      const data = JSON.parse(JSON.stringify(update.data)) as Record<string, unknown>;
       const event = await this.appendTraceEvent(runDir, state.runId, {
         scope: "node",
         type: "update_published",
         nodeId,
         attemptId,
-        payload: { updateId, type: update.type, key: update.key, data: update.data },
+        payload: { updateId, type: update.type, key: update.key, data },
       });
       const record: WorkflowUpdateRecord = {
         updateId,
@@ -464,7 +465,7 @@ export class WorkflowRunStore {
         attemptId,
         type: update.type,
         key: update.key,
-        data: update.data,
+        data,
       };
       state.updates = updateProjection(state.updates, record);
       state.traceSeq = event.seq;
@@ -1063,8 +1064,16 @@ export async function readLastTraceEvent(
   return events.records.at(-1) ?? null;
 }
 
+export type ReadRunBundleOptions = {
+  /** Load the full append-only trace. Detail views need it; run lists do not. */
+  includeTrace?: boolean;
+};
+
 /** Read a run bundle from disk. Returns null when the bundle is unreadable. */
-export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | null> {
+export async function readRunBundle(
+  runDir: string,
+  options: ReadRunBundleOptions = {},
+): Promise<LoadedRunBundle | null> {
   const manifest = await readJsonFile<WorkflowRunManifest>(path.join(runDir, MANIFEST_PATH));
   if (!manifest || manifest.schema !== RUN_BUNDLE_SCHEMA) {
     return null;
@@ -1082,9 +1091,12 @@ export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | n
   const snapshot = await readJsonFile<WorkflowDefinitionSnapshot>(
     resolveBundlePath(runDir, paths.workflow, WORKFLOW_SNAPSHOT_PATH),
   );
-  const trace = await readNdjsonFile<WorkflowTraceEvent>(
-    resolveBundlePath(runDir, paths.trace, TRACE_PATH),
-  );
+  const trace =
+    options.includeTrace === false
+      ? undefined
+      : await readNdjsonFile<WorkflowTraceEvent>(
+          resolveBundlePath(runDir, paths.trace, TRACE_PATH),
+        );
   const sessionDir = resolveBundlePath(runDir, paths.session, SESSION_DIR);
   const sessionBinding = await readJsonFile<WorkflowSessionBinding>(
     path.join(sessionDir, "binding.json"),
@@ -1159,7 +1171,7 @@ export async function readRunBundle(runDir: string): Promise<LoadedRunBundle | n
     manifest,
     state,
     snapshot,
-    traceEvents: trace.records,
+    ...(trace !== undefined ? { traceEvents: trace.records } : {}),
     sessionBinding,
     sessionEntries: entries.records,
     sessionEvents: events.records,
@@ -1198,7 +1210,7 @@ export async function listRunBundles(outputRoot: string): Promise<LoadedRunBundl
   }
   const bundles: LoadedRunBundle[] = [];
   for (const entry of entries) {
-    const bundle = await readRunBundle(path.join(outputRoot, entry));
+    const bundle = await readRunBundle(path.join(outputRoot, entry), { includeTrace: false });
     if (bundle) {
       bundles.push(bundle);
     }

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -19,7 +19,7 @@ import type {
   WorkflowUpdateInput,
   WorkflowUpdateRecord,
 } from "./types.js";
-import { createUpdateId, updateProjection } from "./updates.js";
+import { MAX_CURRENT_UPDATES, createUpdateId, updateProjection } from "./updates.js";
 
 export const RUN_BUNDLE_SCHEMA = "pi-workflows.run-bundle.v1" as const;
 export const RUN_STATE_SCHEMA = "pi-workflows.run-state.v1" as const;
@@ -441,9 +441,15 @@ export class WorkflowRunStore {
     update: WorkflowUpdateInput,
   ): Promise<{ event: WorkflowTraceEvent; record: WorkflowUpdateRecord }> {
     return await this.withRunLock(runDir, async () => {
+      const exists = (state.updates ?? []).some(
+        (record) => record.type === update.type && record.key === update.key,
+      );
+      if (!exists && (state.updates?.length ?? 0) >= MAX_CURRENT_UPDATES) {
+        throw new Error(`workflow run supports at most ${MAX_CURRENT_UPDATES} current updates`);
+      }
       const updateId = createUpdateId();
       const event = await this.appendTraceEvent(runDir, state.runId, {
-        scope: "update",
+        scope: "node",
         type: "update_published",
         nodeId,
         attemptId,

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -19,6 +19,55 @@ export type WorkflowNodeContext<TInput = unknown> = {
   signal: AbortSignal;
 };
 
+export type WorkflowUpdateInput = {
+  type: string;
+  key: string;
+  data: Record<string, unknown>;
+};
+
+export type WorkflowUpdateRecord = {
+  updateId: string;
+  seq: number;
+  at: string;
+  runId: string;
+  nodeId: string;
+  attemptId: string;
+  type: string;
+  key: string;
+  data: Record<string, unknown>;
+};
+
+export type WorkflowUpdateReceipt = Pick<
+  WorkflowUpdateRecord,
+  "updateId" | "seq" | "at" | "type" | "key"
+>;
+
+export type WorkflowActionContext<TInput = unknown> = WorkflowNodeContext<TInput> & {
+  publishUpdate(update: WorkflowUpdateInput): Promise<WorkflowUpdateReceipt>;
+};
+
+export type WorkflowProgressStatus =
+  | "pending"
+  | "running"
+  | "waiting"
+  | "blocked"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "unknown";
+
+export type WorkflowProgressData = {
+  schema: "pi-workflows.progress.v1";
+  status: WorkflowProgressStatus;
+  label?: string;
+  phase?: string;
+  completed?: number;
+  total?: number;
+  unit?: string;
+  sourceUpdatedAt?: string;
+  sourceEstimatedFinishAt?: string;
+};
+
 export type WorkflowNodeCommon = {
   /**
    * Per-node timeout or a callback that derives it from the run context.
@@ -78,7 +127,7 @@ export type NotifyNodeDefinition = WorkflowNodeCommon & {
 /** A deterministic runtime-owned step implemented as a local function. */
 export type FunctionActionNodeDefinition = WorkflowNodeCommon & {
   nodeType: "action";
-  run: (context: WorkflowNodeContext) => MaybePromise<unknown>;
+  run: (context: WorkflowActionContext) => MaybePromise<unknown>;
 };
 
 export type ShellActionExecution = {
@@ -106,10 +155,24 @@ export type ShellActionResult = {
 };
 
 /** A deterministic runtime-owned step implemented as a shell command. */
+export type ShellUpdateLine = {
+  stream: "stdout" | "stderr";
+  text: string;
+};
+
+export type ShellActionUpdates = {
+  streams?: Array<"stdout" | "stderr">;
+  parseLine: (
+    line: ShellUpdateLine,
+    context: WorkflowActionContext,
+  ) => MaybePromise<WorkflowUpdateInput | WorkflowUpdateInput[] | undefined>;
+};
+
 export type ShellActionNodeDefinition = WorkflowNodeCommon & {
   nodeType: "action";
   exec: (context: WorkflowNodeContext) => MaybePromise<ShellActionExecution>;
   parse?: (result: ShellActionResult, context: WorkflowNodeContext) => MaybePromise<unknown>;
+  updates?: ShellActionUpdates;
 };
 
 export type ActionNodeDefinition = FunctionActionNodeDefinition | ShellActionNodeDefinition;
@@ -277,6 +340,8 @@ export type WorkflowRunState = {
   outputs: Record<string, unknown>;
   results: Record<string, WorkflowNodeResult>;
   steps: WorkflowStepRecord[];
+  /** Latest update for each `(type, key)` pair, sorted by trace sequence. */
+  updates?: WorkflowUpdateRecord[];
   currentNode?: string;
   currentAttemptId?: string;
   currentNodeStartedAt?: string;
@@ -308,7 +373,7 @@ export type WorkflowDefinitionSnapshot = {
 export type WorkflowTraceEvent = {
   seq: number;
   at: string;
-  scope: "run" | "node" | "agent" | "action" | "session";
+  scope: "run" | "node" | "agent" | "action" | "session" | "update";
   type: string;
   runId: string;
   nodeId?: string;
@@ -439,6 +504,11 @@ export type AgentStepRequest = {
    * error message the executor should surface to the model for retry.
    */
   accept: (output: unknown) => Promise<{ ok: true; value: unknown } | { ok: false; error: string }>;
+  /** Publish a non-completing update from a headless executor. */
+  publishUpdate?: (
+    update: WorkflowUpdateInput,
+    idempotencyKey?: string,
+  ) => Promise<WorkflowUpdateReceipt>;
 };
 
 export type AgentStepSubmission = {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -373,7 +373,7 @@ export type WorkflowDefinitionSnapshot = {
 export type WorkflowTraceEvent = {
   seq: number;
   at: string;
-  scope: "run" | "node" | "agent" | "action" | "session" | "update";
+  scope: "run" | "node" | "agent" | "action" | "session";
   type: string;
   runId: string;
   nodeId?: string;

--- a/src/workflows/updates.ts
+++ b/src/workflows/updates.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import type {
+  WorkflowProgressData,
+  WorkflowUpdateInput,
+  WorkflowUpdateReceipt,
+  WorkflowUpdateRecord,
+} from "./types.js";
+
+export const MAX_UPDATE_DATA_BYTES = 64 * 1024;
+export const MAX_CURRENT_UPDATES = 1_024;
+export const UPDATE_RATE_PER_SECOND = 20;
+export const UPDATE_RATE_BURST = 100;
+
+const TYPE_PATTERN = /^[a-z][a-z0-9.-]{0,63}$/;
+const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
+const PROGRESS_STATUSES = new Set([
+  "pending",
+  "running",
+  "waiting",
+  "blocked",
+  "completed",
+  "failed",
+  "cancelled",
+  "unknown",
+]);
+const PROGRESS_FIELDS = new Set([
+  "schema",
+  "status",
+  "label",
+  "phase",
+  "completed",
+  "total",
+  "unit",
+  "sourceUpdatedAt",
+  "sourceEstimatedFinishAt",
+]);
+
+export function validateWorkflowUpdate(input: unknown): WorkflowUpdateInput {
+  if (!isRecord(input)) throw new Error("update must be an object");
+  const type = input.type;
+  const key = input.key;
+  const data = input.data;
+  if (typeof type !== "string" || !TYPE_PATTERN.test(type)) {
+    throw new Error("update.type must match [a-z][a-z0-9.-]{0,63}");
+  }
+  if (typeof key !== "string" || !KEY_PATTERN.test(key)) {
+    throw new Error("update.key must match [A-Za-z0-9][A-Za-z0-9._:/-]{0,127}");
+  }
+  if (!isRecord(data)) throw new Error("update.data must be a non-null JSON object");
+  assertJsonValue(data, "update.data");
+  const bytes = Buffer.byteLength(JSON.stringify(data), "utf8");
+  if (bytes > MAX_UPDATE_DATA_BYTES) {
+    throw new Error(`update.data must be at most ${MAX_UPDATE_DATA_BYTES} bytes`);
+  }
+  const normalized = { type, key, data };
+  if (type === "progress") validateProgressData(data);
+  return normalized;
+}
+
+export function validateProgressData(data: Record<string, unknown>): WorkflowProgressData {
+  for (const field of Object.keys(data)) {
+    if (!PROGRESS_FIELDS.has(field)) throw new Error(`progress.${field} is not supported`);
+  }
+  if (data.schema !== "pi-workflows.progress.v1") {
+    throw new Error("progress.schema must equal pi-workflows.progress.v1");
+  }
+  if (typeof data.status !== "string" || !PROGRESS_STATUSES.has(data.status)) {
+    throw new Error("progress.status is invalid");
+  }
+  optionalString(data.label, "progress.label", 200);
+  optionalString(data.phase, "progress.phase", 128);
+  optionalFiniteNonNegative(data.completed, "progress.completed");
+  if (data.total !== undefined) {
+    if (typeof data.total !== "number" || !Number.isFinite(data.total) || data.total <= 0) {
+      throw new Error("progress.total must be a finite number greater than zero");
+    }
+    if (typeof data.completed === "number" && data.total < data.completed) {
+      throw new Error("progress.total must be at least progress.completed");
+    }
+  }
+  if (data.completed !== undefined || data.total !== undefined) {
+    if (
+      typeof data.unit !== "string" ||
+      data.unit.trim().length < 1 ||
+      data.unit.trim().length > 32
+    ) {
+      throw new Error("progress.unit is required with counts and must be 1 to 32 characters");
+    }
+  } else if (data.unit !== undefined) {
+    optionalString(data.unit, "progress.unit", 32);
+  }
+  optionalDate(data.sourceUpdatedAt, "progress.sourceUpdatedAt");
+  optionalDate(data.sourceEstimatedFinishAt, "progress.sourceEstimatedFinishAt");
+  return data as WorkflowProgressData;
+}
+
+export function updateProjection(
+  current: WorkflowUpdateRecord[] | undefined,
+  record: WorkflowUpdateRecord,
+): WorkflowUpdateRecord[] {
+  const next = (current ?? []).filter(
+    (entry) => !(entry.type === record.type && entry.key === record.key),
+  );
+  next.push(record);
+  next.sort((a, b) => a.seq - b.seq);
+  return next;
+}
+
+export function createUpdateId(): string {
+  return `upd_${randomUUID()}`;
+}
+
+export function updateReceipt(record: WorkflowUpdateRecord): WorkflowUpdateReceipt {
+  return {
+    updateId: record.updateId,
+    seq: record.seq,
+    at: record.at,
+    type: record.type,
+    key: record.key,
+  };
+}
+
+export class UpdateRateLimiter {
+  private tokens = UPDATE_RATE_BURST;
+  private lastMs = Date.now();
+
+  take(nowMs = Date.now()): void {
+    const elapsed = Math.max(0, nowMs - this.lastMs) / 1_000;
+    this.tokens = Math.min(UPDATE_RATE_BURST, this.tokens + elapsed * UPDATE_RATE_PER_SECOND);
+    this.lastMs = nowMs;
+    if (this.tokens < 1) throw new Error("workflow update rate limit exceeded");
+    this.tokens -= 1;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertJsonValue(value: unknown, path: string): void {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${path} contains a non-finite number`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertJsonValue(item, `${path}[${index}]`));
+    return;
+  }
+  if (isRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      if (item === undefined) throw new Error(`${path}.${key} is undefined`);
+      assertJsonValue(item, `${path}.${key}`);
+    }
+    return;
+  }
+  throw new Error(`${path} contains a non-JSON value`);
+}
+
+function optionalString(value: unknown, field: string, max: number): void {
+  if (value === undefined) return;
+  if (typeof value !== "string" || value.trim().length < 1 || value.trim().length > max) {
+    throw new Error(`${field} must be 1 to ${max} characters`);
+  }
+}
+
+function optionalFiniteNonNegative(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a finite non-negative number`);
+  }
+}
+
+function optionalDate(value: unknown, field: string): void {
+  if (value === undefined) return;
+  if (
+    typeof value !== "string" ||
+    !Number.isFinite(Date.parse(value)) ||
+    !/[zZ]|[+-]\d\d:\d\d$/.test(value)
+  ) {
+    throw new Error(`${field} must be an RFC 3339 timestamp with an offset`);
+  }
+}

--- a/src/workflows/updates.ts
+++ b/src/workflows/updates.ts
@@ -137,7 +137,9 @@ export class UpdateRateLimiter {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
 }
 
 function assertJsonValue(value: unknown, path: string): void {

--- a/src/workflows/updates.ts
+++ b/src/workflows/updates.ts
@@ -167,6 +167,14 @@ function optionalString(value: unknown, field: string, max: number): void {
   if (typeof value !== "string" || value.trim().length < 1 || value.trim().length > max) {
     throw new Error(`${field} must be 1 to ${max} characters`);
   }
+  if (
+    [...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code < 32 || (code >= 127 && code <= 159);
+    })
+  ) {
+    throw new Error(`${field} must not contain control characters`);
+  }
 }
 
 function optionalFiniteNonNegative(value: unknown, field: string): void {

--- a/src/workflows/updates.ts
+++ b/src/workflows/updates.ts
@@ -37,6 +37,11 @@ const PROGRESS_FIELDS = new Set([
 
 export function validateWorkflowUpdate(input: unknown): WorkflowUpdateInput {
   if (!isRecord(input)) throw new Error("update must be an object");
+  for (const field of Object.keys(input)) {
+    if (field !== "type" && field !== "key" && field !== "data") {
+      throw new Error(`update.${field} is not supported`);
+    }
+  }
   const type = input.type;
   const key = input.key;
   const data = input.data;
@@ -79,15 +84,13 @@ export function validateProgressData(data: Record<string, unknown>): WorkflowPro
     }
   }
   if (data.completed !== undefined || data.total !== undefined) {
-    if (
-      typeof data.unit !== "string" ||
-      data.unit.trim().length < 1 ||
-      data.unit.trim().length > 32
-    ) {
-      throw new Error("progress.unit is required with counts and must be 1 to 32 characters");
+    if (!validUnit(data.unit)) {
+      throw new Error(
+        "progress.unit is required with counts and must be 1 to 32 printable characters",
+      );
     }
-  } else if (data.unit !== undefined) {
-    optionalString(data.unit, "progress.unit", 32);
+  } else if (data.unit !== undefined && !validUnit(data.unit)) {
+    throw new Error("progress.unit must be 1 to 32 printable characters");
   }
   optionalDate(data.sourceUpdatedAt, "progress.sourceUpdatedAt");
   optionalDate(data.sourceEstimatedFinishAt, "progress.sourceEstimatedFinishAt");
@@ -169,6 +172,18 @@ function optionalFiniteNonNegative(value: unknown, field: string): void {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     throw new Error(`${field} must be a finite non-negative number`);
   }
+}
+
+function validUnit(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.trim().length >= 1 &&
+    value.trim().length <= 32 &&
+    [...value].every((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code >= 32 && !(code >= 127 && code <= 159);
+    })
+  );
 }
 
 function optionalDate(value: unknown, field: string): void {

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -287,9 +287,47 @@ describe.sequential("pi-workflows end to end", () => {
               input: {
                 task: "Check the fixture once",
                 everyMinutes: 30,
-                reportWhen: "The fixture fails",
                 stopWhen: "The first check is complete",
                 maxChecks: 1,
+              },
+            },
+          };
+        }
+        if (
+          lastRole === "tool" &&
+          /workflow step contract \(workflow: monitor, step: check/i.test(lastUserText)
+        ) {
+          const monitorStepMatch = lastUserText.match(
+            /workflow step contract \(workflow: monitor, step: check, attempt: ([a-z0-9-]+)\)/i,
+          );
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "submit",
+              step: "check",
+              attempt: monitorStepMatch?.[1] ?? "",
+              output: {
+                route: "stop",
+                observation: "The fixture check completed at 1 of 2 items.",
+                report: "The fixture check completed.",
+                progress: {
+                  tracks: [
+                    {
+                      key: "fixture",
+                      data: {
+                        schema: "pi-workflows.progress.v1",
+                        label: "Fixture",
+                        status: "running",
+                        completed: 1,
+                        total: 2,
+                        unit: "items",
+                        sourceEstimatedFinishAt: "2099-01-01T00:00:00.000Z",
+                      },
+                    },
+                  ],
+                },
+                reason: "The requested first check is complete.",
               },
             },
           };
@@ -340,13 +378,20 @@ describe.sequential("pi-workflows end to end", () => {
             kind: "tool",
             toolName: "workflow",
             args: {
-              action: "submit",
+              action: "update",
               step: "check",
               attempt: monitorStepMatch[2] ?? "",
-              output: {
-                route: "stop_quiet",
-                observation: "The fixture check completed.",
-                reason: "The requested first check is complete.",
+              update: {
+                type: "progress",
+                key: "live-agent",
+                data: {
+                  schema: "pi-workflows.progress.v1",
+                  label: "Live agent",
+                  status: "running",
+                  completed: 1,
+                  total: 2,
+                  unit: "items",
+                },
               },
             },
           };
@@ -818,16 +863,22 @@ describe.sequential("pi-workflows end to end", () => {
       () => `pi stderr:\n${pi.stderr()}\npi stdout tail:\n${pi.stdoutLines.slice(-15).join("\n")}`,
     );
 
-    expect(state.status).toBe("completed");
+    expect(state.status, state.error).toBe("completed");
     expect(state.workflowName).toBe("monitor");
-    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "2" });
+    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "3" });
     expect(state.workflowPath).toBeUndefined();
     expect(state.workflowHash).toBeUndefined();
     expect(state.finalOutput).toMatchObject({
-      observation: "The fixture check completed.",
+      observation: "The fixture check completed at 1 of 2 items.",
       reason: "The requested first check is complete.",
     });
     expect(state.steps.some((step) => step.nodeId === "sleep")).toBe(false);
+    expect(state.updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "progress", key: "live-agent" }),
+        expect.objectContaining({ type: "progress", key: "fixture" }),
+      ]),
+    );
   });
 
   it("reconciles a durable controller through the real pi extension", async () => {

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -118,7 +118,7 @@ describe("resolveWorkflowRef", () => {
     const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir }, builtinWorkflowCatalog);
 
     expect(resolved.sourceKind).toBe("builtin");
-    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "2" });
+    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "3" });
     expect(resolved.definition.name).toBe("monitor");
   });
 

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -1,374 +1,214 @@
 import { describe, expect, it } from "vitest";
-import monitor from "../src/builtins/monitor.workflow.js";
+import monitor, {
+  prepareMonitorInput,
+  validateMonitorCheck,
+} from "../src/builtins/monitor.workflow.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import { WorkflowRunStore } from "../src/workflows/store.js";
-import type {
-  AgentNodeDefinition,
-  AgentStepExecutor,
-  ComputeNodeDefinition,
-  NotifyNodeDefinition,
-  ShellActionNodeDefinition,
-  WorkflowNodeContext,
-} from "../src/workflows/types.js";
+import type { AgentStepExecutor, WorkflowNotificationRequest } from "../src/workflows/types.js";
 import { makeTempDir } from "./helpers.js";
 
-function scriptedExecutor(outputs: unknown[]): AgentStepExecutor {
+function scriptedExecutor(outputs: unknown[], prompts: string[] = []): AgentStepExecutor {
   const remaining = [...outputs];
   return {
     async runAgentStep(request) {
+      prompts.push(request.prompt);
       const output = remaining.shift();
-      if (output === undefined) {
-        throw new Error("No scripted monitor output remains");
-      }
+      if (output === undefined) throw new Error("No scripted monitor output remains");
       const accepted = await request.accept(output);
-      if (!accepted.ok) {
-        throw new Error(accepted.error);
-      }
+      if (!accepted.ok) throw new Error(accepted.error);
       return { output: accepted.value };
     },
   };
 }
 
-function monitorInput(overrides: Record<string, unknown> = {}) {
+function input(overrides: Record<string, unknown> = {}) {
   return {
     task: "Check pull request 123",
-    everyMinutes: 30,
-    reportWhen: "Checks fail",
     stopWhen: "The pull request is merged or closed",
     maxChecks: 5,
     ...overrides,
   };
 }
 
+function check(overrides: Record<string, unknown> = {}) {
+  return {
+    route: "stop",
+    observation: "Pull request 123 is merged.",
+    report: "PR 123 is merged.",
+    reason: "The stop condition is true.",
+    ...overrides,
+  };
+}
+
 describe("built-in monitor workflow", () => {
-  it("finishes quietly when the first check meets the stop condition", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor");
-    const engine = new WorkflowEngine({
-      executor: scriptedExecutor([
-        {
-          route: "stop_quiet",
-          observation: "Pull request 123 is merged.",
-          reason: "The configured stop condition is true.",
-        },
-      ]),
-      store: new WorkflowRunStore(outputRoot),
-    });
-
-    const result = await engine.run(monitor, monitorInput());
-
-    expect(result.state.status).toBe("completed");
-    expect(result.state.finalOutput).toMatchObject({
-      reason: "The configured stop condition is true.",
-      observation: "Pull request 123 is merged.",
-      reported: false,
+  it("defaults to 30 minutes and explicit-user-stop when no finish rule is supplied", () => {
+    expect(prepareMonitorInput({ task: "Observe the target" })).toMatchObject({
+      everyMinutes: 30,
+      stopWhen: "Stop only when the user explicitly asks to stop.",
+      maxChecks: 1_000,
+      checkTimeoutMinutes: 60,
     });
   });
 
-  it("runs a report step before finishing when the check asks to report", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-report");
-    const prompts: string[] = [];
-    const notifications: { content: string; notificationIndex: number }[] = [];
-    const outputs = [
-      {
-        route: "stop_report",
-        observation: "The Linux check failed.",
-        report: "PR 123 now has a failed Linux check.",
-        reason: "A requested report condition is true and the pull request closed.",
-      },
-    ];
-    const executor: AgentStepExecutor = {
-      async runAgentStep(request) {
-        prompts.push(request.prompt);
-        const output = outputs.shift();
-        const accepted = await request.accept(output);
-        if (!accepted.ok) {
-          throw new Error(accepted.error);
-        }
-        return { output: accepted.value };
-      },
-    };
+  it("reports every accepted stop check before completion", async () => {
+    const notifications: WorkflowNotificationRequest[] = [];
     const engine = new WorkflowEngine({
-      executor,
-      store: new WorkflowRunStore(outputRoot),
+      executor: scriptedExecutor([check()]),
+      store: new WorkflowRunStore(await makeTempDir("monitor-stop")),
       notificationSink: {
-        notify: (request) => {
-          notifications.push({
-            content: request.content,
-            notificationIndex: request.notificationIndex,
-          });
-          return { notificationId: "notification-1", targetSessionId: "session-1" };
+        notify(request) {
+          notifications.push(request);
+          return { notificationId: "n1", targetSessionId: "s1" };
         },
       },
     });
 
-    const result = await engine.run(monitor, monitorInput());
+    const result = await engine.run(monitor, input());
 
     expect(result.state.status).toBe("completed");
-    expect(prompts).toHaveLength(1);
-    expect(notifications).toEqual([
-      { content: "PR 123 now has a failed Linux check.", notificationIndex: 1 },
+    expect(notifications.map((item) => item.content)).toEqual(["PR 123 is merged."]);
+    expect(result.state.steps.map((step) => step.nodeId)).toEqual([
+      "prepare",
+      "check",
+      "estimate",
+      "publish_progress",
+      "report",
+      "decide",
+      "finish",
     ]);
-    expect(result.state.finalOutput).toMatchObject({ reported: true });
+    expect(result.state.finalOutput).toMatchObject({ reported: true, checks: 1 });
   });
 
-  it("stops at the check limit before starting another sleep", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-limit");
+  it("reports a continue check and then stops at the disclosed safety limit", async () => {
+    const notifications: WorkflowNotificationRequest[] = [];
     const engine = new WorkflowEngine({
       executor: scriptedExecutor([
-        {
-          route: "continue_quiet",
-          observation: "Pull request 123 is still open.",
-          reason: "The stop condition is not true.",
-        },
+        check({
+          route: "continue",
+          observation: "PR 123 remains open.",
+          report: "PR 123 remains open.",
+          reason: "It is not merged.",
+        }),
       ]),
-      store: new WorkflowRunStore(outputRoot),
+      store: new WorkflowRunStore(await makeTempDir("monitor-limit")),
+      notificationSink: {
+        notify(request) {
+          notifications.push(request);
+          return { notificationId: "n1", targetSessionId: "s1" };
+        },
+      },
     });
 
-    const result = await engine.run(monitor, monitorInput({ maxChecks: 1 }));
+    const result = await engine.run(monitor, input({ maxChecks: 1 }));
 
     expect(result.state.status).toBe("completed");
+    expect(notifications).toHaveLength(1);
     expect(result.state.finalOutput).toMatchObject({
-      reason: "Reached the 1-check limit.",
-      observation: "Pull request 123 is still open.",
+      reason: "Reached the 1-check safety limit.",
+      reported: true,
     });
     expect(result.state.steps.some((step) => step.nodeId === "sleep")).toBe(false);
   });
 
-  it.each([
-    [null, "monitor input must be an object"],
-    [[], "monitor input must be an object"],
-    [{ task: 1, everyMinutes: 30 }, "task must be a string"],
-    [{ task: " ", everyMinutes: 30 }, "task must not be empty"],
-    [{ task: "x".repeat(8_001), everyMinutes: 30 }, "task must be at most 8000"],
-    [{ task: "check", everyMinutes: "30" }, "everyMinutes must be an integer"],
-    [{ task: "check", everyMinutes: 1.5 }, "everyMinutes must be an integer"],
-    [{ task: "check", everyMinutes: 0 }, "everyMinutes must be an integer"],
-    [{ task: "check", everyMinutes: 1_441 }, "everyMinutes must be an integer"],
-    [{ task: "check", everyMinutes: 30, maxChecks: 1.5 }, "maxChecks must be an integer"],
-    [{ task: "check", everyMinutes: 30, maxChecks: 0 }, "maxChecks must be an integer"],
-    [{ task: "check", everyMinutes: 30, maxChecks: 1_001 }, "maxChecks must be an integer"],
-    [{ task: "check", everyMinutes: 30, reportWhen: false }, "reportWhen must be a string"],
-    [{ task: "check", everyMinutes: 30, stopWhen: " " }, "stopWhen must not be empty"],
-  ])("rejects invalid monitor input %#", async (input, expectedError) => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-input");
-    const engine = new WorkflowEngine({
-      executor: scriptedExecutor([]),
-      store: new WorkflowRunStore(outputRoot),
-    });
-
-    const result = await engine.run(monitor, input);
-
-    expect(result.state.status).toBe("failed");
-    expect(result.state.error).toContain(expectedError);
-    expect(result.state.steps).toHaveLength(1);
-  });
-
-  it("applies default report, stop, and check limits", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-defaults");
+  it("publishes progress and adds a model-free estimate to the report", async () => {
+    const notifications: WorkflowNotificationRequest[] = [];
     const engine = new WorkflowEngine({
       executor: scriptedExecutor([
-        {
-          route: "stop_quiet",
-          observation: "Initial state",
-          reason: "Done",
-        },
+        check({
+          report: "Checks are still running.",
+          progress: {
+            tracks: [
+              {
+                key: "checks",
+                data: {
+                  schema: "pi-workflows.progress.v1",
+                  label: "Checks",
+                  status: "running",
+                  completed: 8,
+                  total: 10,
+                  unit: "checks",
+                },
+              },
+            ],
+          },
+        }),
       ]),
-      store: new WorkflowRunStore(outputRoot),
+      store: new WorkflowRunStore(await makeTempDir("monitor-progress")),
+      notificationSink: {
+        notify(request) {
+          notifications.push(request);
+          return { notificationId: "n1", targetSessionId: "s1" };
+        },
+      },
     });
 
-    const result = await engine.run(monitor, { task: "Check a target", everyMinutes: 30 });
+    const result = await engine.run(monitor, input());
 
-    expect(result.state.status).toBe("completed");
-    expect(result.state.outputs.prepare).toMatchObject({
-      maxChecks: 1_000,
-      reportWhen: expect.stringContaining("changes materially"),
-      stopWhen: expect.stringContaining("maximum check count"),
-    });
+    expect(result.state.updates).toHaveLength(1);
+    expect(result.state.updates?.[0]).toMatchObject({ type: "progress", key: "checks" });
+    expect(notifications[0]?.content).toContain("Progress: Checks  8/10 checks");
+    expect(notifications[0]?.content).toContain("ETA unavailable (needs another progress sample)");
   });
 
-  it("rejects invalid check and report outputs", async () => {
-    const invalidCheck = new WorkflowEngine({
-      executor: scriptedExecutor([{ route: "unknown", observation: "state", reason: "bad route" }]),
-      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-bad-check")),
-    });
-    const missingReport = new WorkflowEngine({
-      executor: scriptedExecutor([
-        { route: "stop_report", observation: "state", reason: "missing report" },
-      ]),
-      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-no-report")),
-    });
-    const noSink = new WorkflowEngine({
-      executor: scriptedExecutor([
-        {
-          route: "stop_report",
-          observation: "state",
-          report: "State changed.",
-          reason: "report",
-        },
-      ]),
-      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-no-sink")),
-    });
-
-    const [badCheck, noReport, missingSink] = await Promise.all([
-      invalidCheck.run(monitor, monitorInput()),
-      missingReport.run(monitor, monitorInput()),
-      noSink.run(monitor, monitorInput()),
-    ]);
-
-    expect(badCheck.state.error).toContain("route must be one of");
-    expect(noReport.state.error).toContain("requires a report");
-    expect(missingSink.state.error).toContain("requires a notification sink");
-  });
-
-  it("formats monitor prompts, guards, and fallback output", async () => {
-    const engine = new WorkflowEngine({
-      executor: scriptedExecutor([
-        {
-          route: "stop_quiet",
-          observation: "Initial state",
-          reason: "Test complete",
-        },
-      ]),
-      store: new WorkflowRunStore(await makeTempDir("pi-workflows-monitor-callbacks")),
-    });
-    const result = await engine.run(monitor, monitorInput());
-    const context: WorkflowNodeContext = {
-      input: result.state.input,
-      outputs: result.state.outputs,
-      results: result.state.results,
-      state: result.state,
-      signal: new AbortController().signal,
-    };
-
-    if (typeof monitor.title !== "function" || typeof monitor.presentationPrompt !== "function") {
-      throw new Error("Monitor title and presentation prompt must be functions");
-    }
-    expect(await monitor.title({ input: monitorInput(), workflowName: "monitor" })).toContain(
-      "monitor: Check pull request 123",
-    );
-    expect(await monitor.title({ input: null, workflowName: "monitor" })).toBe("monitor");
-    expect(
-      await monitor.presentationPrompt({
-        state: result.state,
-        finalOutput: { reported: true },
-        signal: context.signal,
-      }),
-    ).toBeUndefined();
-    expect(
-      await monitor.presentationPrompt({
-        state: result.state,
-        finalOutput: {},
-        signal: context.signal,
-      }),
-    ).toContain("monitor ended");
-
-    const check = monitor.nodes.check as AgentNodeDefinition;
-    expect(await check.prompt(context)).toContain("Previous accepted observation: Initial state");
-    const report = monitor.nodes.report_stop as NotifyNodeDefinition;
-    expect(
-      await report.message({
-        ...context,
-        outputs: { check: { observation: "Fallback observation" } },
-      }),
-    ).toContain("Fallback observation");
-
-    const guard = monitor.nodes.guard as ComputeNodeDefinition;
-    expect(
-      await guard.run({
-        ...context,
-        outputs: {
-          ...context.outputs,
-          prepare: { ...monitorInput(), maxChecks: 1 },
-        },
-      }),
-    ).toMatchObject({ route: "stop", checks: 1, reason: "Reached the 1-check limit." });
-    const continueGuard = monitor.nodes.continue_guard as ComputeNodeDefinition;
-    expect(await continueGuard.run(context)).toMatchObject({ route: "sleep", checks: 1 });
-    const finish = monitor.nodes.finish as ComputeNodeDefinition;
-    expect(await finish.run({ ...context, outputs: {} })).toEqual({
-      reason: "Monitor finished.",
-      observation: null,
-      reported: false,
-    });
-  });
-
-  it("derives agent timeouts from the prepared monitor configuration", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-timeout");
-    const engine = new WorkflowEngine({
-      executor: scriptedExecutor([
-        {
-          route: "stop_quiet",
-          observation: "Initial state",
-          reason: "Test complete",
-        },
-      ]),
-      store: new WorkflowRunStore(outputRoot),
-    });
-    const result = await engine.run(monitor, monitorInput({ checkTimeoutMinutes: 90 }));
-    const context: WorkflowNodeContext = {
-      input: result.state.input,
-      outputs: result.state.outputs,
-      results: result.state.results,
-      state: result.state,
-      signal: new AbortController().signal,
-    };
-
-    const node = monitor.nodes.check as AgentNodeDefinition;
-    expect(node.timeoutMs).toBeTypeOf("function");
-    expect(await (node.timeoutMs as (context: WorkflowNodeContext) => number)(context)).toBe(
-      90 * 60_000,
-    );
-    expect(result.state.outputs.prepare).toMatchObject({ checkTimeoutMinutes: 90 });
-  });
-
-  it("defaults the agent timeout to at least 60 minutes", async () => {
-    const prepare = monitor.nodes.prepare as ComputeNodeDefinition;
+  it("includes the prior observation and progress summary in the next prompt", async () => {
+    const prompts: string[] = [];
+    const executor = scriptedExecutor([], prompts);
+    const checkNode = monitor.nodes.check;
+    if (checkNode?.nodeType !== "agent") throw new Error("check must be an agent node");
     const state = {
-      steps: [],
+      steps: [{ nodeId: "check", outcome: "ok" }],
     } as never;
-    const context = {
-      input: monitorInput({ everyMinutes: 30 }),
-      outputs: {},
+    const prompt = await checkNode.prompt({
+      input: input(),
+      outputs: {
+        prepare: prepareMonitorInput(input()),
+        check: check({ observation: "The target is at 4 of 10." }),
+        estimate: { tracks: [] },
+      },
       results: {},
       state,
       signal: new AbortController().signal,
-    } satisfies WorkflowNodeContext;
-
-    expect(await prepare.run(context)).toMatchObject({ checkTimeoutMinutes: 60 });
-    expect(() =>
-      prepare.run({ ...context, input: monitorInput({ checkTimeoutMinutes: 4 }) }),
-    ).toThrow(/checkTimeoutMinutes/);
+    });
+    expect(prompt).toContain("Perform monitoring check 2 of at most 5");
+    expect(prompt).toContain("Previous accepted observation: The target is at 4 of 10.");
+    expect(executor).toBeDefined();
   });
 
-  it("configures a 30-minute shell sleep above both timeout limits", async () => {
-    const outputRoot = await makeTempDir("pi-workflows-monitor-sleep");
-    const engine = new WorkflowEngine({
-      executor: scriptedExecutor([
-        {
-          route: "stop_quiet",
-          observation: "Initial state",
-          reason: "Test complete",
-        },
-      ]),
-      store: new WorkflowRunStore(outputRoot),
-    });
-    const result = await engine.run(monitor, monitorInput());
-    const sleep = monitor.nodes.sleep as ShellActionNodeDefinition;
-    const context: WorkflowNodeContext = {
-      input: result.state.input,
-      outputs: result.state.outputs,
-      results: result.state.results,
-      state: result.state,
-      signal: new AbortController().signal,
-    };
+  it("rejects quiet routes, missing reports, duplicate tracks, and unknown fields", () => {
+    expect(() => validateMonitorCheck(check({ route: "stop_quiet" }))).toThrow("route");
+    const { report: _report, ...withoutReport } = check();
+    expect(() => validateMonitorCheck(withoutReport)).toThrow("report");
+    expect(() => validateMonitorCheck(check({ extra: true }))).toThrow("not supported");
+    expect(() =>
+      validateMonitorCheck(
+        check({
+          progress: {
+            tracks: [
+              { key: "same", data: progress(1, 2) },
+              { key: "same", data: progress(1, 2) },
+            ],
+          },
+        }),
+      ),
+    ).toThrow("duplicated");
+  });
 
-    const execution = await sleep.exec(context);
-
-    expect(execution).toMatchObject({
-      command: process.execPath,
-      args: ["-e", "setTimeout(() => {}, Number(process.argv[1]))", "1800000"],
-    });
-    expect(execution.timeoutMs).toBeGreaterThan(30 * 60_000);
-    expect(sleep.timeoutMs).toBeGreaterThan(30 * 60_000);
+  it("has no presentation prompt, report acknowledgement, or quiet routing", () => {
+    expect(monitor.presentationPrompt).toBeUndefined();
+    expect(monitor.nodes.report?.nodeType).toBe("notify");
+    expect(monitor.nodes.report_continue).toBeUndefined();
+    expect(monitor.nodes.report_stop).toBeUndefined();
+    expect(JSON.stringify(monitor.edges)).not.toContain("quiet");
   });
 });
+
+function progress(completed: number, total: number) {
+  return {
+    schema: "pi-workflows.progress.v1",
+    status: "running",
+    completed,
+    total,
+    unit: "items",
+  };
+}

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -155,6 +155,27 @@ describe("built-in monitor workflow", () => {
     expect(notifications[0]?.content).toContain("ETA unavailable (needs another progress sample)");
   });
 
+  it("paces large progress batches below the engine update limit", async () => {
+    const tracks = Array.from({ length: 101 }, (_, index) => ({
+      key: `track-${index}`,
+      data: progress(1, 2),
+    }));
+    const engine = new WorkflowEngine({
+      executor: scriptedExecutor([check({ progress: { tracks } })]),
+      store: new WorkflowRunStore(await makeTempDir("monitor-progress-batch")),
+      notificationSink: {
+        notify() {
+          return { notificationId: "n1", targetSessionId: "s1" };
+        },
+      },
+    });
+
+    const result = await engine.run(monitor, input());
+
+    expect(result.state.status).toBe("completed");
+    expect(result.state.updates).toHaveLength(101);
+  }, 10_000);
+
   it("includes the prior observation and progress summary in the next prompt", async () => {
     const prompts: string[] = [];
     const executor = scriptedExecutor([], prompts);

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -49,6 +49,9 @@ describe("built-in monitor workflow", () => {
       maxChecks: 1_000,
       checkTimeoutMinutes: 60,
     });
+    expect(() => prepareMonitorInput({ task: "Observe", reportWhen: "state changes" })).toThrow(
+      "reportWhen is not supported",
+    );
   });
 
   it("reports every accepted stop check before completion", async () => {

--- a/test/monitor-workflow.test.ts
+++ b/test/monitor-workflow.test.ts
@@ -104,6 +104,7 @@ describe("built-in monitor workflow", () => {
 
     expect(result.state.status).toBe("completed");
     expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.content).toContain("Reached the 1-check safety limit.");
     expect(result.state.finalOutput).toMatchObject({
       reason: "Reached the 1-check safety limit.",
       reported: true,

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -311,7 +311,7 @@ function progressEvent(seq: number, at: string, completed: number) {
   return {
     seq,
     at,
-    scope: "update" as const,
+    scope: "node" as const,
     type: "update_published",
     runId: "run-1",
     nodeId: "work",

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -127,6 +127,20 @@ describe("renderRunListLines edges", () => {
 describe("renderRunDetailLines", () => {
   const size = { width: 100, height: 50 };
 
+  it("renders progress history, measured ETA, sample count, and confidence", () => {
+    const bundle = makeBundle();
+    bundle.traceEvents = [
+      progressEvent(2, "2026-07-19T00:00:00.000Z", 0),
+      progressEvent(3, "2026-07-19T00:00:30.000Z", 25),
+      progressEvent(4, "2026-07-19T00:01:00.000Z", 50),
+    ];
+
+    const lines = renderRunDetailLines(bundle, size, NOW).map(stripAnsi).join("\n");
+    expect(lines).toContain("progress");
+    expect(lines).toContain("Import  50/100 rows  ETA 1m");
+    expect(lines).toContain("3 samples · medium confidence");
+  });
+
   it("renders header, nodes, steps, and final output", () => {
     const bundle = makeBundle({
       status: "completed",
@@ -292,6 +306,31 @@ describe("renderRunDetailLines", () => {
     );
   });
 });
+
+function progressEvent(seq: number, at: string, completed: number) {
+  return {
+    seq,
+    at,
+    scope: "update" as const,
+    type: "update_published",
+    runId: "run-1",
+    nodeId: "work",
+    attemptId: "attempt-1",
+    payload: {
+      updateId: `u${seq}`,
+      type: "progress",
+      key: "overall",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        label: "Import",
+        status: "running",
+        completed,
+        total: 100,
+        unit: "rows",
+      },
+    },
+  };
+}
 
 describe("ansi helpers", () => {
   it("strips ANSI and measures visible length", () => {

--- a/test/rpc-executor-flow.test.ts
+++ b/test/rpc-executor-flow.test.ts
@@ -23,7 +23,7 @@ async function makeFakePi(
   const stdinLog = path.join(dir, "stdin.log");
   await fs.writeFile(
     fakePi,
-    `#!/bin/sh\ncat > ${JSON.stringify(stdinLog)} &\nCATPID=$!\n${script}\nwait $CATPID\n`,
+    `#!/bin/sh\nSTDIN_LOG=${JSON.stringify(stdinLog)}\nexec 3<&0\ncat <&3 > "$STDIN_LOG" &\nCATPID=$!\n${script}\nwait $CATPID\n`,
     { encoding: "utf8", mode: 0o755 },
   );
   return { dir, fakePi, stdinLog };
@@ -31,6 +31,16 @@ async function makeFakePi(
 
 function submissionLine(step: string, attempt: string, output: unknown): string {
   return `PI_WORKFLOWS_STEP_SUBMISSION ${JSON.stringify({ action: "submit", step, attempt, output })}\\n`;
+}
+
+function updateLine(step: string, attempt: string): string {
+  return `PI_WORKFLOWS_STEP_SUBMISSION ${JSON.stringify({
+    action: "update",
+    step,
+    attempt,
+    idempotencyKey: "tool-1",
+    update: { type: "progress", key: "job", data: {} },
+  })}\\n`;
 }
 
 describe("RpcStepExecutor submissions", () => {
@@ -48,6 +58,30 @@ describe("RpcStepExecutor submissions", () => {
       new AbortController().signal,
     );
     expect(submission.output).toBeNull();
+    await executor.close();
+  });
+
+  it("reports a rejected update to the headless agent and keeps the step open", async () => {
+    const { fakePi, stdinLog } = await makeFakePi(
+      `sleep 0.2\nprintf '${updateLine("work", "a1")}' >&2\nfor _ in 1 2 3 4 5 6 7 8 9 10; do\n  grep -q 'Workflow update rejected' "$STDIN_LOG" && break\n  sleep 0.1\ndone\ngrep -q 'Workflow update rejected' "$STDIN_LOG" || exit 4\nprintf '${submissionLine("work", "a1", { done: true })}' >&2\nsleep 2\n`,
+    );
+    const executor = new RpcStepExecutor({
+      cwd: "/tmp",
+      registry: new HostProcessRegistry("/tmp"),
+      piBin: fakePi,
+    });
+    const request = requestFor("work", "a1") as AgentStepRequest;
+    request.publishUpdate = async () => {
+      throw new Error("progress.schema must equal pi-workflows.progress.v1");
+    };
+
+    await expect(
+      executor.runAgentStep(request, new AbortController().signal),
+    ).resolves.toMatchObject({ output: null });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(await fs.readFile(stdinLog, "utf8")).toContain(
+      "Workflow update rejected: progress.schema must equal pi-workflows.progress.v1",
+    );
     await executor.close();
   });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -476,6 +476,9 @@ describe("listRunBundles", () => {
     const bundles = await listRunBundles(outputRoot);
 
     expect(bundles.map((bundle) => bundle.state.runId)).toEqual([newer.runId, older.runId]);
+    expect(bundles.every((bundle) => bundle.traceEvents === undefined)).toBe(true);
+    const detail = await readRunBundle(bundles[0]!.runDir);
+    expect(detail?.traceEvents).toEqual([]);
   });
 
   it("returns empty for a missing directory", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -92,6 +92,29 @@ describe("WorkflowRunStore", () => {
     expect(events.map((event) => event.type)).toEqual(["run_completed"]);
   });
 
+  it("rejects an update when its attempt was aborted before admission", async () => {
+    const outputRoot = await makeTempDir("pi-workflows-store");
+    const store = new WorkflowRunStore(outputRoot);
+    const state = makeState();
+    const runDir = await store.initializeRunBundle(workflow, state);
+    const abort = new AbortController();
+    abort.abort(new Error("attempt ended"));
+
+    await expect(
+      store.publishUpdate(
+        runDir,
+        state,
+        "one",
+        "attempt-1",
+        { type: "test", key: "job", data: {} },
+        { signal: abort.signal },
+      ),
+    ).rejects.toThrow("attempt ended");
+    expect(state.updates).toBeUndefined();
+    const detail = await readRunBundle(runDir, { includeTrace: true });
+    expect(detail?.traceEvents).toEqual([]);
+  });
+
   it("assigns monotonic trace sequence numbers", async () => {
     const outputRoot = await makeTempDir("pi-workflows-store");
     const store = new WorkflowRunStore(outputRoot);
@@ -477,7 +500,9 @@ describe("listRunBundles", () => {
 
     expect(bundles.map((bundle) => bundle.state.runId)).toEqual([newer.runId, older.runId]);
     expect(bundles.every((bundle) => bundle.traceEvents === undefined)).toBe(true);
-    const detail = await readRunBundle(bundles[0]!.runDir);
+    const projected = await readRunBundle(bundles[0]!.runDir);
+    expect(projected?.traceEvents).toBeUndefined();
+    const detail = await readRunBundle(bundles[0]!.runDir, { includeTrace: true });
     expect(detail?.traceEvents).toEqual([]);
   });
 

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -314,6 +314,22 @@ describe("progress estimation", () => {
       now,
     );
     expect(stalled.unavailableReason).toBe("no positive progress rate");
+    const terminal = estimateProgress(
+      "job",
+      [
+        {
+          at: "2026-08-16T10:10:00.000Z",
+          data: {
+            ...progress(10, 10),
+            status: "completed" as const,
+            sourceEstimatedFinishAt: "2026-08-16T10:30:00.000Z",
+          },
+        },
+      ],
+      now,
+    );
+    expect(terminal.sourceEstimatedFinishAt).toBeUndefined();
+    expect(formatProgressLine(terminal, now)).not.toContain("ETA");
     const expired = estimateProgress(
       "job",
       [

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -52,6 +52,38 @@ describe("workflow updates", () => {
     expect(updates.map((event) => event.seq)).toEqual([3, 4]);
   });
 
+  it("snapshots mutable update data before retaining it", async () => {
+    const { engine: runtime } = await engine();
+    const workflow = defineWorkflow({
+      name: "mutable-update-data",
+      startAt: "work",
+      nodes: {
+        work: action({
+          run: async ({ publishUpdate }) => {
+            const data = progress(1, 3);
+            await publishUpdate({ type: "progress", key: "overall", data });
+            data.completed = 2;
+            await publishUpdate({ type: "progress", key: "overall", data });
+            data.completed = 3;
+            return "done";
+          },
+        }),
+      },
+      edges: [],
+    });
+
+    const result = await runtime.run(workflow, {});
+    expect(result.state.updates?.[0]?.data.completed).toBe(2);
+    const trace = (await fs.readFile(path.join(result.runDir, "trace.ndjson"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as WorkflowTraceEvent)
+      .filter((event) => event.type === "update_published");
+    expect(trace.map((event) => (event.payload.data as { completed: number }).completed)).toEqual([
+      1, 2,
+    ]);
+  });
+
   it("serializes concurrent admission at the current-key limit", async () => {
     const { engine: runtime } = await engine();
     const workflow = defineWorkflow({

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { action, agent, defineWorkflow, shell } from "../src/workflows/definition.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { estimateProgress, formatProgressLine } from "../src/workflows/progress.js";
+import type { WorkflowTraceEvent } from "../src/workflows/types.js";
+import { validateWorkflowUpdate } from "../src/workflows/updates.js";
+import { makeTempDir, ScriptedExecutor } from "./helpers.js";
+
+async function engine(executor = new ScriptedExecutor()) {
+  return {
+    executor,
+    engine: new WorkflowEngine({ executor, outputRoot: await makeTempDir("workflow-updates") }),
+  };
+}
+
+describe("workflow updates", () => {
+  it("persists function-action updates in trace order and projects the latest value", async () => {
+    const { engine: runtime } = await engine();
+    const workflow = defineWorkflow({
+      name: "function-updates",
+      startAt: "work",
+      nodes: {
+        work: action({
+          run: async ({ publishUpdate }) => {
+            await publishUpdate({ type: "progress", key: "overall", data: progress(1, 3) });
+            await publishUpdate({ type: "progress", key: "overall", data: progress(2, 3) });
+            return "done";
+          },
+        }),
+      },
+      edges: [],
+    });
+
+    const result = await runtime.run(workflow, {});
+    expect(result.state.updates).toHaveLength(1);
+    expect(result.state.updates?.[0]?.data.completed).toBe(2);
+    const trace = (await fs.readFile(path.join(result.runDir, "trace.ndjson"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as WorkflowTraceEvent);
+    const updates = trace.filter((event) => event.type === "update_published");
+    expect(updates).toHaveLength(2);
+    expect(updates.map((event) => event.seq)).toEqual([3, 4]);
+  });
+
+  it("accepts agent updates without completing the step and deduplicates delivery", async () => {
+    const executor = new ScriptedExecutor().respond("check", async (request) => {
+      const first = await request.publishUpdate?.(
+        { type: "progress", key: "job", data: progress(4, 10) },
+        "tool-call-1",
+      );
+      const duplicate = await request.publishUpdate?.(
+        { type: "progress", key: "job", data: progress(9, 10) },
+        "tool-call-1",
+      );
+      expect(duplicate).toEqual(first);
+      const accepted = await request.accept({ ok: true });
+      if (!accepted.ok) throw new Error(accepted.error);
+      return { output: accepted.value };
+    });
+    const { engine: runtime } = await engine(executor);
+    const workflow = defineWorkflow({
+      name: "agent-updates",
+      startAt: "check",
+      nodes: { check: agent({ prompt: () => "check" }) },
+      edges: [],
+    });
+
+    const result = await runtime.run(workflow, {});
+    expect(result.state.status).toBe("completed");
+    expect(result.state.updates).toHaveLength(1);
+    expect(result.state.updates?.[0]?.data.completed).toBe(4);
+  });
+
+  it("parses shell update lines while retaining normal output", async () => {
+    const { engine: runtime } = await engine();
+    const workflow = defineWorkflow({
+      name: "shell-updates",
+      startAt: "work",
+      nodes: {
+        work: shell({
+          exec: () => ({
+            command: process.execPath,
+            args: ["-e", "console.log(JSON.stringify({n:1})); console.log(JSON.stringify({n:2}))"],
+          }),
+          updates: {
+            parseLine: ({ text }) => {
+              const value = JSON.parse(text) as { n: number };
+              return { type: "progress", key: "shell", data: progress(value.n, 2) };
+            },
+          },
+        }),
+      },
+      edges: [],
+    });
+
+    const result = await runtime.run(workflow, {});
+    expect(result.state.status).toBe("completed");
+    expect(result.state.updates?.[0]?.data.completed).toBe(2);
+    expect((result.state.finalOutput as { stdout: string }).stdout).toContain('{"n":2}');
+  });
+
+  it("validates update envelopes and progress fields", () => {
+    expect(() => validateWorkflowUpdate({ type: "Bad", key: "x", data: {} })).toThrow(
+      "update.type",
+    );
+    expect(() =>
+      validateWorkflowUpdate({
+        type: "progress",
+        key: "x",
+        data: { ...progress(2, 1) },
+      }),
+    ).toThrow("at least progress.completed");
+  });
+});
+
+describe("progress estimation", () => {
+  it("uses recent measured intervals and shows an ETA", () => {
+    const estimate = estimateProgress(
+      "overall",
+      [
+        { at: "2026-08-16T10:00:00.000Z", data: progress(0, 100) },
+        { at: "2026-08-16T10:01:00.000Z", data: progress(20, 100) },
+        { at: "2026-08-16T10:02:00.000Z", data: progress(40, 100) },
+      ],
+      new Date("2026-08-16T10:02:00.000Z"),
+    );
+    expect(estimate.sampleCount).toBe(3);
+    expect(estimate.remainingMedianMs).toBe(180_000);
+    expect(formatProgressLine(estimate, new Date("2026-08-16T10:02:00.000Z"))).toContain("ETA 3m");
+  });
+
+  it("uses a fresh target-supplied finish time", () => {
+    const data = {
+      ...progress(1, 10),
+      sourceUpdatedAt: "2026-08-16T10:00:00.000Z",
+      sourceEstimatedFinishAt: "2026-08-16T10:30:00.000Z",
+    };
+    const estimate = estimateProgress(
+      "job",
+      [{ at: "2026-08-16T10:00:01.000Z", data }],
+      new Date("2026-08-16T10:10:00.000Z"),
+    );
+    expect(formatProgressLine(estimate, new Date("2026-08-16T10:10:00.000Z"))).toContain(
+      "source ETA 20m",
+    );
+  });
+});
+
+function progress(completed: number, total: number) {
+  return {
+    schema: "pi-workflows.progress.v1" as const,
+    status: "running" as const,
+    completed,
+    total,
+    unit: "items",
+  };
+}

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -51,6 +51,42 @@ describe("workflow updates", () => {
     expect(updates.map((event) => event.seq)).toEqual([3, 4]);
   });
 
+  it("serializes concurrent admission at the current-key limit", async () => {
+    const { engine: runtime } = await engine();
+    const workflow = defineWorkflow({
+      name: "concurrent-update-limit",
+      startAt: "work",
+      nodes: {
+        work: action({
+          run: async (context) => {
+            context.state.updates = Array.from({ length: 1_023 }, (_, index) => ({
+              updateId: `seed-${index}`,
+              seq: index + 1,
+              at: "2026-08-16T10:00:00.000Z",
+              runId: context.state.runId,
+              nodeId: "work",
+              attemptId: "seed",
+              type: "seed",
+              key: `key-${index}`,
+              data: {},
+            }));
+            const results = await Promise.allSettled([
+              context.publishUpdate({ type: "test", key: "new-a", data: {} }),
+              context.publishUpdate({ type: "test", key: "new-b", data: {} }),
+            ]);
+            return results.map((result) => result.status);
+          },
+        }),
+      },
+      edges: [],
+    });
+
+    const result = await runtime.run(workflow, {});
+    expect(result.state.status).toBe("completed");
+    expect(result.state.finalOutput).toEqual(expect.arrayContaining(["fulfilled", "rejected"]));
+    expect(result.state.updates).toHaveLength(1_024);
+  });
+
   it("accepts agent updates without completing the step and deduplicates delivery", async () => {
     const executor = new ScriptedExecutor().respond("check", async (request) => {
       const first = await request.publishUpdate?.(
@@ -111,6 +147,7 @@ describe("workflow updates", () => {
   it("validates update envelopes and progress fields", () => {
     const invalid = [
       [{ type: "Bad", key: "x", data: {} }, "update.type"],
+      [{ type: "ok", key: "x", data: {}, seq: 1 }, "update.seq is not supported"],
       [{ type: "ok", key: " bad", data: {} }, "update.key"],
       [{ type: "ok", key: "x", data: [] }, "update.data"],
       [{ type: "ok", key: "x", data: { value: Number.NaN } }, "non-finite"],
@@ -230,7 +267,7 @@ describe("progress estimation", () => {
       {
         seq: 1,
         at: "2026-08-16T10:00:00.000Z",
-        scope: "update" as const,
+        scope: "node" as const,
         type: "update_published",
         runId: "r1",
         nodeId: "work",
@@ -240,7 +277,7 @@ describe("progress estimation", () => {
       {
         seq: 2,
         at: "2026-08-16T10:01:00.000Z",
-        scope: "update" as const,
+        scope: "node" as const,
         type: "update_published",
         runId: "r1",
         nodeId: "work",

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { action, agent, defineWorkflow, shell } from "../src/workflows/definition.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import {
+  appendProgressHistory,
   estimateProgress,
   formatProgressLine,
   formatProgressReport,
@@ -87,16 +88,18 @@ describe("workflow updates", () => {
     expect(result.state.updates).toHaveLength(1_024);
   });
 
-  it("accepts agent updates without completing the step and deduplicates delivery", async () => {
+  it("accepts agent updates without completing the step and deduplicates concurrent delivery", async () => {
     const executor = new ScriptedExecutor().respond("check", async (request) => {
-      const first = await request.publishUpdate?.(
-        { type: "progress", key: "job", data: progress(4, 10) },
-        "tool-call-1",
-      );
-      const duplicate = await request.publishUpdate?.(
-        { type: "progress", key: "job", data: progress(9, 10) },
-        "tool-call-1",
-      );
+      const [first, duplicate] = await Promise.all([
+        request.publishUpdate?.(
+          { type: "progress", key: "job", data: progress(4, 10) },
+          "tool-call-1",
+        ),
+        request.publishUpdate?.(
+          { type: "progress", key: "job", data: progress(9, 10) },
+          "tool-call-1",
+        ),
+      ]);
       expect(duplicate).toEqual(first);
       const accepted = await request.accept({ ok: true });
       if (!accepted.ok) throw new Error(accepted.error);
@@ -152,6 +155,9 @@ describe("workflow updates", () => {
       [{ type: "ok", key: "x", data: [] }, "update.data"],
       [{ type: "ok", key: "x", data: { value: Number.NaN } }, "non-finite"],
       [{ type: "ok", key: "x", data: { value: undefined } }, "undefined"],
+      [{ type: "ok", key: "x", data: { value: new Map() } }, "non-JSON"],
+      [{ type: "ok", key: "x", data: { value: new Date() } }, "non-JSON"],
+      [{ type: "ok", key: "x", data: { value: new (class Value {})() } }, "non-JSON"],
       [{ type: "progress", key: "x", data: { ...progress(2, 1) } }, "at least progress.completed"],
       [{ type: "progress", key: "x", data: { ...progress(1, 2), extra: true } }, "not supported"],
       [{ type: "progress", key: "x", data: { ...progress(1, 2), status: "busy" } }, "status"],
@@ -194,6 +200,25 @@ describe("workflow updates", () => {
 });
 
 describe("progress estimation", () => {
+  it("bounds live history per track and across tracks", () => {
+    const records = Array.from({ length: 20 }, (_, index) => ({
+      updateId: `u${index}`,
+      seq: index + 1,
+      at: `2026-08-16T10:${String(index).padStart(2, "0")}:00.000Z`,
+      runId: "r1",
+      nodeId: "work",
+      attemptId: "a1",
+      type: "progress",
+      key: index % 2 === 0 ? "a" : "b",
+      data: progress(index, 20),
+    }));
+    const bounded = appendProgressHistory([], records, 3, 5);
+    expect(bounded).toHaveLength(5);
+    expect(bounded.filter((record) => record.key === "a")).toHaveLength(2);
+    expect(bounded.filter((record) => record.key === "b")).toHaveLength(3);
+    expect(bounded.map((record) => record.updateId)).toEqual(["u15", "u16", "u17", "u18", "u19"]);
+  });
+
   it("uses recent measured intervals and shows an ETA", () => {
     const estimate = estimateProgress(
       "overall",

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -8,6 +8,7 @@ import {
   estimateProgress,
   formatProgressLine,
   formatProgressReport,
+  formatRemaining,
   progressRecordsFromTrace,
   progressTracksFromRecords,
 } from "../src/workflows/progress.js";
@@ -341,6 +342,25 @@ describe("progress estimation", () => {
       now,
     );
     expect(expired.sourceEstimatedFinishAt).toBeUndefined();
+    const sameTime = estimateProgress(
+      "job",
+      [
+        { at: "2026-08-16T10:10:00.000Z", data: progress(1, 10) },
+        { at: "2026-08-16T10:10:00.000Z", data: progress(2, 10) },
+      ],
+      now,
+    );
+    expect(sameTime.unavailableReason).toBe("needs another progress sample");
+  });
+
+  it("formats sub-minute, minute, hour, and day durations", () => {
+    expect([30_000, 120_000, 7_200_000, 72_000_000, 172_800_000].map(formatRemaining)).toEqual([
+      "30s",
+      "2m",
+      "2.0h",
+      "20h",
+      "2.0d",
+    ]);
   });
 
   it("starts a new estimation epoch when progress identity changes", () => {
@@ -383,6 +403,26 @@ describe("progress estimation", () => {
         type: "node_finished",
         runId: "r1",
         payload: {},
+      },
+      {
+        seq: 4,
+        at: "2026-08-16T10:01:00.000Z",
+        scope: "node" as const,
+        type: "update_published",
+        runId: "r1",
+        nodeId: "work",
+        attemptId: "a1",
+        payload: { updateId: 4, type: "progress", key: "a", data: progress(3, 4) },
+      },
+      {
+        seq: 5,
+        at: "2026-08-16T10:01:00.000Z",
+        scope: "node" as const,
+        type: "update_published",
+        runId: "r1",
+        nodeId: "work",
+        attemptId: "a1",
+        payload: { updateId: "u5", type: "progress", key: "a", data: [] },
       },
     ];
     const records = progressRecordsFromTrace(events);

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -162,6 +162,14 @@ describe("workflow updates", () => {
       [{ type: "progress", key: "x", data: { ...progress(1, 2), extra: true } }, "not supported"],
       [{ type: "progress", key: "x", data: { ...progress(1, 2), status: "busy" } }, "status"],
       [
+        { type: "progress", key: "x", data: { ...progress(1, 2), label: "fake\nrow" } },
+        "control characters",
+      ],
+      [
+        { type: "progress", key: "x", data: { ...progress(1, 2), phase: "\u001b[2J" } },
+        "control characters",
+      ],
+      [
         {
           type: "progress",
           key: "x",
@@ -217,6 +225,17 @@ describe("progress estimation", () => {
     expect(bounded.filter((record) => record.key === "a")).toHaveLength(2);
     expect(bounded.filter((record) => record.key === "b")).toHaveLength(3);
     expect(bounded.map((record) => record.updateId)).toEqual(["u15", "u16", "u17", "u18", "u19"]);
+  });
+
+  it("sanitizes progress labels at the terminal formatting boundary", () => {
+    const line = formatProgressLine({
+      key: "job",
+      data: { ...progress(1, 2), label: "\u001b[2Jfake\nrow" },
+      sampleCount: 1,
+    });
+    expect(line).toContain("fake row");
+    expect(line).not.toContain("\u001b");
+    expect(line).not.toContain("\n");
   });
 
   it("uses recent measured intervals and shows an ETA", () => {

--- a/test/updates.test.ts
+++ b/test/updates.test.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { action, agent, defineWorkflow, shell } from "../src/workflows/definition.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
-import { estimateProgress, formatProgressLine } from "../src/workflows/progress.js";
+import {
+  estimateProgress,
+  formatProgressLine,
+  formatProgressReport,
+  progressRecordsFromTrace,
+  progressTracksFromRecords,
+} from "../src/workflows/progress.js";
 import type { WorkflowTraceEvent } from "../src/workflows/types.js";
 import { validateWorkflowUpdate } from "../src/workflows/updates.js";
 import { makeTempDir, ScriptedExecutor } from "./helpers.js";
@@ -103,16 +109,50 @@ describe("workflow updates", () => {
   });
 
   it("validates update envelopes and progress fields", () => {
-    expect(() => validateWorkflowUpdate({ type: "Bad", key: "x", data: {} })).toThrow(
-      "update.type",
-    );
+    const invalid = [
+      [{ type: "Bad", key: "x", data: {} }, "update.type"],
+      [{ type: "ok", key: " bad", data: {} }, "update.key"],
+      [{ type: "ok", key: "x", data: [] }, "update.data"],
+      [{ type: "ok", key: "x", data: { value: Number.NaN } }, "non-finite"],
+      [{ type: "ok", key: "x", data: { value: undefined } }, "undefined"],
+      [{ type: "progress", key: "x", data: { ...progress(2, 1) } }, "at least progress.completed"],
+      [{ type: "progress", key: "x", data: { ...progress(1, 2), extra: true } }, "not supported"],
+      [{ type: "progress", key: "x", data: { ...progress(1, 2), status: "busy" } }, "status"],
+      [
+        {
+          type: "progress",
+          key: "x",
+          data: { schema: "pi-workflows.progress.v1", status: "running", completed: -1, unit: "x" },
+        },
+        "non-negative",
+      ],
+      [
+        {
+          type: "progress",
+          key: "x",
+          data: { schema: "pi-workflows.progress.v1", status: "running", total: 0, unit: "x" },
+        },
+        "greater than zero",
+      ],
+      [
+        {
+          type: "progress",
+          key: "x",
+          data: { schema: "pi-workflows.progress.v1", status: "running", completed: 1 },
+        },
+        "unit is required",
+      ],
+      [
+        { type: "progress", key: "x", data: { ...progress(1, 2), sourceUpdatedAt: "yesterday" } },
+        "RFC 3339",
+      ],
+    ] as const;
+    for (const [value, message] of invalid) {
+      expect(() => validateWorkflowUpdate(value)).toThrow(message);
+    }
     expect(() =>
-      validateWorkflowUpdate({
-        type: "progress",
-        key: "x",
-        data: { ...progress(2, 1) },
-      }),
-    ).toThrow("at least progress.completed");
+      validateWorkflowUpdate({ type: "ok", key: "x", data: { value: "x".repeat(70_000) } }),
+    ).toThrow("65536 bytes");
   });
 });
 
@@ -130,6 +170,103 @@ describe("progress estimation", () => {
     expect(estimate.sampleCount).toBe(3);
     expect(estimate.remainingMedianMs).toBe(180_000);
     expect(formatProgressLine(estimate, new Date("2026-08-16T10:02:00.000Z"))).toContain("ETA 3m");
+  });
+
+  it("handles waiting, terminal, unknown-total, stalled, and expired-source states", () => {
+    const now = new Date("2026-08-16T10:10:00.000Z");
+    const cases = [
+      {
+        data: { ...progress(1, 10), status: "waiting" as const },
+        text: "ETA unavailable (progress is waiting)",
+      },
+      {
+        data: { ...progress(10, 10), status: "completed" as const },
+        text: "10/10 items",
+      },
+      {
+        data: { schema: "pi-workflows.progress.v1" as const, status: "running" as const },
+        text: "ETA unavailable (total is unknown)",
+      },
+    ];
+    for (const item of cases) {
+      const estimate = estimateProgress("job", [{ at: now.toISOString(), data: item.data }], now);
+      expect(formatProgressLine(estimate, now)).toContain(item.text);
+    }
+    const stalled = estimateProgress(
+      "job",
+      [
+        { at: "2026-08-16T10:00:00.000Z", data: progress(1, 10) },
+        { at: "2026-08-16T10:01:00.000Z", data: progress(1, 10) },
+      ],
+      now,
+    );
+    expect(stalled.unavailableReason).toBe("no positive progress rate");
+    const expired = estimateProgress(
+      "job",
+      [
+        {
+          at: "2026-08-16T10:00:00.000Z",
+          data: { ...progress(1, 10), sourceEstimatedFinishAt: "2026-08-16T10:05:00.000Z" },
+        },
+      ],
+      now,
+    );
+    expect(expired.sourceEstimatedFinishAt).toBeUndefined();
+  });
+
+  it("starts a new estimation epoch when progress identity changes", () => {
+    const resetSamples = [
+      { at: "2026-08-16T10:00:00.000Z", data: { ...progress(10, 100), phase: "one" } },
+      { at: "2026-08-16T10:01:00.000Z", data: { ...progress(20, 100), phase: "one" } },
+      { at: "2026-08-16T10:02:00.000Z", data: { ...progress(5, 50), phase: "two" } },
+    ];
+    const estimate = estimateProgress("job", resetSamples, new Date("2026-08-16T10:02:00.000Z"));
+    expect(estimate.sampleCount).toBe(1);
+    expect(estimate.unavailableReason).toBe("needs another progress sample");
+  });
+
+  it("reduces trace history and formats reports without combining tracks", () => {
+    const events = [
+      {
+        seq: 1,
+        at: "2026-08-16T10:00:00.000Z",
+        scope: "update" as const,
+        type: "update_published",
+        runId: "r1",
+        nodeId: "work",
+        attemptId: "a1",
+        payload: { updateId: "u1", type: "progress", key: "a", data: progress(1, 4) },
+      },
+      {
+        seq: 2,
+        at: "2026-08-16T10:01:00.000Z",
+        scope: "update" as const,
+        type: "update_published",
+        runId: "r1",
+        nodeId: "work",
+        attemptId: "a1",
+        payload: { updateId: "u2", type: "progress", key: "a", data: progress(2, 4) },
+      },
+      {
+        seq: 3,
+        at: "2026-08-16T10:01:00.000Z",
+        scope: "node" as const,
+        type: "node_finished",
+        runId: "r1",
+        payload: {},
+      },
+    ];
+    const records = progressRecordsFromTrace(events);
+    expect(records).toHaveLength(2);
+    const tracks = progressTracksFromRecords(records, new Date("2026-08-16T10:01:00.000Z"));
+    expect(tracks).toHaveLength(1);
+    expect(
+      formatProgressReport(
+        tracks.map((track) => track.estimate),
+        30,
+      ),
+    ).toContain("Next check: 30 min");
+    expect(progressTracksFromRecords([{ ...records[0]!, data: { invalid: true } }])).toEqual([]);
   });
 
   it("uses a fresh target-supplied finish time", () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -168,6 +168,55 @@ describe("nodeTypeGlyph", () => {
 });
 
 describe("buildWidgetLines", () => {
+  it("shows optional progress, ETA, elapsed update age, and next-check time", () => {
+    const now = new Date("2026-01-01T00:10:00.000Z");
+    const state = makeState({
+      currentNode: "second",
+      updates: [
+        {
+          updateId: "u1",
+          seq: 2,
+          at: "2026-01-01T00:09:00.000Z",
+          runId: "r1",
+          nodeId: "work",
+          attemptId: "a1",
+          type: "progress",
+          key: "overall",
+          data: {
+            schema: "pi-workflows.progress.v1",
+            label: "Import",
+            status: "running",
+            completed: 40,
+            total: 100,
+            unit: "rows",
+            sourceEstimatedFinishAt: "2026-01-01T00:30:00.000Z",
+          },
+        },
+        {
+          updateId: "u2",
+          seq: 3,
+          at: "2026-01-01T00:09:00.000Z",
+          runId: "r1",
+          nodeId: "schedule",
+          attemptId: "a2",
+          type: "monitor.schedule",
+          key: "next-check",
+          data: {
+            schema: "pi-workflows.monitor-schedule.v1",
+            lastCheckAt: "2026-01-01T00:09:00.000Z",
+            nextCheckAt: "2026-01-01T00:39:00.000Z",
+            everyMinutes: 30,
+          },
+        },
+      ],
+    });
+
+    const lines = buildWidgetLines(state, snapshot, now).join("\n");
+    expect(lines).toContain("Import  40/100 rows  source ETA 20m");
+    expect(lines).toContain("Last update 1m ago  next check 29m");
+    expect(lines.split("\n").length).toBeLessThanOrEqual(10);
+  });
+
   it("uses the compact one-line node list at wide widths", () => {
     const state = makeState({
       currentNode: "second",

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -244,6 +244,61 @@ describe("buildWidgetLines", () => {
     expect(lines).toContain("Worker  2/10 items");
   });
 
+  it("merges monitor estimates with every durable projected track", () => {
+    const overallData = {
+      schema: "pi-workflows.progress.v1" as const,
+      label: "Overall",
+      status: "running" as const,
+      completed: 5,
+      total: 10,
+      unit: "items",
+    };
+    const state = makeState({
+      currentNode: "second",
+      updates: [
+        {
+          updateId: "u1",
+          seq: 1,
+          at: "2026-01-01T00:01:00.000Z",
+          runId: "r1",
+          nodeId: "work",
+          attemptId: "a1",
+          type: "progress",
+          key: "overall",
+          data: overallData,
+        },
+        {
+          updateId: "u2",
+          seq: 2,
+          at: "2026-01-01T00:01:00.000Z",
+          runId: "r1",
+          nodeId: "work",
+          attemptId: "a1",
+          type: "progress",
+          key: "worker",
+          data: { ...overallData, label: "Worker", completed: 2 },
+        },
+      ],
+      outputs: {
+        estimate: {
+          tracks: [
+            {
+              key: "overall",
+              samples: [],
+              estimate: { key: "overall", data: overallData, sampleCount: 2 },
+            },
+          ],
+        },
+      },
+    });
+
+    const lines = buildWidgetLines(state, snapshot, new Date("2026-01-01T00:01:00.000Z")).join(
+      "\n",
+    );
+    expect(lines).toContain("Overall  5/10 items");
+    expect(lines).toContain("Worker  2/10 items");
+  });
+
   it("shows optional progress, ETA, elapsed update age, and next-check time", () => {
     const now = new Date("2026-01-01T00:10:00.000Z");
     const state = makeState({

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -168,6 +168,40 @@ describe("nodeTypeGlyph", () => {
 });
 
 describe("buildWidgetLines", () => {
+  it("calculates measured ETA from live update history for any workflow", () => {
+    const state = makeState({ currentNode: "second" });
+    const history = [0, 25, 50].map((completed, index) => ({
+      updateId: `u${index}`,
+      seq: index + 1,
+      at: `2026-01-01T00:0${index}:00.000Z`,
+      runId: "r1",
+      nodeId: "work",
+      attemptId: "a1",
+      type: "progress",
+      key: "overall",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        label: "Import",
+        status: "running",
+        completed,
+        total: 100,
+        unit: "rows",
+      },
+    }));
+
+    const view = buildWidgetView(
+      state,
+      snapshot,
+      new Date("2026-01-01T00:02:00.000Z"),
+      null,
+      false,
+      120,
+      undefined,
+      history,
+    );
+    expect(view.lines.join("\n")).toContain("Import  50/100 rows  ETA 2m");
+  });
+
   it("shows optional progress, ETA, elapsed update age, and next-check time", () => {
     const now = new Date("2026-01-01T00:10:00.000Z");
     const state = makeState({

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -202,6 +202,48 @@ describe("buildWidgetLines", () => {
     expect(view.lines.join("\n")).toContain("Import  50/100 rows  ETA 2m");
   });
 
+  it("keeps latest tracks that are outside the bounded measured history", () => {
+    const overall = {
+      updateId: "u1",
+      seq: 1,
+      at: "2026-01-01T00:01:00.000Z",
+      runId: "r1",
+      nodeId: "work",
+      attemptId: "a1",
+      type: "progress",
+      key: "overall",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        label: "Overall",
+        status: "running",
+        completed: 5,
+        total: 10,
+        unit: "items",
+      },
+    } as const;
+    const worker = {
+      ...overall,
+      updateId: "u2",
+      seq: 2,
+      key: "worker",
+      data: { ...overall.data, label: "Worker", completed: 2 },
+    } as const;
+    const state = makeState({ currentNode: "second", updates: [overall, worker] });
+    const view = buildWidgetView(
+      state,
+      snapshot,
+      new Date("2026-01-01T00:01:00.000Z"),
+      null,
+      false,
+      120,
+      undefined,
+      [overall],
+    );
+    const lines = view.lines.join("\n");
+    expect(lines).toContain("Overall  5/10 items");
+    expect(lines).toContain("Worker  2/10 items");
+  });
+
   it("shows optional progress, ETA, elapsed update age, and next-check time", () => {
     const now = new Date("2026-01-01T00:10:00.000Z");
     const state = makeState({

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2684,7 +2684,7 @@ fn median_value(values: &[f64]) -> Option<f64> {
         return None;
     }
     let middle = values.len() / 2;
-    Some(if values.len() % 2 == 0 {
+    Some(if values.len().is_multiple_of(2) {
         (values[middle - 1] + values[middle]) / 2.0
     } else {
         values[middle]

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2580,18 +2580,23 @@ fn progress_info_lines(events: &[Value], palette: &Palette) -> Vec<Line<'static>
         ]));
 
         let mut detail = Vec::new();
+        let source_at = latest
+            .get("sourceUpdatedAt")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp_ms)
+            .unwrap_or(*latest_at);
         let source_eta = latest
             .get("sourceEstimatedFinishAt")
             .and_then(Value::as_str)
             .and_then(parse_timestamp_ms)
-            .filter(|finish| *finish > now_ms());
+            .filter(|finish| *finish > source_at && *finish > now_ms());
         if let Some(finish) = source_eta {
             detail.push(format!("source ETA {}", format_eta_ms(finish - now_ms())));
         } else if !matches!(
             status,
             "completed" | "failed" | "cancelled" | "waiting" | "blocked"
         ) {
-            let rates = progress_rates(samples);
+            let rates = progress_rates(current_progress_epoch(samples));
             if let (Some(all), Some(done), Some(median)) = (total, completed, median_value(&rates))
             {
                 if median > 0.0 {
@@ -2608,7 +2613,7 @@ fn progress_info_lines(events: &[Value], palette: &Palette) -> Vec<Line<'static>
                 detail.push("ETA unavailable".to_string());
             }
         }
-        detail.push(format!("{} samples", samples.len()));
+        detail.push(format!("{} samples", current_progress_epoch(samples).len()));
         detail.push(format!(
             "updated {}",
             format_eta_ms((now_ms() - *latest_at).max(0))
@@ -2619,6 +2624,41 @@ fn progress_info_lines(events: &[Value], palette: &Palette) -> Vec<Line<'static>
         ]));
     }
     lines
+}
+
+fn current_progress_epoch(samples: &[(i64, Value)]) -> &[(i64, Value)] {
+    let mut start = 0;
+    for index in 1..samples.len() {
+        if progress_resets(&samples[index - 1].1, &samples[index].1) {
+            start = index;
+        }
+    }
+    &samples[start..]
+}
+
+fn progress_resets(previous: &Value, current: &Value) -> bool {
+    let changed_identity = previous.get("phase") != current.get("phase")
+        || previous.get("unit") != current.get("unit")
+        || previous.get("total") != current.get("total");
+    let decreased = match (
+        previous.get("completed").and_then(Value::as_f64),
+        current.get("completed").and_then(Value::as_f64),
+    ) {
+        (Some(before), Some(after)) => after < before,
+        _ => false,
+    };
+    let previous_status = previous
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let current_status = current
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    changed_identity
+        || decreased
+        || (matches!(previous_status, "completed" | "failed" | "cancelled")
+            && !matches!(current_status, "completed" | "failed" | "cancelled"))
 }
 
 fn progress_rates(samples: &[(i64, Value)]) -> Vec<f64> {
@@ -2751,13 +2791,39 @@ fn draw_transport(
 mod tests {
     use super::{
         centered_camera, clamp_camera_axis, collect_artifact_paths, completed_step_at, contains,
-        graph_position_label, inspector_height_for_drag, inspector_tab_label, inspector_tab_layout,
-        resolve_remote_artifacts, resolved_inspector_height, sidebar_width_for_drag,
-        temporal_through_seq, trace_events_for_scope, valid_session_binding, GraphNodeStyle,
-        InspectorTab, NodeBounds, Rect, StepRecord, TraceScope, DEFAULT_NODE_STYLE,
+        current_progress_epoch, graph_position_label, inspector_height_for_drag,
+        inspector_tab_label, inspector_tab_layout, progress_rates, resolve_remote_artifacts,
+        resolved_inspector_height, sidebar_width_for_drag, temporal_through_seq,
+        trace_events_for_scope, valid_session_binding, GraphNodeStyle, InspectorTab, NodeBounds,
+        Rect, StepRecord, TraceScope, DEFAULT_NODE_STYLE,
     };
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn progress_estimation_resets_on_phase_change() {
+        let samples = vec![
+            (
+                0,
+                json!({ "status": "running", "phase": "one", "completed": 0, "total": 100, "unit": "rows" }),
+            ),
+            (
+                1_000,
+                json!({ "status": "running", "phase": "one", "completed": 10, "total": 100, "unit": "rows" }),
+            ),
+            (
+                2_000,
+                json!({ "status": "running", "phase": "two", "completed": 0, "total": 50, "unit": "rows" }),
+            ),
+            (
+                3_000,
+                json!({ "status": "running", "phase": "two", "completed": 5, "total": 50, "unit": "rows" }),
+            ),
+        ];
+        let epoch = current_progress_epoch(&samples);
+        assert_eq!(epoch.len(), 2);
+        assert_eq!(progress_rates(epoch), vec![0.005]);
+    }
 
     #[test]
     fn bordered_nodes_are_the_default() {

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2590,27 +2590,28 @@ fn progress_info_lines(events: &[Value], palette: &Palette) -> Vec<Line<'static>
             .and_then(Value::as_str)
             .and_then(parse_timestamp_ms)
             .filter(|finish| *finish > source_at && *finish > now_ms());
-        if let Some(finish) = source_eta {
-            detail.push(format!("source ETA {}", format_eta_ms(finish - now_ms())));
-        } else if !matches!(
-            status,
-            "completed" | "failed" | "cancelled" | "waiting" | "blocked"
-        ) {
-            let rates = progress_rates(current_progress_epoch(samples));
-            if let (Some(all), Some(done), Some(median)) = (total, completed, median_value(&rates))
-            {
-                if median > 0.0 {
-                    detail.push(format!(
-                        "ETA {}",
-                        format_eta_ms(((all - done).max(0.0) / median) as i64)
-                    ));
-                    detail.push(format!("rate {}/min", compact_number(median * 60_000.0)));
-                    detail.push(format!("{} confidence", progress_confidence(&rates)));
+        let terminal = matches!(status, "completed" | "failed" | "cancelled");
+        if !terminal {
+            if let Some(finish) = source_eta {
+                detail.push(format!("source ETA {}", format_eta_ms(finish - now_ms())));
+            } else if !matches!(status, "waiting" | "blocked") {
+                let rates = progress_rates(current_progress_epoch(samples));
+                if let (Some(all), Some(done), Some(median)) =
+                    (total, completed, median_value(&rates))
+                {
+                    if median > 0.0 {
+                        detail.push(format!(
+                            "ETA {}",
+                            format_eta_ms(((all - done).max(0.0) / median) as i64)
+                        ));
+                        detail.push(format!("rate {}/min", compact_number(median * 60_000.0)));
+                        detail.push(format!("{} confidence", progress_confidence(&rates)));
+                    } else {
+                        detail.push("ETA unavailable".to_string());
+                    }
                 } else {
                     detail.push("ETA unavailable".to_string());
                 }
-            } else {
-                detail.push("ETA unavailable".to_string());
             }
         }
         detail.push(format!("{} samples", current_progress_epoch(samples).len()));

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2460,6 +2460,7 @@ fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'stat
             state.trace_seq
         )),
     ]));
+    lines.extend(progress_info_lines(data.events, palette));
     let capture = capture_integrity(data);
     lines.push(Line::from(vec![
         label("session"),
@@ -2511,6 +2512,186 @@ fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'stat
         ]));
     }
     lines
+}
+
+fn progress_info_lines(events: &[Value], palette: &Palette) -> Vec<Line<'static>> {
+    let mut tracks: HashMap<String, Vec<(i64, Value)>> = HashMap::new();
+    for event in events {
+        if event.get("type").and_then(Value::as_str) != Some("update_published")
+            || event.pointer("/payload/type").and_then(Value::as_str) != Some("progress")
+        {
+            continue;
+        }
+        let Some(key) = event.pointer("/payload/key").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(data) = event
+            .pointer("/payload/data")
+            .filter(|value| value.is_object())
+        else {
+            continue;
+        };
+        let Some(at) = event
+            .get("at")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp_ms)
+        else {
+            continue;
+        };
+        tracks
+            .entry(key.to_string())
+            .or_default()
+            .push((at, data.clone()));
+    }
+    let mut keys: Vec<String> = tracks.keys().cloned().collect();
+    keys.sort_by_key(|key| (key != "overall", key.clone()));
+    if keys.is_empty() {
+        return Vec::new();
+    }
+    let label =
+        |text: &str| Span::styled(format!("{text:<14}"), Style::default().fg(palette.accent));
+    let mut lines = vec![Line::from("")];
+    for key in keys {
+        let samples = tracks.get(&key).expect("progress key exists");
+        let Some((latest_at, latest)) = samples.last() else {
+            continue;
+        };
+        let name = latest.get("label").and_then(Value::as_str).unwrap_or(&key);
+        let status = latest
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let completed = latest.get("completed").and_then(Value::as_f64);
+        let total = latest.get("total").and_then(Value::as_f64);
+        let unit = latest.get("unit").and_then(Value::as_str).unwrap_or("");
+        let count = match (completed, total) {
+            (Some(done), Some(all)) => format!(
+                "{} / {} {}",
+                compact_number(done),
+                compact_number(all),
+                sanitize_text(unit)
+            ),
+            (Some(done), None) => format!("{} {}", compact_number(done), sanitize_text(unit)),
+            _ => status.to_string(),
+        };
+        lines.push(Line::from(vec![
+            label("progress"),
+            Span::raw(format!("{} · {}", sanitize_text(name), count.trim())),
+        ]));
+
+        let mut detail = Vec::new();
+        let source_eta = latest
+            .get("sourceEstimatedFinishAt")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp_ms)
+            .filter(|finish| *finish > now_ms());
+        if let Some(finish) = source_eta {
+            detail.push(format!("source ETA {}", format_eta_ms(finish - now_ms())));
+        } else if !matches!(
+            status,
+            "completed" | "failed" | "cancelled" | "waiting" | "blocked"
+        ) {
+            let rates = progress_rates(samples);
+            if let (Some(all), Some(done), Some(median)) = (total, completed, median_value(&rates))
+            {
+                if median > 0.0 {
+                    detail.push(format!(
+                        "ETA {}",
+                        format_eta_ms(((all - done).max(0.0) / median) as i64)
+                    ));
+                    detail.push(format!("rate {}/min", compact_number(median * 60_000.0)));
+                    detail.push(format!("{} confidence", progress_confidence(&rates)));
+                } else {
+                    detail.push("ETA unavailable".to_string());
+                }
+            } else {
+                detail.push("ETA unavailable".to_string());
+            }
+        }
+        detail.push(format!("{} samples", samples.len()));
+        detail.push(format!(
+            "updated {}",
+            format_eta_ms((now_ms() - *latest_at).max(0))
+        ));
+        lines.push(Line::from(vec![
+            label("estimate"),
+            Span::styled(detail.join(" · "), Style::default().fg(palette.subtext)),
+        ]));
+    }
+    lines
+}
+
+fn progress_rates(samples: &[(i64, Value)]) -> Vec<f64> {
+    let start = samples.len().saturating_sub(9);
+    let mut rates = Vec::new();
+    for pair in samples[start..].windows(2) {
+        let (previous_at, previous) = &pair[0];
+        let (current_at, current) = &pair[1];
+        let elapsed = current_at - previous_at;
+        let before = previous.get("completed").and_then(Value::as_f64);
+        let after = current.get("completed").and_then(Value::as_f64);
+        if elapsed > 0 && before.is_some() && after.is_some() {
+            rates.push((after.unwrap_or(0.0) - before.unwrap_or(0.0)) / elapsed as f64);
+        }
+    }
+    rates.sort_by(f64::total_cmp);
+    rates
+}
+
+fn median_value(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let middle = values.len() / 2;
+    Some(if values.len() % 2 == 0 {
+        (values[middle - 1] + values[middle]) / 2.0
+    } else {
+        values[middle]
+    })
+}
+
+fn progress_confidence(rates: &[f64]) -> &'static str {
+    if rates.len() < 2 {
+        return "low";
+    }
+    let median = median_value(rates).unwrap_or(0.0);
+    if median <= 0.0 {
+        return "low";
+    }
+    let p25 = rates[((rates.len() - 1) as f64 * 0.25).round() as usize];
+    let p75 = rates[((rates.len() - 1) as f64 * 0.75).round() as usize];
+    let spread = (p75 - p25) / median;
+    if rates.len() >= 5 && spread <= 0.25 {
+        "high"
+    } else if spread <= 0.5 {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+fn compact_number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.2}")
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    }
+}
+
+fn format_eta_ms(ms: i64) -> String {
+    let seconds = ms.max(0) / 1_000;
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3_600 {
+        format!("{}m", (seconds + 59) / 60)
+    } else if seconds < 86_400 {
+        format!("{:.1}h", seconds as f64 / 3_600.0)
+    } else {
+        format!("{:.1}d", seconds as f64 / 86_400.0)
+    }
 }
 
 struct TransportOptions<'a> {


### PR DESCRIPTION
## Summary

Long-running workflows could not show durable progress before a node finished.
This change adds one general update API, then uses it for counts, rates, ETA, monitor reports, and live display.
The built-in monitor now reports every accepted check and does not start an unnecessary assistant reply.

## What Changed

Workflow authors can now publish structured updates from agent steps, function actions, shell output, and the standalone host path.
Updates are durable, ordered, bounded, and separate from node completion and routing.

- Added `WorkflowUpdateInput`, durable update receipts and records, `publishUpdate()`, and the non-completing `workflow update` tool action.
- Added claim-fenced persistence, latest-value projection, trace history, idempotency, payload limits, key limits, and rate limits.
- Added shell line parsing with backpressure, UTF-8 and line-size checks, and normal stdout and stderr capture.
- Added `pi-workflows.progress.v1` validation, independent tracks, source ETA, measured ETA, epoch resets, confidence, and model-free formatting.
- Added progress views to the Pi widget, TypeScript viewer, and Rust `piw` inspector.
- Replaced monitor quiet routes with one report per accepted check, a 30-minute default, optional progress tracks, schedule updates, and no report acknowledgement turn.
- Updated the built-in monitor revision and prepared version `0.6.0`.
- Updated the public authoring, persistence, monitor, update, and development documentation.

## Testing

The engine, both viewers, real Pi integration, and the live terminal behavior were tested.
The real Pi E2E test publishes an agent update and then submits the same monitor step.

- `npm run check` — passed, 698 tests, 85.25% branch coverage.
- `npm run test:e2e` — passed, 7 real Pi RPC tests.
- `cargo fmt --manifest-path tui/Cargo.toml -- --check` — passed.
- `cargo test --manifest-path tui/Cargo.toml` — passed, including live server and parity tests.
- `npx slophammer-ts@latest dry .` — passed with 0 candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — passed.
- Live Herdr Pi test — verified compact step cards, multiple concurrent tracks, measured ETA, source ETA, waiting state, elapsed update age, next-check countdown, monitor progress notifications, and no assistant response after a notification.

## Risks

The update path is additive, but the built-in monitor contract changes in place.
Existing revision-2 monitor runs will refuse resume instead of mixing old run state with revision 3.

- Progress estimates depend on at least two usable samples unless the source supplies an ETA.
- The monitor keeps the 1,000-check safety ceiling.
- The compact widget stays within Pi's 10-line limit, so it can hide lower-priority graph rows or tracks when space is limited.
