### PR TITLE
feat: bundle workflow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ Or try the npm package without installing it:
 pi -e npm:@osolmaz/pi-workflows
 ```
 
+The Pi package includes the extension and two optional skills:
+
+- `pi-workflows` teaches the agent how to operate and author workflows.
+- `monitor` starts and operates the built-in monitor workflow.
+
+Pi discovers both skills when it loads the package. Use `pi config` to disable
+the extension, all bundled skills, or one skill independently. The equivalent
+settings entry below keeps the extension and disables only `monitor`:
+
+```json
+{
+  "packages": [
+    {
+      "source": "npm:@osolmaz/pi-workflows",
+      "skills": ["-skills/monitor"]
+    }
+  ]
+}
+```
+
+Set `"skills": []` to disable both bundled skills while keeping the extension.
+Set `"extensions": []` to keep the skills without loading the extension.
+
 Install the interactive terminal viewer separately from crates.io. The crate
 is named `pi-workflows`; its command is `piw`:
 

--- a/docs/plans/2026-08-17-bundled-skills-plan.md
+++ b/docs/plans/2026-08-17-bundled-skills-plan.md
@@ -1,0 +1,104 @@
+---
+title: Bundle Pi Workflows skills with the extension
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-17
+---
+
+# Bundle Pi Workflows skills with the extension
+
+Pi Workflows should be the single source of truth for instructions that teach an agent how to use its extension and built-in workflows. Installing the Pi package should discover those skills with the extension, while Pi's normal package filters let users disable either resource type or an individual skill.
+
+## Outcome
+
+The npm package will include two optional Pi skills:
+
+- `pi-workflows` explains when and how to use the `workflow` tool, control runs, complete step contracts, publish progress, and author workflow files.
+- `monitor` starts and operates the built-in monitor workflow with the established 30-minute default, inferred finish rule, status report on every check, and structured progress guidance.
+
+The existing monitor skill in `osolmaz/tools` will move here and be removed from that repository. OnurPi will expose the upstream extension and skills from one reviewed package version.
+
+## Scope
+
+- Add stable skill paths under `skills/`.
+- Declare both the extension and skills in the Pi package manifest.
+- Include the skill files in npm artifacts.
+- Document bundled resources and independent disable controls.
+- Add automated checks for manifest paths, skill metadata, package contents, and duplicate skill names.
+- Test discovery from a packed package with the real Pi runtime.
+- Release the compatible feature as `0.7.0`, following the repository's pre-1.0 minor-release convention.
+- Update the OnurPi pin and package resource forwarding.
+- Delete the Tools copy and sync local skill mirrors so no duplicate remains.
+
+## Non-goals
+
+- Do not add a new workflow node, workflow schema field, or Pi core API.
+- Do not load skills only while a workflow step is active.
+- Do not create a general workflow-to-skill attachment system.
+- Do not copy unrelated operating-policy skills such as `autoimplement` or `autoresearch-loop`.
+
+## Public contract
+
+The package uses Pi's documented package resource contract:
+
+- `pi.extensions` exposes the existing extension.
+- `pi.skills` exposes `skills/`.
+- Pi package filters and `pi config` can disable all skills, one skill, or the extension independently.
+
+The `workflow` tool description remains the small always-available call contract. The `pi-workflows` skill contains detailed guidance that Pi loads only when a matching task requires it. Workflow step messages remain compact and authoritative for `submit` and `update` attempt identifiers.
+
+## Contract impact
+
+- **Session state:** no new session entry or change to normal Pi session behavior.
+- **Other persistent data:** none.
+- **Pi internals:** none.
+- **Public Pi API:** package `pi.skills` discovery and existing package resource filters. The extension continues to use its current public APIs.
+
+## Implementation
+
+1. Add `skills/pi-workflows/SKILL.md` with concise tool and authoring guidance linked to the bundled reference docs.
+2. Move the current monitor skill to `skills/monitor/SKILL.md` and align repository-relative references with the package layout.
+3. Add `skills` to the npm package files and Pi manifest.
+4. Add tests that validate declared paths, required frontmatter, unique skill names, and packed files.
+5. Update README installation and configuration examples, including independent resource filtering.
+6. Pack the package and start the real Pi runtime from that artifact. Verify that `/skill:pi-workflows` and `/skill:monitor` are discovered with the extension, then verify that package filtering can hide the monitor skill without hiding the extension.
+7. Run all repository checks and Pi Reviewer, merge, release `0.7.0`, and verify npm contents.
+8. Pin `0.7.0` in OnurPi, forward the dependency's skills, and run OnurPi checks.
+9. Remove `agents/skills/monitor` from Tools, run the sync script, and verify that the installed skill now comes from the Pi Workflows package only.
+
+## Acceptance criteria
+
+- A direct Pi installation of `@osolmaz/pi-workflows` discovers the extension and both skills.
+- The OnurPi wrapper discovers the same two upstream skills.
+- Users can disable bundled skills or the extension with standard Pi package settings.
+- The model can use the `workflow` tool from the new skill without larger workflow step messages.
+- npm contains the two `SKILL.md` files and their referenced documentation.
+- Tools contains no monitor skill source or synced duplicate.
+- Local checks, real-Pi end-to-end tests, Pi Reviewer, and CI pass.
+
+## Verification
+
+Run in `pi-workflows`:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+npm pack --dry-run
+```
+
+Run the packed-package Pi discovery smoke test documented by the implementation, then run in OnurPi:
+
+```bash
+npm run check
+npm run slophammer
+git diff --check
+```
+
+Run in Tools after deletion:
+
+```bash
+python3 agents/sync-skills.py monitor
+npx -y @simpledoc/simpledoc check
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"
@@ -20,6 +20,7 @@
   "files": [
     "dist",
     "src",
+    "skills",
     "examples",
     "docs",
     "README.md",
@@ -86,6 +87,9 @@
   "pi": {
     "extensions": [
       "./src/extension/index.ts"
+    ],
+    "skills": [
+      "./skills"
     ]
   }
 }

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -8,7 +8,7 @@ compatibility: Requires Pi Workflows and the built-in monitor workflow.
 
 Use the built-in Pi `monitor` workflow as an autopilot for the requested objective. Monitoring is not passive status polling. The agent must maintain nominal operation, repair recoverable failures, resume durable work, and continue until the complete objective is verified or a material blocker makes safe continuation impossible.
 
-A monitor request authorizes routine operational actions that are necessary to preserve and finish the stated objective. These actions include restarting or resuming the same Job or process, repairing an exact operational configuration or storage-path error, retrying transient infrastructure failures, restoring a verified checkpoint, and replacing a failed physical attempt with the same immutable execution contract. It does not authorize changing the objective, method, model, data source, production selection, or other consequential contract.
+A monitor request authorizes routine operational actions that are necessary to preserve and finish the stated objective, subject to the conversation and repository approval boundaries. These actions can include restarting or resuming the same non-paid Job or process, repairing an exact operational configuration or storage-path error, retrying transient infrastructure failures, restoring a verified checkpoint, and replacing a failed physical attempt with the same immutable execution contract. Paid launches, resumes, retries, or replacements require the explicit approval described below. Monitoring does not authorize changing the objective, method, model, data source, production selection, or other consequential contract.
 
 ## Prepare and start without delay
 
@@ -34,11 +34,11 @@ When the conversation gives no clear finish criterion, set `stopWhen` to `Stop o
 
 Do not invent a finite check count. Omit `maxChecks` unless the user explicitly requests one. The workflow host can apply its own safety upper bound. Disclose that bound if it appears.
 
-## Default Hugging Face authority
+## Paid infrastructure authority
 
-For an objective that uses Hugging Face infrastructure, invoking this skill grants a default cumulative spending ceiling of **$1,000**, including all related attempts and money already spent, unless the conversation or repository sets a lower ceiling. This is a hard maximum, not a spending target.
+A monitoring request does not grant spending approval or create a default spending ceiling. Before launching, resuming, retrying, or replacing paid work, load and follow the paid-compute, provider, Job-control, and runtime skills that apply. Present the required estimate and obtain explicit approval when those policies require it.
 
-Before launching or resuming paid work, load and follow the paid-compute, Hugging Face, Job-control, and runtime skills that apply. Measure or estimate cost, use the cheapest safe configuration, publish durable partial work, and enforce the cumulative ceiling in receipts or launch guards. Continue autonomously within the approved contract. Stop before the ceiling or when new evidence invalidates the approved estimate, method, hardware, or recovery assumptions.
+After approval, preserve the exact method, hardware, concurrency, cumulative cost ceiling, and recovery assumptions in the monitor task. Continue only within that approved contract. Stop for a decision before new paid work when there is no applicable approval, when the ceiling would be exceeded, or when evidence invalidates an approved assumption.
 
 The monitor may use a credential only when the conversation or repository has already authorized that credential's source, destination, and purpose. It may reuse that authorization for retries and replacement attempts under the same objective. It must not discover unrelated credentials, broaden scopes, copy credentials to a new store, or print secret values.
 
@@ -64,7 +64,7 @@ Do not start a second monitor for the same objective while one is active. Update
 
 ## Complete workflow checks
 
-Each workflow check arrives with an exact step contract. Apply the operational authority recorded in `task`. The default monitor contract is recovery-capable autopilot, not read-only observation.
+Each workflow check arrives with an exact step contract. Apply only the operational authority recorded in `task`. The default monitor contract is recovery-capable autopilot within recorded approval boundaries, not authority to create new spending or change the objective.
 
 For each check:
 

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: monitor
+description: Use when the user asks to monitor, watch, track, or periodically check a running command, remote Job, CI run, deployment, publication, or other long-running objective. Starts the built-in Pi monitor workflow immediately in the current session and drives the objective autonomously, including routine recovery, until verified completion or a material blocker.
+compatibility: Requires Pi Workflows and the built-in monitor workflow.
+---
+
+# Monitor
+
+Use the built-in Pi `monitor` workflow as an autopilot for the requested objective. Monitoring is not passive status polling. The agent must maintain nominal operation, repair recoverable failures, resume durable work, and continue until the complete objective is verified or a material blocker makes safe continuation impossible.
+
+A monitor request authorizes routine operational actions that are necessary to preserve and finish the stated objective. These actions include restarting or resuming the same Job or process, repairing an exact operational configuration or storage-path error, retrying transient infrastructure failures, restoring a verified checkpoint, and replacing a failed physical attempt with the same immutable execution contract. It does not authorize changing the objective, method, model, data source, production selection, or other consequential contract.
+
+## Prepare and start without delay
+
+As soon as the user invokes this skill:
+
+1. Read the current conversation, active plan, repository instructions, and applicable compute, runtime, credential, deployment, or publication skills.
+2. Preserve the exact objective, immutable execution contract, current identifiers, durable progress, cost already spent, approval ceilings, finish criteria, and known recovery rules in the workflow input. Write or update a durable plan or incident note first only when the work needs one for safe continuation.
+3. Make the workflow instructions faithful to what the user requested. Do not reduce an implementation or recovery objective to observation-only monitoring.
+4. Call `workflow` with `action: "start"` in the current Pi session without asking for another confirmation or waiting for a later turn.
+5. Let the first workflow check run immediately. Do not use Unified Exec sleeps, manual polling loops, a second scheduler, or a separate Pi session as a substitute.
+
+Do not finish the initiating turn before the workflow start call. If a safe contract cannot yet be written because a critical identifier or boundary is missing, gather it immediately when possible. Ask the user only when the missing decision is consequential and cannot be inferred safely.
+
+## Build the monitor contract
+
+Derive the workflow input from the full conversation:
+
+- `task`: State the complete objective, the exact current target and stable identifiers, authoritative status sources, durable progress and final-output surfaces, approved recovery actions, immutable boundaries, cost and credential rules, and required validation or downstream operations.
+- `everyMinutes`: Use the user's interval when present. Use `30` when the user gives no interval. The built-in workflow accepts intervals from 1 minute through 24 hours.
+- `stopWhen`: Infer verified completion from the full conversation. Describe completion of the complete objective, not only the end of one physical process. Also name material blockers that require human intervention.
+
+When the conversation gives no clear finish criterion, set `stopWhen` to `Stop only when the user explicitly asks to stop.` Do not use that fallback when a broader implementation, repair, publication, or deployment objective is clear from context.
+
+Do not invent a finite check count. Omit `maxChecks` unless the user explicitly requests one. The workflow host can apply its own safety upper bound. Disclose that bound if it appears.
+
+## Default Hugging Face authority
+
+For an objective that uses Hugging Face infrastructure, invoking this skill grants a default cumulative spending ceiling of **$1,000**, including all related attempts and money already spent, unless the conversation or repository sets a lower ceiling. This is a hard maximum, not a spending target.
+
+Before launching or resuming paid work, load and follow the paid-compute, Hugging Face, Job-control, and runtime skills that apply. Measure or estimate cost, use the cheapest safe configuration, publish durable partial work, and enforce the cumulative ceiling in receipts or launch guards. Continue autonomously within the approved contract. Stop before the ceiling or when new evidence invalidates the approved estimate, method, hardware, or recovery assumptions.
+
+The monitor may use a credential only when the conversation or repository has already authorized that credential's source, destination, and purpose. It may reuse that authorization for retries and replacement attempts under the same objective. It must not discover unrelated credentials, broaden scopes, copy credentials to a new store, or print secret values.
+
+## Start the workflow
+
+Start the built-in workflow in the current session with this shape:
+
+```text
+workflow({
+  action: "start",
+  workflow: "monitor",
+  input: {
+    task: "<complete objective, contract, recovery authority, and verification task>",
+    everyMinutes: 30,
+    stopWhen: "<derived finish criterion or explicit-user-stop fallback>"
+  }
+})
+```
+
+Use the user-supplied interval instead of `30` when present. Add `maxChecks` only when the user explicitly supplies that limit. Do not send `reportWhen`; the current monitor reports every accepted check.
+
+Do not start a second monitor for the same objective while one is active. Update or replace the run only when the objective or contract changes. A replacement must preserve the previous accepted observation and durable recovery state.
+
+## Complete workflow checks
+
+Each workflow check arrives with an exact step contract. Apply the operational authority recorded in `task`. The default monitor contract is recovery-capable autopilot, not read-only observation.
+
+For each check:
+
+1. Query the target's authoritative status.
+2. Query durable progress and final-output surfaces. Run independent reads in parallel when useful.
+3. Compare the current values with the previous accepted observation.
+4. If operation is not nominal, preserve evidence, diagnose the issue, apply the smallest authorized repair, and verify that durable progress resumes. Fix issues and restart Jobs or processes when that is necessary to keep the same objective moving.
+5. Include a concise report for every accepted check. Report absolute totals and meaningful deltas when counters matter.
+6. Select `continue` or `stop` as required by the step contract.
+7. Call `workflow` with `action: "submit"` exactly once, using the supplied step and attempt IDs and the required output shape.
+
+The workflow sends each report as a Pi notification. Notifications do not start a new assistant turn. Do not add a separate assistant reply to a workflow notification.
+
+## Publish progress when measurable
+
+Progress is optional. Do not invent it for work that has no factual count, total, rate, or source estimate.
+
+When the target exposes measurable progress, include one or more tracks in the check output. Use a stable key for each independent process or workstream. Use `overall` for a real aggregate only; do not add unrelated tracks together.
+
+Each track uses `pi-workflows.progress.v1` and can include:
+
+- `status`: `pending`, `running`, `waiting`, `blocked`, `completed`, `failed`, `cancelled`, or `unknown`;
+- `label` and `phase` for short display text and estimation epochs;
+- `completed`, `total`, and `unit` for factual counts;
+- `sourceUpdatedAt` and `sourceEstimatedFinishAt` when the target provides its own fresh estimate.
+
+Submit observed facts. The workflow computes rates, confidence, remaining work, and measured ETA from durable samples. Do not guess a count, rate, or ETA. A changed phase, total, unit, or lower completed count starts a new estimation epoch.
+
+For several concurrent processes, publish one stable track per process. The Pi widget and viewers show them separately and keep each ETA independent.
+
+## Apply finish rules
+
+### Still active
+
+Continue. Keep reports short unless the state changed materially.
+
+### Completed
+
+Stop only after the inferred finish criterion is true. Verify required final artifacts, checksums, receipts, publication state, or downstream health before selecting `stop`.
+
+### Failed, stopped, or blocked
+
+Do not disarm the monitor for a superficial reason. One failed physical Job, command, CI run, deployment attempt, upload, or status read is not the end of the objective. Treat it as an operational event, preserve evidence and durable state, diagnose it, apply the smallest safe repair, restart or resume the same immutable contract, restore nominal operation, and keep monitoring.
+
+Examples of recoverable conditions include transient provider or network errors, platform eviction, rate limits, expired physical attempts, safe checkpoint reconciliation, exact path or configuration mistakes, bounded storage failures, and a stalled deployment that has a documented recovery action.
+
+Stop only for a material blocker, such as:
+
+- a deterministic shared code or data defect that makes further attempts unsafe;
+- an invalid, missing, or unverifiable checkpoint when useful state would be lost;
+- a required credential that has no prior source-and-destination authorization;
+- a changed model, method, source, hardware class, objective, or production decision;
+- a destructive or security-sensitive action outside the recorded authority;
+- a cost, time, or resource ceiling that cannot safely contain the remaining work;
+- evidence that the requested result cannot be made truthful or valid under the current contract.
+
+Never keep paid workers retrying a deterministic shared failure. Contain affected work, report the evidence and ETA impact, and stop for a decision.
+
+### Status unavailable
+
+Retry only a cheap, bounded status read. If the source remains unavailable, report the gap. Continue only when observation remains safe and the finish criterion is not met.
+
+## Check the right surfaces
+
+Depending on the target, inspect:
+
+- Process, Job, workflow, CI, or deployment status.
+- Durable receipts and counters.
+- Checkpoints or partial outputs.
+- Final manifests, databases, publications, or release artifacts.
+- Error state and the freshness of the last durable update.
+
+Logs and progress counters alone do not prove saved work or completion. Prefer durable artifacts and authoritative remote state.
+
+## Stop on user request
+
+When the user asks to stop, cancel the active monitor workflow with `workflow({ action: "cancel" })` and confirm that monitoring stopped. Do not wait for the next scheduled check.
+
+## Status format
+
+For an unchanged active target, prefer a compact report:
+
+```text
+Target remains running:
+- Progress: <absolute total> (<delta since last report>)
+- Cost or resource use: <total>
+- Durable output: <state>
+- Next check: <interval>
+```
+
+Explain anomalies, failures, or approval boundaries when they occur. Avoid repeating the full history at every check.

--- a/skills/pi-workflows/SKILL.md
+++ b/skills/pi-workflows/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: pi-workflows
+description: Use when creating, reviewing, debugging, starting, inspecting, or controlling Pi Workflows; authoring .workflow.ts files; using the workflow tool; handling workflow step contracts, checkpoints, updates, or progress; or deciding how a task should compose workflow primitives.
+compatibility: Requires the Pi Workflows extension.
+---
+
+# Pi Workflows
+
+Use Pi Workflows for durable multi-step work that needs explicit routing, retries, checkpoints, scheduled waits, or progress. Keep simple one-turn work outside a workflow.
+
+The `workflow` tool schema is the authority for call shapes. A workflow step message is the authority for its current step id, attempt id, and expected output. Do not guess these values from an earlier attempt.
+
+## Operate workflows
+
+Use the smallest applicable action:
+
+- `list` discovers available workflows. Use its offset for later pages.
+- `start` starts a discovered workflow name or workflow file path with structured input.
+- `status` reads the active run, or the named run when `runId` is supplied.
+- `pause`, `resume`, and `cancel` control the current active run.
+- `answer` supplies input to a waiting checkpoint.
+- `update` publishes a non-completing durable update for the active step attempt.
+- `submit` completes the active agent step with its required output.
+
+Use `start` only once for one requested run. Do not build a manual polling loop around a workflow that already schedules its own work. Use the `monitor` skill for monitoring requests.
+
+## Complete agent steps
+
+When a workflow step message arrives:
+
+1. Do the requested work with the available tools.
+2. Produce output that matches the exact expected shape.
+3. Call `workflow` with `action: "submit"` exactly once, using the step and attempt ids from that message.
+4. If validation rejects the output, correct it and submit again with the same current ids.
+5. After acceptance, end the turn. The workflow sends the next step or presentation message when needed.
+
+A node id can run more than once in a loop. Each run has a new attempt id. Never reuse an attempt id from conversation history.
+
+## Publish updates and progress
+
+Use `update` only while the named step attempt is active. An update does not complete the step and does not control routing.
+
+For progress, publish `pi-workflows.progress.v1` data with stable track keys. Report observed counts and source-provided estimates. Do not invent totals, rates, confidence, or completion times. Use separate keys for concurrent processes and send explicit terminal states before a track disappears.
+
+The workflow definition should publish progress from function and shell actions when the runtime already has exact counts. Do not add an agent step only to format data that code can publish directly.
+
+Read [../../docs/WORKFLOW_UPDATES.md](../../docs/WORKFLOW_UPDATES.md) before adding update producers or progress estimation.
+
+## Author workflows
+
+A workflow is a `.workflow.ts`, `.workflow.js`, `.workflow.mts`, or `.workflow.mjs` module whose default export comes from `defineWorkflow(...)`.
+
+Follow these rules:
+
+- Compose the existing node and edge primitives before adding a new primitive.
+- Keep `compute` pure. Put external effects in agent, function-action, or shell-action nodes.
+- Use structured node outputs for routing.
+- Use a checkpoint when progress requires human input.
+- Set explicit step and command timeouts.
+- Bound ordinary loops with `maxSteps` or another clear finish rule.
+- Use a controller instead of a workflow for indefinite resource reconciliation.
+- Keep presentation separate from execution. Use `presentationPrompt` only when a final assistant response is needed.
+- Preserve the single active workflow rule in one Pi session.
+
+Read [../../docs/workflows.md](../../docs/workflows.md) before creating or changing a workflow. Read [../../docs/DESIGN_PHILOSOPHY.md](../../docs/DESIGN_PHILOSOPHY.md) before adding public primitives. Use the examples under [../../examples/workflows](../../examples/workflows) as starting points.
+
+## Verify changes
+
+For workflow definitions, test success, failure, routing, retries or loops, checkpoints, timeouts, cancellation, and resume behavior that applies.
+
+For extension or engine changes, run the repository checks and the real-Pi end-to-end suite. Verify discovery through the installed package path rather than only loading the source extension file.

--- a/test/e2e/package-resources.e2e.test.ts
+++ b/test/e2e/package-resources.e2e.test.ts
@@ -1,0 +1,173 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const piBin = path.join(repoRoot, "node_modules", ".bin", "pi");
+const tempDirs: string[] = [];
+
+type CommandInfo = {
+  name: string;
+  sourceInfo?: { path?: string };
+};
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-workflows-package-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function getCommands(args: string[], tempDir: string): Promise<CommandInfo[]> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        piBin,
+        "--mode",
+        "rpc",
+        "--no-session",
+        "--offline",
+        "--no-context-files",
+        "--no-themes",
+        "--no-prompt-templates",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-4o-mini",
+        ...args,
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: tempDir,
+          PI_CODING_AGENT_DIR: path.join(tempDir, "agent"),
+          PI_OFFLINE: "1",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Pi package discovery timed out.\n${stderr}`));
+    }, 30_000);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`Pi package discovery exited with ${code}.\n${stderr}\n${stdout}`));
+        return;
+      }
+
+      const responses = stdout
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      const response = responses.find(
+        (entry) => entry.type === "response" && entry.command === "get_commands",
+      ) as { data?: { commands?: CommandInfo[] } } | undefined;
+      if (!response?.data?.commands) {
+        reject(new Error(`Pi did not return get_commands.\n${stderr}\n${stdout}`));
+        return;
+      }
+      resolve(response.data.commands);
+    });
+
+    child.stdin.end(`${JSON.stringify({ type: "get_commands" })}\n`);
+  });
+}
+
+function command(commands: CommandInfo[], name: string): CommandInfo | undefined {
+  return commands.find((entry) => entry.name === name);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe.sequential("Pi package resource discovery", () => {
+  it("discovers the extension and both bundled skills from the package", async () => {
+    const tempDir = await makeTempDir();
+    const commands = await getCommands(["-e", repoRoot], tempDir);
+
+    expect(command(commands, "workflow")?.sourceInfo?.path).toBe(
+      path.join(repoRoot, "src", "extension", "index.ts"),
+    );
+    expect(command(commands, "skill:monitor")?.sourceInfo?.path).toBe(
+      path.join(repoRoot, "skills", "monitor", "SKILL.md"),
+    );
+    expect(command(commands, "skill:pi-workflows")?.sourceInfo?.path).toBe(
+      path.join(repoRoot, "skills", "pi-workflows", "SKILL.md"),
+    );
+  });
+
+  it("can disable one bundled skill without disabling the extension", async () => {
+    const tempDir = await makeTempDir();
+    const agentDir = path.join(tempDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "settings.json"),
+      `${JSON.stringify(
+        {
+          packages: [{ source: repoRoot, skills: ["-skills/monitor"] }],
+        },
+        undefined,
+        2,
+      )}\n`,
+    );
+
+    const commands = await getCommands([], tempDir);
+
+    expect(command(commands, "workflow")).toBeDefined();
+    expect(command(commands, "skill:pi-workflows")).toBeDefined();
+    expect(command(commands, "skill:monitor")).toBeUndefined();
+  });
+
+  it("can disable all bundled skills without disabling the extension", async () => {
+    const tempDir = await makeTempDir();
+    const agentDir = path.join(tempDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "settings.json"),
+      `${JSON.stringify({ packages: [{ source: repoRoot, skills: [] }] }, undefined, 2)}\n`,
+    );
+
+    const commands = await getCommands([], tempDir);
+
+    expect(command(commands, "workflow")).toBeDefined();
+    expect(command(commands, "skill:pi-workflows")).toBeUndefined();
+    expect(command(commands, "skill:monitor")).toBeUndefined();
+  });
+
+  it("can disable the extension without disabling bundled skills", async () => {
+    const tempDir = await makeTempDir();
+    const agentDir = path.join(tempDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "settings.json"),
+      `${JSON.stringify({ packages: [{ source: repoRoot, extensions: [] }] }, undefined, 2)}\n`,
+    );
+
+    const commands = await getCommands([], tempDir);
+
+    expect(command(commands, "workflow")).toBeUndefined();
+    expect(command(commands, "skill:pi-workflows")).toBeDefined();
+    expect(command(commands, "skill:monitor")).toBeDefined();
+  });
+});

--- a/test/package-resources.test.ts
+++ b/test/package-resources.test.ts
@@ -85,6 +85,13 @@ describe("Pi package resources", () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  it("does not grant paid-compute approval through the monitor skill", async () => {
+    const markdown = await fs.readFile(path.join(skillsRoot, "monitor", "SKILL.md"), "utf8");
+
+    expect(markdown).toContain("A monitoring request does not grant spending approval");
+    expect(markdown).not.toContain("grants a default cumulative spending ceiling");
+  });
+
   it("keeps local references in the workflow skill inside the package", async () => {
     const skillPath = path.join(skillsRoot, "pi-workflows", "SKILL.md");
     const markdown = await fs.readFile(skillPath, "utf8");

--- a/test/package-resources.test.ts
+++ b/test/package-resources.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const packageJsonPath = path.join(repoRoot, "package.json");
+const skillsRoot = path.join(repoRoot, "skills");
+
+interface PackageManifest {
+  files?: string[];
+  pi?: {
+    extensions?: string[];
+    skills?: string[];
+  };
+}
+
+function parseFrontmatter(markdown: string): Map<string, string> {
+  const match = /^---\n([\s\S]*?)\n---(?:\n|$)/u.exec(markdown);
+  if (!match) return new Map();
+
+  const body = match[1];
+  if (body === undefined) return new Map();
+
+  return new Map(
+    body
+      .split("\n")
+      .map((line) => {
+        const separator = line.indexOf(":");
+        if (separator < 0) return undefined;
+        return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()] as const;
+      })
+      .filter((entry): entry is readonly [string, string] => entry !== undefined),
+  );
+}
+
+async function skillFiles(): Promise<string[]> {
+  const entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(skillsRoot, entry.name, "SKILL.md"))
+    .sort();
+}
+
+describe("Pi package resources", () => {
+  it("publishes the extension and skill directory", async () => {
+    const manifest = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as PackageManifest;
+
+    expect(manifest.files).toContain("skills");
+    expect(manifest.pi?.extensions).toEqual(["./src/extension/index.ts"]);
+    expect(manifest.pi?.skills).toEqual(["./skills"]);
+
+    const extensionPath = manifest.pi?.extensions?.[0];
+    const skillPath = manifest.pi?.skills?.[0];
+    if (extensionPath === undefined || skillPath === undefined) {
+      throw new Error("Pi package resources are missing from package.json.");
+    }
+    await expect(fs.stat(path.join(repoRoot, extensionPath))).resolves.toBeDefined();
+    await expect(fs.stat(path.join(repoRoot, skillPath))).resolves.toBeDefined();
+  });
+
+  it("ships valid uniquely named skills", async () => {
+    const files = await skillFiles();
+    expect(files.map((file) => path.relative(skillsRoot, file))).toEqual([
+      "monitor/SKILL.md",
+      "pi-workflows/SKILL.md",
+    ]);
+
+    const names: string[] = [];
+    for (const file of files) {
+      const markdown = await fs.readFile(file, "utf8");
+      const frontmatter = parseFrontmatter(markdown);
+      const name = frontmatter.get("name");
+      const description = frontmatter.get("description");
+
+      expect(name).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u);
+      expect(description?.length).toBeGreaterThan(0);
+      if (name === undefined || description === undefined) {
+        throw new Error(`${file} has incomplete frontmatter.`);
+      }
+      expect(description.length).toBeLessThanOrEqual(1024);
+      names.push(name);
+    }
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("keeps local references in the workflow skill inside the package", async () => {
+    const skillPath = path.join(skillsRoot, "pi-workflows", "SKILL.md");
+    const markdown = await fs.readFile(skillPath, "utf8");
+    const links = [...markdown.matchAll(/\[[^\]]+\]\((\.\.\/\.\.\/[^)]+)\)/gu)]
+      .map((match) => match[1])
+      .filter((link): link is string => link !== undefined);
+
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      await expect(fs.stat(path.resolve(path.dirname(skillPath), link))).resolves.toBeDefined();
+    }
+  });
+});

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Pi Workflows should teach agents how to use the extension when the package is installed.
This change bundles a general `pi-workflows` skill and moves the `monitor` skill beside the workflow that it controls.
Pi's normal package filters can disable one skill, all skills, or the extension independently.

## What Changed

The npm package now owns and publishes its extension guidance.
The detailed skill content stays optional, while the workflow tool and step messages keep their small call contracts.

- Added `skills/pi-workflows/SKILL.md` for tool operation, step contracts, updates, progress, and workflow authoring.
- Moved the current monitor operating policy to `skills/monitor/SKILL.md`.
- Declared `skills/` in the npm files list and Pi package manifest.
- Documented resource filtering through `pi config` and package settings.
- Added manifest and real-Pi discovery tests, including independent resource disable cases.
- Prepared npm and crates.io version `0.7.0` under the repository's shared release tag.

## Testing

The full TypeScript, real-Pi, package, Slophammer, and Rust checks pass.
A packed npm artifact was installed into a temporary directory and the real Pi RPC runtime discovered the extension and both skills from that installed artifact.

- `npm run check` — 46 files and 713 tests passed with coverage thresholds.
- `npm run test:e2e` — 2 files and 11 real-Pi tests passed.
- `npx slophammer-ts@latest dry .` — no candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — no findings.
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml` — 59 tests passed.
- `cargo publish --manifest-path tui/Cargo.toml --dry-run`
- `npm pack --dry-run --json` — both `SKILL.md` files included.

`npx -y @simpledoc/simpledoc check` still reports the repository's existing ten-file naming and frontmatter migration backlog. The new dated plan follows the current SimpleDoc convention.

## Risks

The runtime behavior and persisted workflow formats do not change.
The main risk is skill-name collision with an existing user skill; Pi keeps its normal precedence rules and lets users disable package skills.

- No Pi core or private API changes.
- No new session entries or persistent data.
- No workflow schema changes.