### PR TITLE
fix: suppress assistant tails after workflow submissions

### DIFF
--- a/docs/MONITOR.md
+++ b/docs/MONITOR.md
@@ -196,7 +196,7 @@ Each accepted check reaches `report`, including a check that selects `stop`. The
 
 The extension delivers the custom Pi message with `triggerTurn: false`. The notification stays in session history and later model context. Its arrival does not start an assistant response.
 
-The monitor does not use `sendUserMessage`. It does not ask an agent to repeat or acknowledge the notification.
+The monitor does not use `sendUserMessage`. It does not ask an agent to repeat or acknowledge the notification. After the workflow tool accepts the check, the extension removes any extra assistant tail text from that agent run, so only the notification reports the check.
 
 A check that times out or fails before producing accepted output is not an accepted check. The run enters its normal terminal error state and the extension shows the workflow lifecycle notification. It does not invent a successful check report.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -463,6 +463,7 @@ possible. Defaults worth knowing:
   When no run is live but the widget still shows a parked or finished run,
   the same command clears the widget.
 - One workflow runs per session at a time.
+- After the workflow tool accepts an agent-step submission, the extension removes any assistant tail text from the rest of that agent run. The next workflow message or notification is the visible continuation. Explicit final presentation remains a separate opt-in response.
 - Agent nudges: if the model ends its turn without submitting the pending
   step, it gets a reminder, twice by default, then the step fails.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -320,6 +320,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   };
   let activeRun: ActiveRun | null = null;
   let systemTurnAbort: AgentStepContract | null = null;
+  let suppressWorkflowAssistantTail = false;
   let lastExpiredAttempt: { contract: AgentStepContract; reason: string } | null = null;
   let pendingToolLaunch: {
     ctx: ExtensionContext;
@@ -1682,6 +1683,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           if (!result.accepted) {
             throw new Error(result.message);
           }
+          suppressWorkflowAssistantTail = true;
           return {
             content: [{ type: "text", text: result.message }],
             details: { action: "submit", step: params.step, accepted: true },
@@ -1745,6 +1747,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_start", () => {
+    suppressWorkflowAssistantTail = false;
     if (!activeRun && presentationPending === null && presentationAbort) {
       // A normal user turn started while an async presentation prompt was
       // still resolving. The user's new request supersedes that old result.
@@ -1755,6 +1758,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_end", (event, ctx) => {
+    suppressWorkflowAssistantTail = false;
     const aborted = event.messages.some(
       (message) =>
         typeof message === "object" &&
@@ -1802,6 +1806,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("message_end", (event) => {
+    if (suppressWorkflowAssistantTail && event.message.role === "assistant") {
+      const message = {
+        ...event.message,
+        content: event.message.content.filter((part) => part.type !== "text"),
+      };
+      activeRun?.recorder?.handleMessageEnd({ ...event, message });
+      return { message };
+    }
     activeRun?.recorder?.handleMessageEnd(event);
   });
 
@@ -1847,6 +1859,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   pi.on("session_shutdown", async () => {
     sessionClosed = true;
     systemTurnAbort = null;
+    suppressWorkflowAssistantTail = false;
     supersedePresentation();
     const run = activeRun;
     if (run !== null && run.claimToken !== undefined) {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -531,6 +531,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         return;
       }
       presentationPending = run.generation;
+      suppressWorkflowAssistantTail = false;
       pi.sendMessage(
         {
           customType: PRESENTATION_MESSAGE_TYPE,

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1628,6 +1628,14 @@ export default defineWorkflow({
         (entry) => entry.message.customType === "pi-workflows-presentation",
       );
       expect(presentation?.message.content).toContain("reply was");
+      const presentationResponse = {
+        role: "assistant",
+        content: [{ type: "text", text: "The reply was hi." }],
+      };
+      const [replacement] = await harness.emitAsync("message_end", {
+        message: presentationResponse,
+      });
+      expect(replacement).toBeUndefined();
       await harness.emitAsync("session_shutdown");
     } finally {
       vi.unstubAllEnvs();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -207,11 +207,10 @@ function makeHarness(options: {
         void listener(payload, ctx);
       }
     },
-    emitAsync: async (event: string, payload?: unknown) => {
+    emitAsync: async (event: string, payload?: unknown) =>
       await Promise.all(
         (listeners.get(event) ?? []).map(async (listener) => await listener(payload, ctx)),
-      );
-    },
+      ),
   };
 }
 
@@ -399,6 +398,55 @@ describe("pi-workflows extension", () => {
       } finally {
         queue.close();
       }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("removes assistant tail text after an accepted workflow submission", async () => {
+    const cwd = await makeTempDir("pi-workflows-tail");
+    const runsDir = await makeTempDir("pi-workflows-tail-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({
+        cwd,
+        respond: (prompt, tool) => {
+          const contract = stepFromPrompt(prompt);
+          if (contract) {
+            void tool.execute("submit-tail", {
+              action: "submit",
+              ...contract,
+              output: { reply: "hi" },
+            });
+          }
+        },
+      });
+
+      await harness.command.handler("mini say hi", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
+
+      const assistantMessage = {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "The workflow submission is complete." },
+          { type: "text", text: "This reply must not appear." },
+        ],
+      };
+      await harness.emitAsync("turn_end", { message: assistantMessage, toolResults: [] });
+      const [replacement] = await harness.emitAsync("message_end", {
+        message: assistantMessage,
+      });
+      expect(replacement).toEqual({
+        message: {
+          ...assistantMessage,
+          content: [{ type: "thinking", thinking: "The workflow submission is complete." }],
+        },
+      });
+
+      await harness.emitAsync("agent_end", { messages: [] });
+      const [normal] = await harness.emitAsync("message_end", { message: assistantMessage });
+      expect(normal).toBeUndefined();
     } finally {
       vi.unstubAllEnvs();
     }

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
## Summary

A model could add a normal assistant reply after it submitted an accepted workflow step.
This change removes that extra tail text, so the next workflow message or notification is the only visible continuation.
It also prepares patch release 0.6.1.

## What Changed

The extension now owns the end of an accepted workflow-step turn instead of relying on the model to obey a text instruction.
Explicit workflow presentations still work because they start as a separate agent run.

- Mark the current agent run after an accepted `workflow submit`.
- Replace later assistant messages in that run with the same message minus text parts.
- Clear the marker when the agent run ends, a new run starts, or the session closes.
- Record the filtered message in the workflow session journal.
- Document the behavior and bump npm and Cargo versions to 0.6.1.

## Testing

The regression is covered in the extension harness and in a real Pi session inside Herdr.
The live monitor produced its notification and completed without a second assistant message.

- `npm run check` — 709 tests passed
- `npm run test:e2e` — 7 tests passed
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`

SimpleDoc still reports the repository's existing document-name migration backlog. This change does not add that backlog.

## Risks

The change only removes text after an accepted workflow submission.
Tool-call and thinking parts stay intact, and normal assistant turns are unchanged.