### PR TITLE
feat: add durable job progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ structured, validated output to route on. See the
 [design philosophy](docs/DESIGN_PHILOSOPHY.md) for the principles behind the
 engine and its public parts. Running steps can publish durable [workflow
 updates](docs/WORKFLOW_UPDATES.md), including progress counts and ETA data.
-Agent instructions use compact [workflow step
-messages](docs/WORKFLOW_STEP_MESSAGES.md), and the built-in
+Remote workers can publish the same tracks through the storage-neutral
+[durable job progress API](docs/JOB_PROGRESS.md). Agent instructions use compact
+[workflow step messages](docs/WORKFLOW_STEP_MESSAGES.md), and the built-in
 [monitor](docs/MONITOR.md) reports every check without starting an extra
 assistant turn.
 

--- a/docs/JOB_PROGRESS.md
+++ b/docs/JOB_PROGRESS.md
@@ -1,0 +1,107 @@
+# Durable job progress
+
+`@osolmaz/pi-workflows/job-progress` lets a remote job publish progress that a Pi Workflows monitor can validate and measure. It uses the existing `pi-workflows.progress.v1` track contract and ETA estimator.
+
+## Report progress
+
+Create one reporter for one physical job. Inject the storage write so the package remains independent of a cloud provider.
+
+```ts
+import { createJobProgressReporter } from "@osolmaz/pi-workflows/job-progress";
+
+const reporter = createJobProgressReporter({
+  application: "example",
+  component: "batch-worker",
+  jobId: process.env.JOB_ID ?? "local",
+  sourceRevision: "abc123",
+  contractHash: "def456",
+  startedAt: new Date().toISOString(),
+  minimumIntervalMs: 30_000,
+  publishTimeoutMs: 15_000,
+  publish: async (snapshot, signal) => {
+    await bucket.writeText(progressPath, JSON.stringify(snapshot), { signal });
+  },
+});
+
+await reporter.report({
+  phase: "processing",
+  tracks: [
+    {
+      key: "records",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        status: "running",
+        phase: "processing",
+        completed: 400,
+        total: 1_000,
+        unit: "records",
+      },
+    },
+  ],
+});
+```
+
+The first update, each phase change, and each terminal update publishes immediately. Other updates are coalesced until `minimumIntervalMs` has passed. Call `flush()` at a durable checkpoint or before exit when the current snapshot has not been published.
+
+The reporter keeps the latest snapshot after a write failure. The application decides when to log and retry that failure. A progress failure must not replace receipt or checkpoint validation.
+
+## Finish a job
+
+A terminal update gets a finish timestamp and publishes immediately:
+
+```ts
+await reporter.report({
+  state: "completed",
+  phase: "complete",
+  tracks: [
+    {
+      key: "records",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        status: "completed",
+        phase: "complete",
+        completed: 1_000,
+        total: 1_000,
+        unit: "records",
+      },
+    },
+  ],
+});
+```
+
+A terminal snapshot is not a receipt. Receipts, manifests, hashes, and durable application outputs remain authoritative.
+
+## Store and discover snapshots
+
+Write one mutable snapshot per physical job:
+
+```text
+<existing-bucket>/<application-prefix>/runs/<job-id>/progress.json
+```
+
+Add these immutable labels to the job or schedule:
+
+```text
+progress_schema=pi-workflows.job-progress.v1
+progress_bucket=<existing-bucket>
+progress_prefix=<application-prefix>/runs
+```
+
+A monitor reads the labels, forms `<progress_prefix>/<job-id>/progress.json`, validates the snapshot with `validateJobProgressSnapshot`, and publishes its tracks with stable keys. It should retain consecutive snapshots so Pi Workflows can estimate a conservative ETA from measured rates.
+
+## Estimate from snapshots
+
+```ts
+import { estimateJobProgress } from "@osolmaz/pi-workflows/job-progress";
+
+const result = estimateJobProgress(previousSnapshots);
+for (const estimate of result.estimates) {
+  console.log(estimate.key, estimate.remainingMedianMs);
+}
+```
+
+The estimator returns no measured ETA until a track has a known total and enough positive progress samples. A source-provided `sourceEstimatedFinishAt` remains available through the normal progress contract.
+
+## Data boundary
+
+Snapshots may contain identifiers, phases, counters, totals, timestamps, and cost totals. Do not put credentials, environment values, input records, model responses, logs, or private content in a snapshot. The strict validator rejects unknown fields and limits the encoded snapshot to 64 KiB.

--- a/docs/JOB_PROGRESS.md
+++ b/docs/JOB_PROGRESS.md
@@ -16,6 +16,16 @@ const reporter = createJobProgressReporter({
   sourceRevision: "abc123",
   contractHash: "def456",
   startedAt: new Date().toISOString(),
+  initialTracks: [
+    {
+      key: "overall",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        status: "running",
+        phase: "starting",
+      },
+    },
+  ],
   minimumIntervalMs: 30_000,
   publishTimeoutMs: 15_000,
   publish: async (snapshot, signal) => {

--- a/docs/JOB_PROGRESS.md
+++ b/docs/JOB_PROGRESS.md
@@ -43,7 +43,9 @@ await reporter.report({
 
 The first update, each phase change, and each terminal update publishes immediately. Other updates are coalesced until `minimumIntervalMs` has passed. Call `flush()` at a durable checkpoint or before exit when the current snapshot has not been published.
 
-The reporter keeps the latest snapshot after a write failure. The application decides when to log and retry that failure. A progress failure must not replace receipt or checkpoint validation.
+On process restart, read and validate the existing snapshot and pass it as `previousSnapshot`. The reporter continues its sequence number and rejects an identity, deadline, or terminal-state mismatch.
+
+The reporter keeps the latest snapshot after a write failure. The application decides when to log and retry that failure. A timed-out storage write remains serialized until the underlying write settles, so an older write cannot overwrite a newer snapshot. Storage adapters must honor the abort signal and settle after cancellation. A progress failure must not replace receipt or checkpoint validation.
 
 ## Finish a job
 

--- a/docs/MONITOR.md
+++ b/docs/MONITOR.md
@@ -242,6 +242,11 @@ One monitor can track several processes. Each uses a stable progress key. A miss
 
 The progress estimator treats each key independently. A phase, unit, total, or counter reset in one track does not reset another track.
 
+Remote Jobs can publish the same tracks in a strict
+[`pi-workflows.job-progress.v1` snapshot](JOB_PROGRESS.md). A monitor discovers
+the snapshot from immutable Job labels, validates its identity, and submits its
+tracks without copying log-derived guesses into progress fields.
+
 ## Interval and lifetime
 
 The normal workflow engine remains finite. The built-in monitor therefore retains the 1,000-check safety ceiling and must not claim to be mathematically unbounded.

--- a/docs/plans/2026-08-17-durable-job-progress-plan.md
+++ b/docs/plans/2026-08-17-durable-job-progress-plan.md
@@ -1,0 +1,176 @@
+# Durable job progress
+
+## Problem
+
+Long-running remote jobs can expose state only through logs and final receipts. A monitor can confirm that a job is running, but it cannot give a reliable progress value or remaining time when the job does not publish a completed count, a total, and source timestamps.
+
+xTap Pool and OurModels need the same durable progress contract. The contract must work with their existing Hugging Face Buckets, survive worker restarts, and use the ETA estimator that Pi Workflows already uses for `pi-workflows.progress.v1` tracks.
+
+## Requirements
+
+The implementation must:
+
+- add one storage-neutral job progress API to `@osolmaz/pi-workflows`
+- reuse `pi-workflows.progress.v1` for progress tracks
+- write one mutable snapshot for each physical job in the application's existing Bucket
+- let monitors discover the snapshot from immutable job labels
+- let Pi Workflows validate the snapshot and estimate remaining time from repeated samples
+- let xTap Pool report restore, review, recovery, and publication progress
+- let OurModels report discovery, processing, cache, and publication progress
+- keep receipts, content hashes, manifests, and databases authoritative
+- avoid secrets, post text, model output, and other private content in progress snapshots
+- preserve one physical enrichment job at a time during the xTap Pool change
+- leave the OurModels replacement schedule suspended until a paid run is separately approved
+
+## Non-goals
+
+This work does not add:
+
+- a new remote store
+- a metrics database
+- a second ETA protocol
+- a Pi core change
+- a service or daemon
+- a compatibility path for an older snapshot schema
+- automatic authority to retry, deploy, publish, or spend money
+
+## Public contract
+
+The npm package exports a new subpath:
+
+```ts
+import {
+  createJobProgressReporter,
+  estimateJobProgress,
+  validateJobProgressSnapshot,
+  type JobProgressSnapshot,
+} from "@osolmaz/pi-workflows/job-progress";
+```
+
+A snapshot has schema `pi-workflows.job-progress.v1` and contains:
+
+- stable application and component names
+- the physical job identifier
+- source and work-contract identifiers
+- a monotonic sequence number
+- job state and current phase
+- start, update, optional deadline, and optional finish timestamps
+- one or more keyed `pi-workflows.progress.v1` tracks
+- optional settled cost and active reservation facts
+
+The validator is strict. It rejects unknown fields, duplicate track keys, invalid timestamps, non-finite values, invalid progress tracks, and oversized snapshots.
+
+The reporter accepts an injected asynchronous `publish(snapshot)` callback. Pi Workflows does not import a Hugging Face client. The reporter:
+
+- keeps sequence numbers monotonic within the process
+- rejects regressions within one phase and epoch
+- coalesces frequent updates with a configurable minimum interval
+- flushes phase changes and terminal states immediately
+- bounds publication time with an abort deadline
+- preserves the most recent unsent snapshot after a transient publication failure
+- never includes arbitrary metadata or environment values
+
+A terminal snapshot is operational evidence only. The application's receipt and durable output validation still decide whether work succeeded.
+
+## Storage and discovery
+
+Each application writes snapshots to its existing Bucket.
+
+xTap Pool uses:
+
+```text
+osolmaz/xtap-pool-bucket/operations/enrichment/runs/<job-id>/progress.json
+```
+
+OurModels uses:
+
+```text
+osolmaz/ourmodels-data/<prefix>/operations/community-posts/runs/<job-id>/progress.json
+```
+
+Each schedule supplies these immutable labels:
+
+```text
+progress_schema=pi-workflows.job-progress.v1
+progress_bucket=<bucket>
+progress_prefix=<path-before-job-id>
+```
+
+A monitor reads the labels, appends the physical job identifier and `progress.json`, reads the snapshot with existing local Hugging Face authentication, validates it, and publishes each track under a stable workflow progress key. The monitor does not trust an ETA string from logs. It uses source finish time when the snapshot provides one, or the existing conservative estimator after enough measured samples.
+
+## xTap Pool tracks
+
+The enrichment worker reports these stable tracks when facts are measurable:
+
+| Key                | Unit       | Source                                             |
+| ------------------ | ---------- | -------------------------------------------------- |
+| `database-restore` | bytes      | downloaded database bytes and expected object size |
+| `registry-replay`  | events     | replayed registry events and discovered total      |
+| `registry-scan`    | candidates | durable scan cursor and fixed candidate total      |
+| `queue`            | records    | terminal records and durable queue total           |
+| `publication`      | bytes      | uploaded and verified database bytes               |
+| `overall`          | phases     | completed phases and fixed phase count             |
+
+Phase-only states remain valid when a total is not yet known. The worker must not invent totals.
+
+The existing three unresolved records must receive durable outcomes under the fixed full-response deadline or become exactly validated blocked records. The worker then publishes and verifies the index before its final receipt is accepted.
+
+## OurModels tracks
+
+The community-posts worker reports these stable tracks when facts are measurable:
+
+| Key               | Unit    | Source                                          |
+| ----------------- | ------- | ----------------------------------------------- |
+| `model-discovery` | models  | discovered and inspected model count            |
+| `community-posts` | models  | processed models and fixed discovered total     |
+| `cache`           | records | durable cached model results and expected total |
+| `publication`     | bytes   | uploaded and verified artifact bytes            |
+| `overall`         | phases  | completed phases and fixed phase count          |
+
+The worker continues to use its existing receipt and manifest rules. A progress write failure must not corrupt a useful checkpoint or published result.
+
+## Delivery sequence
+
+1. Add and release `@osolmaz/pi-workflows/job-progress` as version `0.8.0`.
+2. Add snapshot discovery guidance to the bundled monitor skill.
+3. Update xTap Pool to use `0.8.0`, add measured callbacks, and add schedule labels.
+4. Merge and deploy xTap Pool, then replace the old suspended schedule.
+5. End the old physical job only when the replacement source is ready and the one-job rule can be preserved.
+6. Start one instrumented xTap Pool recovery job under the existing restoration budget.
+7. Update OurModels to use `0.8.0`, add measured callbacks, and replace old schedules with one suspended instrumented schedule.
+8. Do not start a paid OurModels run until its measured cost range and ceiling receive the required approval.
+9. Start a Pi monitor that reads both progress surfaces and displays current progress and ETA.
+
+## Acceptance checks
+
+Pi Workflows must pass:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+```
+
+Tests must cover strict validation, unknown fields, duplicate keys, monotonic updates, phase resets, coalescing, transient publication failure, deadline abort, terminal flush, and ETA estimation from snapshots.
+
+xTap Pool must pass its repository checks, including mutation testing. A live recovery must show a valid snapshot in the existing index Bucket, and repeated monitor samples must produce a measured ETA when a track has a known total and positive progress.
+
+OurModels must pass:
+
+```bash
+npm run check
+npm run coverage
+npm run dry
+npm run mutate
+node scripts/test-bounds-engine.mjs
+node scripts/validate-model-data.mjs
+```
+
+Its replacement schedule must remain suspended with only the approved two secrets until a paid run is authorized.
+
+## Recovery
+
+If a progress publication fails, the worker keeps useful work and retries only the latest snapshot at the next bounded update. If the job ends before that succeeds, the receipt and durable outputs remain authoritative and the monitor marks progress stale.
+
+If a repeated deterministic worker defect appears, stop the affected job and schedule. Preserve all existing Bucket objects and return the exact failing phase, source revision, snapshot, receipt state, and last valid durable outputs.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -369,6 +369,16 @@ and resume later by running that wait again from the beginning.
 A monitor uses the session's single active workflow slot. It does not provide
 cron syntax, calendar scheduling, OS notifications, or a background service.
 
+### Durable remote Job progress
+
+Remote workers can publish the same progress tracks through
+`@osolmaz/pi-workflows/job-progress`. The storage-neutral reporter writes a
+strict, versioned snapshot through an application-supplied callback. A monitor
+can read consecutive snapshots from an existing remote store and use the normal
+progress estimator without treating logs as durable state. See
+[JOB_PROGRESS.md](JOB_PROGRESS.md) for the API, snapshot schema, restart rules,
+and discovery labels.
+
 ## The step contract
 
 Every `agent` prompt ends with a step contract block naming the workflow, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"
@@ -39,6 +39,10 @@
     "./controllers": {
       "types": "./dist/controllers/index.d.ts",
       "default": "./dist/controllers/index.js"
+    },
+    "./job-progress": {
+      "types": "./dist/job-progress/index.d.ts",
+      "default": "./dist/job-progress/index.js"
     }
   },
   "publishConfig": {

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -95,6 +95,18 @@ Submit observed facts. The workflow computes rates, confidence, remaining work, 
 
 For several concurrent processes, publish one stable track per process. The Pi widget and viewers show them separately and keep each ETA independent.
 
+### Read durable job snapshots
+
+A remote job can advertise a `pi-workflows.job-progress.v1` snapshot with these immutable labels:
+
+- `progress_schema=pi-workflows.job-progress.v1`
+- `progress_bucket=<existing-bucket>`
+- `progress_prefix=<path-before-job-id>`
+
+When these labels exist, form `<progress_prefix>/<physical-job-id>/progress.json`, read it from the named existing store with an already authorized credential, and validate it with the installed `@osolmaz/pi-workflows/job-progress` API. Reject a snapshot whose job ID, source revision, or work-contract identity does not match the observed Job. Do not follow a path or credential named inside unvalidated data.
+
+Publish the snapshot tracks under stable keys. Preserve consecutive samples so the workflow can estimate ETA from measured progress. Treat a stale or missing snapshot as unavailable progress, not as proof that the Job stopped. Receipts, hashes, manifests, and final outputs remain the completion evidence.
+
 ## Apply finish rules
 
 ### Still active

--- a/src/job-progress/index.ts
+++ b/src/job-progress/index.ts
@@ -1,0 +1,24 @@
+export {
+  createJobProgressReporter,
+  estimateJobProgress,
+  type JobProgressReporter,
+} from "./reporter.js";
+export {
+  isTerminalJobProgressState,
+  MAX_JOB_PROGRESS_BYTES,
+  MAX_JOB_PROGRESS_TRACKS,
+  validateJobProgressSnapshot,
+} from "./validation.js";
+export {
+  JOB_PROGRESS_SCHEMA,
+  type JobProgressCost,
+  type JobProgressEstimate,
+  type JobProgressIdentity,
+  type JobProgressPublish,
+  type JobProgressPublishResult,
+  type JobProgressReporterOptions,
+  type JobProgressSnapshot,
+  type JobProgressState,
+  type JobProgressTrack,
+  type JobProgressUpdate,
+} from "./types.js";

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -124,8 +124,8 @@ export function estimateJobProgress(
   const validated = snapshots.map(validateJobProgressSnapshot);
   const latest = validated.at(-1) as JobProgressSnapshot;
   for (const snapshot of validated) assertSameIdentity(latest, snapshot);
-  const keys = new Set(validated.flatMap((snapshot) => snapshot.tracks.map((track) => track.key)));
-  const tracks: ProgressTrackState[] = [...keys].map((key) => {
+  const keys = latest.tracks.map((track) => track.key);
+  const tracks: ProgressTrackState[] = keys.map((key) => {
     const samples: ProgressSample[] = validated.flatMap((snapshot) => {
       const track = snapshot.tracks.find((candidate) => candidate.key === key);
       return track === undefined ? [] : [{ at: snapshot.updatedAt, data: track.data }];

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -35,7 +35,7 @@ export function createJobProgressReporter(
     options.publishTimeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS,
     "publishTimeoutMs",
   );
-  let current = validateJobProgressSnapshot({
+  const initial = validateJobProgressSnapshot({
     schema: JOB_PROGRESS_SCHEMA,
     application: options.application,
     component: options.component,
@@ -50,6 +50,10 @@ export function createJobProgressReporter(
     ...(options.deadlineAt === undefined ? {} : { deadlineAt: options.deadlineAt }),
     tracks: options.initialTracks ?? [],
   });
+  let current =
+    options.previousSnapshot === undefined
+      ? initial
+      : validatePreviousSnapshot(initial, options.previousSnapshot);
   let lastQueuedAtMs = Number.NEGATIVE_INFINITY;
   let lastQueuedSequence = -1;
   let lastPublishedSequence = -1;
@@ -62,12 +66,15 @@ export function createJobProgressReporter(
     }
     lastQueuedAtMs = Date.parse(snapshot.updatedAt);
     lastQueuedSequence = snapshot.sequence;
-    const operation = tail.then(async () => {
-      await publishWithDeadline(options.publish, cloneSnapshot(snapshot), publishTimeoutMs);
+    const started = tail.then(() =>
+      startPublication(options.publish, cloneSnapshot(snapshot), publishTimeoutMs),
+    );
+    const operation = started.then(async (publication) => {
+      await publication.result;
       lastPublishedSequence = Math.max(lastPublishedSequence, snapshot.sequence);
     });
     queuedOperation = operation;
-    tail = operation.catch(() => undefined);
+    tail = started.then((publication) => publication.settled).catch(() => undefined);
     void operation
       .finally(() => {
         if (lastQueuedSequence === snapshot.sequence) {
@@ -192,24 +199,45 @@ function assertSameIdentity(expected: JobProgressSnapshot, actual: JobProgressSn
   }
 }
 
-async function publishWithDeadline(
+function startPublication(
   publish: JobProgressReporterOptions["publish"],
   snapshot: JobProgressSnapshot,
   timeoutMs: number,
-): Promise<void> {
+): { result: Promise<void>; settled: Promise<void> } {
   const controller = new AbortController();
   let timeout: NodeJS.Timeout | undefined;
+  const write = publish(snapshot, controller.signal);
   const deadline = new Promise<never>((_resolve, reject) => {
     timeout = setTimeout(() => {
       controller.abort();
       reject(new Error(`job progress publication timed out after ${timeoutMs} ms`));
     }, timeoutMs);
   });
-  try {
-    await Promise.race([publish(snapshot, controller.signal), deadline]);
-  } finally {
+  const result = Promise.race([write, deadline]).finally(() => {
     if (timeout !== undefined) clearTimeout(timeout);
+  });
+  return {
+    result,
+    settled: write.then(
+      () => undefined,
+      () => undefined,
+    ),
+  };
+}
+
+function validatePreviousSnapshot(
+  initial: JobProgressSnapshot,
+  previous: JobProgressSnapshot,
+): JobProgressSnapshot {
+  const validated = validateJobProgressSnapshot(previous);
+  assertSameIdentity(initial, validated);
+  if (isTerminalJobProgressState(validated.state)) {
+    throw new Error("job progress cannot resume from a terminal snapshot");
   }
+  if (initial.deadlineAt !== validated.deadlineAt) {
+    throw new Error("job progress previous snapshot deadlineAt does not match");
+  }
+  return validated;
 }
 
 function cloneSnapshot(snapshot: JobProgressSnapshot): JobProgressSnapshot {

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -146,9 +146,21 @@ export function estimateJobProgress(
 ): JobProgressEstimate {
   if (snapshots.length === 0)
     throw new Error("job progress estimation requires at least one snapshot");
-  const validated = snapshots.map(validateJobProgressSnapshot);
+  const validated = snapshots
+    .map(validateJobProgressSnapshot)
+    .sort((left, right) => left.sequence - right.sequence);
   const latest = validated.at(-1) as JobProgressSnapshot;
   for (const snapshot of validated) assertSameIdentity(latest, snapshot);
+  for (let index = 1; index < validated.length; index += 1) {
+    const previous = validated[index - 1] as JobProgressSnapshot;
+    const current = validated[index] as JobProgressSnapshot;
+    if (previous.sequence === current.sequence) {
+      throw new Error(`job progress sequence ${current.sequence} is duplicated`);
+    }
+    if (Date.parse(previous.updatedAt) > Date.parse(current.updatedAt)) {
+      throw new Error("job progress updatedAt must not decrease as sequence increases");
+    }
+  }
   const keys = latest.tracks.map((track) => track.key);
   const tracks: ProgressTrackState[] = keys.map((key) => {
     const samples: ProgressSample[] = validated.flatMap((snapshot) => {

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -100,13 +100,16 @@ export function createJobProgressReporter(
       const finishedAt = isTerminalJobProgressState(state)
         ? (update.finishedAt ?? timestamp)
         : update.finishedAt;
+      const tracks = isTerminalJobProgressState(state)
+        ? terminalizeTracks(update.tracks ?? current.tracks, state)
+        : (update.tracks ?? current.tracks);
       const next = validateJobProgressSnapshot({
         ...current,
         sequence: current.sequence + 1,
         state,
         phase,
         updatedAt: timestamp,
-        tracks: update.tracks ?? current.tracks,
+        tracks,
         ...(update.cost === undefined ? {} : { cost: update.cost }),
         ...(finishedAt === undefined ? {} : { finishedAt }),
       });
@@ -159,6 +162,24 @@ export function estimateJobProgress(
     tracks,
     estimates: tracks.map((track) => track.estimate),
   };
+}
+
+function terminalizeTracks(
+  tracks: JobProgressTrack[],
+  state: "completed" | "failed" | "cancelled",
+): JobProgressTrack[] {
+  return tracks.map((track) => ({
+    key: track.key,
+    data: {
+      ...track.data,
+      status:
+        track.data.status === "completed" ||
+        track.data.status === "failed" ||
+        track.data.status === "cancelled"
+          ? track.data.status
+          : state,
+    },
+  }));
 }
 
 function assertMonotonicTracks(previous: JobProgressSnapshot, next: JobProgressSnapshot): void {

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -53,9 +53,10 @@ export function createJobProgressReporter(
           tracks: options.initialTracks,
         })
       : validatePreviousSnapshot(options, options.previousSnapshot);
-  let lastQueuedAtMs = Number.NEGATIVE_INFINITY;
+  const resumed = options.previousSnapshot !== undefined;
+  let lastQueuedAtMs = resumed ? Date.parse(current.updatedAt) : Number.NEGATIVE_INFINITY;
   let lastQueuedSequence = -1;
-  let lastPublishedSequence = -1;
+  let lastPublishedSequence = resumed ? current.sequence : -1;
   let queuedOperation: Promise<void> | undefined;
   let tail: Promise<void> = Promise.resolve();
 

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -1,0 +1,216 @@
+import {
+  estimateProgress,
+  type ProgressSample,
+  type ProgressTrackState,
+} from "../workflows/index.js";
+import {
+  JOB_PROGRESS_SCHEMA,
+  type JobProgressEstimate,
+  type JobProgressPublishResult,
+  type JobProgressReporterOptions,
+  type JobProgressSnapshot,
+  type JobProgressTrack,
+  type JobProgressUpdate,
+} from "./types.js";
+import { isTerminalJobProgressState, validateJobProgressSnapshot } from "./validation.js";
+
+const DEFAULT_MINIMUM_INTERVAL_MS = 30_000;
+const DEFAULT_PUBLISH_TIMEOUT_MS = 15_000;
+
+export type JobProgressReporter = {
+  report(update: JobProgressUpdate): Promise<JobProgressPublishResult>;
+  flush(): Promise<JobProgressPublishResult>;
+  snapshot(): JobProgressSnapshot;
+};
+
+export function createJobProgressReporter(
+  options: JobProgressReporterOptions,
+): JobProgressReporter {
+  const now = options.now ?? (() => new Date());
+  const minimumIntervalMs = nonNegativeInteger(
+    options.minimumIntervalMs ?? DEFAULT_MINIMUM_INTERVAL_MS,
+    "minimumIntervalMs",
+  );
+  const publishTimeoutMs = positiveInteger(
+    options.publishTimeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS,
+    "publishTimeoutMs",
+  );
+  let current = validateJobProgressSnapshot({
+    schema: JOB_PROGRESS_SCHEMA,
+    application: options.application,
+    component: options.component,
+    jobId: options.jobId,
+    sourceRevision: options.sourceRevision,
+    contractHash: options.contractHash,
+    sequence: 0,
+    state: options.initialState ?? "running",
+    phase: options.initialPhase ?? "starting",
+    startedAt: options.startedAt,
+    updatedAt: options.startedAt,
+    ...(options.deadlineAt === undefined ? {} : { deadlineAt: options.deadlineAt }),
+    tracks: options.initialTracks ?? [],
+  });
+  let lastQueuedAtMs = Number.NEGATIVE_INFINITY;
+  let lastPublishedSequence = -1;
+  let tail: Promise<void> = Promise.resolve();
+
+  const enqueue = (snapshot: JobProgressSnapshot): Promise<void> => {
+    lastQueuedAtMs = Date.parse(snapshot.updatedAt);
+    const operation = tail.then(async () => {
+      await publishWithDeadline(options.publish, cloneSnapshot(snapshot), publishTimeoutMs);
+      lastPublishedSequence = Math.max(lastPublishedSequence, snapshot.sequence);
+    });
+    tail = operation.catch(() => undefined);
+    return operation;
+  };
+
+  return {
+    async report(update) {
+      if (isTerminalJobProgressState(current.state)) {
+        throw new Error("job progress cannot change after a terminal state");
+      }
+      if (current.sequence >= Number.MAX_SAFE_INTEGER) {
+        throw new Error("job progress sequence is exhausted");
+      }
+      const timestamp = now().toISOString();
+      const state = update.state ?? current.state;
+      const phase = update.phase ?? current.phase;
+      const finishedAt = isTerminalJobProgressState(state)
+        ? (update.finishedAt ?? timestamp)
+        : update.finishedAt;
+      const next = validateJobProgressSnapshot({
+        ...current,
+        sequence: current.sequence + 1,
+        state,
+        phase,
+        updatedAt: timestamp,
+        tracks: update.tracks ?? current.tracks,
+        ...(update.cost === undefined ? {} : { cost: update.cost }),
+        ...(finishedAt === undefined ? {} : { finishedAt }),
+      });
+      assertMonotonicTracks(current, next);
+      const publishNow =
+        update.force === true ||
+        phase !== current.phase ||
+        isTerminalJobProgressState(state) ||
+        Date.parse(timestamp) - lastQueuedAtMs >= minimumIntervalMs;
+      current = next;
+      if (!publishNow) return { snapshot: cloneSnapshot(current), published: false };
+      await enqueue(current);
+      return { snapshot: cloneSnapshot(current), published: true };
+    },
+
+    async flush() {
+      if (lastPublishedSequence >= current.sequence) {
+        await tail;
+        return { snapshot: cloneSnapshot(current), published: false };
+      }
+      await enqueue(current);
+      return { snapshot: cloneSnapshot(current), published: true };
+    },
+
+    snapshot() {
+      return cloneSnapshot(current);
+    },
+  };
+}
+
+export function estimateJobProgress(
+  snapshots: JobProgressSnapshot[],
+  now = new Date(),
+): JobProgressEstimate {
+  if (snapshots.length === 0)
+    throw new Error("job progress estimation requires at least one snapshot");
+  const validated = snapshots.map(validateJobProgressSnapshot);
+  const latest = validated.at(-1) as JobProgressSnapshot;
+  for (const snapshot of validated) assertSameIdentity(latest, snapshot);
+  const keys = new Set(validated.flatMap((snapshot) => snapshot.tracks.map((track) => track.key)));
+  const tracks: ProgressTrackState[] = [...keys].map((key) => {
+    const samples: ProgressSample[] = validated.flatMap((snapshot) => {
+      const track = snapshot.tracks.find((candidate) => candidate.key === key);
+      return track === undefined ? [] : [{ at: snapshot.updatedAt, data: track.data }];
+    });
+    return { key, samples, estimate: estimateProgress(key, samples, now) };
+  });
+  return {
+    snapshot: cloneSnapshot(latest),
+    tracks,
+    estimates: tracks.map((track) => track.estimate),
+  };
+}
+
+function assertMonotonicTracks(previous: JobProgressSnapshot, next: JobProgressSnapshot): void {
+  if (previous.phase !== next.phase) return;
+  for (const track of next.tracks) {
+    const prior = previous.tracks.find((candidate) => candidate.key === track.key);
+    if (prior === undefined || resetsTrack(prior, track)) continue;
+    if (
+      prior.data.completed !== undefined &&
+      track.data.completed !== undefined &&
+      track.data.completed < prior.data.completed
+    ) {
+      throw new Error(`job progress track ${track.key} completed value must not decrease`);
+    }
+  }
+}
+
+function resetsTrack(previous: JobProgressTrack, next: JobProgressTrack): boolean {
+  return (
+    previous.data.phase !== next.data.phase ||
+    previous.data.unit !== next.data.unit ||
+    previous.data.total !== next.data.total
+  );
+}
+
+function assertSameIdentity(expected: JobProgressSnapshot, actual: JobProgressSnapshot): void {
+  for (const field of [
+    "application",
+    "component",
+    "jobId",
+    "sourceRevision",
+    "contractHash",
+    "startedAt",
+  ] as const) {
+    if (expected[field] !== actual[field]) {
+      throw new Error(`job progress sample ${field} does not match`);
+    }
+  }
+}
+
+async function publishWithDeadline(
+  publish: JobProgressReporterOptions["publish"],
+  snapshot: JobProgressSnapshot,
+  timeoutMs: number,
+): Promise<void> {
+  const controller = new AbortController();
+  let timeout: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`job progress publication timed out after ${timeoutMs} ms`));
+    }, timeoutMs);
+  });
+  try {
+    await Promise.race([publish(snapshot, controller.signal), deadline]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function cloneSnapshot(snapshot: JobProgressSnapshot): JobProgressSnapshot {
+  return structuredClone(snapshot);
+}
+
+function nonNegativeInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function positiveInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+  return value;
+}

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -35,25 +35,24 @@ export function createJobProgressReporter(
     options.publishTimeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS,
     "publishTimeoutMs",
   );
-  const initial = validateJobProgressSnapshot({
-    schema: JOB_PROGRESS_SCHEMA,
-    application: options.application,
-    component: options.component,
-    jobId: options.jobId,
-    sourceRevision: options.sourceRevision,
-    contractHash: options.contractHash,
-    sequence: 0,
-    state: options.initialState ?? "running",
-    phase: options.initialPhase ?? "starting",
-    startedAt: options.startedAt,
-    updatedAt: options.startedAt,
-    ...(options.deadlineAt === undefined ? {} : { deadlineAt: options.deadlineAt }),
-    tracks: options.initialTracks ?? [],
-  });
   let current =
     options.previousSnapshot === undefined
-      ? initial
-      : validatePreviousSnapshot(initial, options.previousSnapshot);
+      ? validateJobProgressSnapshot({
+          schema: JOB_PROGRESS_SCHEMA,
+          application: options.application,
+          component: options.component,
+          jobId: options.jobId,
+          sourceRevision: options.sourceRevision,
+          contractHash: options.contractHash,
+          sequence: 0,
+          state: options.initialState ?? "running",
+          phase: options.initialPhase ?? "starting",
+          startedAt: options.startedAt,
+          updatedAt: options.startedAt,
+          ...(options.deadlineAt === undefined ? {} : { deadlineAt: options.deadlineAt }),
+          tracks: options.initialTracks,
+        })
+      : validatePreviousSnapshot(options, options.previousSnapshot);
   let lastQueuedAtMs = Number.NEGATIVE_INFINITY;
   let lastQueuedSequence = -1;
   let lastPublishedSequence = -1;
@@ -120,9 +119,9 @@ export function createJobProgressReporter(
         isTerminalJobProgressState(state) ||
         Date.parse(timestamp) - lastQueuedAtMs >= minimumIntervalMs;
       current = next;
-      if (!publishNow) return { snapshot: cloneSnapshot(current), published: false };
-      await enqueue(current);
-      return { snapshot: cloneSnapshot(current), published: true };
+      if (!publishNow) return { snapshot: cloneSnapshot(next), published: false };
+      await enqueue(next);
+      return { snapshot: cloneSnapshot(next), published: true };
     },
 
     async flush() {
@@ -247,15 +246,26 @@ function startPublication(
 }
 
 function validatePreviousSnapshot(
-  initial: JobProgressSnapshot,
+  identity: JobProgressReporterOptions,
   previous: JobProgressSnapshot,
 ): JobProgressSnapshot {
   const validated = validateJobProgressSnapshot(previous);
-  assertSameIdentity(initial, validated);
+  for (const field of [
+    "application",
+    "component",
+    "jobId",
+    "sourceRevision",
+    "contractHash",
+    "startedAt",
+  ] as const) {
+    if (identity[field] !== validated[field]) {
+      throw new Error(`job progress previous snapshot ${field} does not match`);
+    }
+  }
   if (isTerminalJobProgressState(validated.state)) {
     throw new Error("job progress cannot resume from a terminal snapshot");
   }
-  if (initial.deadlineAt !== validated.deadlineAt) {
+  if (identity.deadlineAt !== validated.deadlineAt) {
     throw new Error("job progress previous snapshot deadlineAt does not match");
   }
   return validated;

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -51,16 +51,31 @@ export function createJobProgressReporter(
     tracks: options.initialTracks ?? [],
   });
   let lastQueuedAtMs = Number.NEGATIVE_INFINITY;
+  let lastQueuedSequence = -1;
   let lastPublishedSequence = -1;
+  let queuedOperation: Promise<void> | undefined;
   let tail: Promise<void> = Promise.resolve();
 
   const enqueue = (snapshot: JobProgressSnapshot): Promise<void> => {
+    if (lastQueuedSequence === snapshot.sequence && queuedOperation !== undefined) {
+      return queuedOperation;
+    }
     lastQueuedAtMs = Date.parse(snapshot.updatedAt);
+    lastQueuedSequence = snapshot.sequence;
     const operation = tail.then(async () => {
       await publishWithDeadline(options.publish, cloneSnapshot(snapshot), publishTimeoutMs);
       lastPublishedSequence = Math.max(lastPublishedSequence, snapshot.sequence);
     });
+    queuedOperation = operation;
     tail = operation.catch(() => undefined);
+    void operation
+      .finally(() => {
+        if (lastQueuedSequence === snapshot.sequence) {
+          lastQueuedSequence = -1;
+          queuedOperation = undefined;
+        }
+      })
+      .catch(() => undefined);
     return operation;
   };
 

--- a/src/job-progress/reporter.ts
+++ b/src/job-progress/reporter.ts
@@ -126,12 +126,13 @@ export function createJobProgressReporter(
     },
 
     async flush() {
-      if (lastPublishedSequence >= current.sequence) {
+      const snapshot = current;
+      if (lastPublishedSequence >= snapshot.sequence) {
         await tail;
-        return { snapshot: cloneSnapshot(current), published: false };
+        return { snapshot: cloneSnapshot(snapshot), published: false };
       }
-      await enqueue(current);
-      return { snapshot: cloneSnapshot(current), published: true };
+      await enqueue(snapshot);
+      return { snapshot: cloneSnapshot(snapshot), published: true };
     },
 
     snapshot() {

--- a/src/job-progress/types.ts
+++ b/src/job-progress/types.ts
@@ -65,16 +65,20 @@ export type JobProgressPublish = (
   signal: AbortSignal,
 ) => Promise<void>;
 
-export type JobProgressReporterOptions = JobProgressIdentity & {
+type JobProgressReporterBaseOptions = JobProgressIdentity & {
   initialState?: JobProgressState;
   initialPhase?: string;
-  initialTracks?: JobProgressTrack[];
-  previousSnapshot?: JobProgressSnapshot;
   publish: JobProgressPublish;
   minimumIntervalMs?: number;
   publishTimeoutMs?: number;
   now?: () => Date;
 };
+
+export type JobProgressReporterOptions = JobProgressReporterBaseOptions &
+  (
+    | { initialTracks: JobProgressTrack[]; previousSnapshot?: never }
+    | { initialTracks?: JobProgressTrack[]; previousSnapshot: JobProgressSnapshot }
+  );
 
 export type JobProgressPublishResult = {
   snapshot: JobProgressSnapshot;

--- a/src/job-progress/types.ts
+++ b/src/job-progress/types.ts
@@ -66,7 +66,7 @@ export type JobProgressPublish = (
 ) => Promise<void>;
 
 type JobProgressReporterBaseOptions = JobProgressIdentity & {
-  initialState?: JobProgressState;
+  initialState?: Exclude<JobProgressState, "completed" | "failed" | "cancelled">;
   initialPhase?: string;
   publish: JobProgressPublish;
   minimumIntervalMs?: number;

--- a/src/job-progress/types.ts
+++ b/src/job-progress/types.ts
@@ -69,6 +69,7 @@ export type JobProgressReporterOptions = JobProgressIdentity & {
   initialState?: JobProgressState;
   initialPhase?: string;
   initialTracks?: JobProgressTrack[];
+  previousSnapshot?: JobProgressSnapshot;
   publish: JobProgressPublish;
   minimumIntervalMs?: number;
   publishTimeoutMs?: number;

--- a/src/job-progress/types.ts
+++ b/src/job-progress/types.ts
@@ -1,0 +1,87 @@
+import type {
+  ProgressEstimate,
+  ProgressTrackState,
+  WorkflowProgressData,
+} from "../workflows/index.js";
+
+export const JOB_PROGRESS_SCHEMA = "pi-workflows.job-progress.v1" as const;
+
+export type JobProgressState =
+  | "queued"
+  | "running"
+  | "waiting"
+  | "blocked"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "unknown";
+
+export type JobProgressTrack = {
+  key: string;
+  data: WorkflowProgressData;
+};
+
+export type JobProgressCost = {
+  settledUsd: number;
+  reservedUsd: number;
+};
+
+export type JobProgressSnapshot = {
+  schema: typeof JOB_PROGRESS_SCHEMA;
+  application: string;
+  component: string;
+  jobId: string;
+  sourceRevision: string;
+  contractHash: string;
+  sequence: number;
+  state: JobProgressState;
+  phase: string;
+  startedAt: string;
+  updatedAt: string;
+  deadlineAt?: string;
+  finishedAt?: string;
+  tracks: JobProgressTrack[];
+  cost?: JobProgressCost;
+};
+
+export type JobProgressIdentity = Pick<
+  JobProgressSnapshot,
+  "application" | "component" | "jobId" | "sourceRevision" | "contractHash" | "startedAt"
+> & {
+  deadlineAt?: string;
+};
+
+export type JobProgressUpdate = {
+  state?: JobProgressState;
+  phase?: string;
+  tracks?: JobProgressTrack[];
+  cost?: JobProgressCost;
+  finishedAt?: string;
+  force?: boolean;
+};
+
+export type JobProgressPublish = (
+  snapshot: JobProgressSnapshot,
+  signal: AbortSignal,
+) => Promise<void>;
+
+export type JobProgressReporterOptions = JobProgressIdentity & {
+  initialState?: JobProgressState;
+  initialPhase?: string;
+  initialTracks?: JobProgressTrack[];
+  publish: JobProgressPublish;
+  minimumIntervalMs?: number;
+  publishTimeoutMs?: number;
+  now?: () => Date;
+};
+
+export type JobProgressPublishResult = {
+  snapshot: JobProgressSnapshot;
+  published: boolean;
+};
+
+export type JobProgressEstimate = {
+  snapshot: JobProgressSnapshot;
+  tracks: ProgressTrackState[];
+  estimates: ProgressEstimate[];
+};

--- a/src/job-progress/validation.ts
+++ b/src/job-progress/validation.ts
@@ -115,6 +115,7 @@ export function isTerminalJobProgressState(
 
 function requiredTracks(value: unknown): JobProgressTrack[] {
   if (!Array.isArray(value)) throw new Error("job progress.tracks must be an array");
+  if (value.length < 1) throw new Error("job progress.tracks must contain at least one entry");
   if (value.length > MAX_JOB_PROGRESS_TRACKS) {
     throw new Error(`job progress.tracks must contain at most ${MAX_JOB_PROGRESS_TRACKS} entries`);
   }

--- a/src/job-progress/validation.ts
+++ b/src/job-progress/validation.ts
@@ -1,0 +1,224 @@
+import { validateProgressData } from "../workflows/index.js";
+import {
+  JOB_PROGRESS_SCHEMA,
+  type JobProgressCost,
+  type JobProgressSnapshot,
+  type JobProgressState,
+  type JobProgressTrack,
+} from "./types.js";
+
+export const MAX_JOB_PROGRESS_BYTES = 64 * 1024;
+export const MAX_JOB_PROGRESS_TRACKS = 128;
+
+const SNAPSHOT_FIELDS = new Set([
+  "schema",
+  "application",
+  "component",
+  "jobId",
+  "sourceRevision",
+  "contractHash",
+  "sequence",
+  "state",
+  "phase",
+  "startedAt",
+  "updatedAt",
+  "deadlineAt",
+  "finishedAt",
+  "tracks",
+  "cost",
+]);
+const TRACK_FIELDS = new Set(["key", "data"]);
+const COST_FIELDS = new Set(["settledUsd", "reservedUsd"]);
+const STATES = new Set<JobProgressState>([
+  "queued",
+  "running",
+  "waiting",
+  "blocked",
+  "completed",
+  "failed",
+  "cancelled",
+  "unknown",
+]);
+const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
+
+export function validateJobProgressSnapshot(value: unknown): JobProgressSnapshot {
+  const bytes = jsonBytes(value);
+  if (bytes > MAX_JOB_PROGRESS_BYTES) {
+    throw new Error(`job progress snapshot must be at most ${MAX_JOB_PROGRESS_BYTES} bytes`);
+  }
+  if (!isRecord(value)) throw new Error("job progress snapshot must be an object");
+  rejectUnknown(value, SNAPSHOT_FIELDS, "job progress");
+  if (value.schema !== JOB_PROGRESS_SCHEMA) {
+    throw new Error(`job progress.schema must equal ${JOB_PROGRESS_SCHEMA}`);
+  }
+
+  const application = requiredText(value.application, "job progress.application", 100);
+  const component = requiredText(value.component, "job progress.component", 100);
+  const jobId = requiredText(value.jobId, "job progress.jobId", 200);
+  const sourceRevision = requiredText(value.sourceRevision, "job progress.sourceRevision", 200);
+  const contractHash = requiredText(value.contractHash, "job progress.contractHash", 200);
+  const sequence = requiredInteger(value.sequence, "job progress.sequence");
+  const state = requiredState(value.state);
+  const phase = requiredText(value.phase, "job progress.phase", 100);
+  const startedAt = requiredTimestamp(value.startedAt, "job progress.startedAt");
+  const updatedAt = requiredTimestamp(value.updatedAt, "job progress.updatedAt");
+  const deadlineAt = optionalTimestamp(value.deadlineAt, "job progress.deadlineAt");
+  const finishedAt = optionalTimestamp(value.finishedAt, "job progress.finishedAt");
+  const tracks = requiredTracks(value.tracks);
+  const cost = optionalCost(value.cost);
+
+  if (Date.parse(updatedAt) < Date.parse(startedAt)) {
+    throw new Error("job progress.updatedAt must not be before startedAt");
+  }
+  if (deadlineAt !== undefined && Date.parse(deadlineAt) <= Date.parse(startedAt)) {
+    throw new Error("job progress.deadlineAt must be after startedAt");
+  }
+  if (finishedAt !== undefined && Date.parse(finishedAt) < Date.parse(startedAt)) {
+    throw new Error("job progress.finishedAt must not be before startedAt");
+  }
+  if (isTerminal(state) && finishedAt === undefined) {
+    throw new Error("job progress.finishedAt is required for a terminal state");
+  }
+  if (!isTerminal(state) && finishedAt !== undefined) {
+    throw new Error("job progress.finishedAt is allowed only for a terminal state");
+  }
+
+  return {
+    schema: JOB_PROGRESS_SCHEMA,
+    application,
+    component,
+    jobId,
+    sourceRevision,
+    contractHash,
+    sequence,
+    state,
+    phase,
+    startedAt,
+    updatedAt,
+    ...(deadlineAt === undefined ? {} : { deadlineAt }),
+    ...(finishedAt === undefined ? {} : { finishedAt }),
+    tracks,
+    ...(cost === undefined ? {} : { cost }),
+  };
+}
+
+export function isTerminalJobProgressState(state: JobProgressState): boolean {
+  return isTerminal(state);
+}
+
+function requiredTracks(value: unknown): JobProgressTrack[] {
+  if (!Array.isArray(value)) throw new Error("job progress.tracks must be an array");
+  if (value.length > MAX_JOB_PROGRESS_TRACKS) {
+    throw new Error(`job progress.tracks must contain at most ${MAX_JOB_PROGRESS_TRACKS} entries`);
+  }
+  const keys = new Set<string>();
+  return value.map((item, index) => {
+    if (!isRecord(item)) throw new Error(`job progress.tracks[${index}] must be an object`);
+    rejectUnknown(item, TRACK_FIELDS, `job progress.tracks[${index}]`);
+    if (typeof item.key !== "string" || !KEY_PATTERN.test(item.key)) {
+      throw new Error(
+        `job progress.tracks[${index}].key must match [A-Za-z0-9][A-Za-z0-9._:/-]{0,127}`,
+      );
+    }
+    if (keys.has(item.key)) throw new Error(`job progress track key ${item.key} is duplicated`);
+    keys.add(item.key);
+    if (!isRecord(item.data)) {
+      throw new Error(`job progress.tracks[${index}].data must be an object`);
+    }
+    return { key: item.key, data: structuredClone(validateProgressData(item.data)) };
+  });
+}
+
+function optionalCost(value: unknown): JobProgressCost | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("job progress.cost must be an object");
+  rejectUnknown(value, COST_FIELDS, "job progress.cost");
+  return {
+    settledUsd: requiredNonNegative(value.settledUsd, "job progress.cost.settledUsd"),
+    reservedUsd: requiredNonNegative(value.reservedUsd, "job progress.cost.reservedUsd"),
+  };
+}
+
+function requiredState(value: unknown): JobProgressState {
+  if (typeof value !== "string" || !STATES.has(value as JobProgressState)) {
+    throw new Error("job progress.state is invalid");
+  }
+  return value as JobProgressState;
+}
+
+function requiredText(value: unknown, field: string, max: number): string {
+  if (typeof value !== "string" || value.trim().length < 1 || value.trim().length > max) {
+    throw new Error(`${field} must be 1 to ${max} characters`);
+  }
+  if ([...value].some(isControlCharacter))
+    throw new Error(`${field} must not contain control characters`);
+  return value;
+}
+
+function requiredInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`${field} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function requiredNonNegative(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a finite non-negative number`);
+  }
+  return value;
+}
+
+function requiredTimestamp(value: unknown, field: string): string {
+  const parsed = optionalTimestamp(value, field);
+  if (parsed === undefined) throw new Error(`${field} is required`);
+  return parsed;
+}
+
+function optionalTimestamp(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (
+    typeof value !== "string" ||
+    !Number.isFinite(Date.parse(value)) ||
+    !/[zZ]|[+-]\d\d:\d\d$/.test(value)
+  ) {
+    throw new Error(`${field} must be an RFC 3339 timestamp with an offset`);
+  }
+  return value;
+}
+
+function rejectUnknown(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  field: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${field}.${key} is not supported`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function jsonBytes(value: unknown): number {
+  let encoded: string | undefined;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw new Error("job progress snapshot must be JSON serializable");
+  }
+  if (encoded === undefined) throw new Error("job progress snapshot must be JSON serializable");
+  return Buffer.byteLength(encoded, "utf8");
+}
+
+function isControlCharacter(character: string): boolean {
+  const code = character.codePointAt(0) ?? 0;
+  return code < 32 || (code >= 127 && code <= 159);
+}
+
+function isTerminal(state: JobProgressState): boolean {
+  return state === "completed" || state === "failed" || state === "cancelled";
+}

--- a/src/job-progress/validation.ts
+++ b/src/job-progress/validation.ts
@@ -40,6 +40,8 @@ const STATES = new Set<JobProgressState>([
   "unknown",
 ]);
 const KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
+const RFC_3339_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 export function validateJobProgressSnapshot(value: unknown): JobProgressSnapshot {
   const bytes = jsonBytes(value);
@@ -177,14 +179,26 @@ function requiredTimestamp(value: unknown, field: string): string {
 
 function optionalTimestamp(value: unknown, field: string): string | undefined {
   if (value === undefined) return undefined;
-  if (
-    typeof value !== "string" ||
-    !Number.isFinite(Date.parse(value)) ||
-    !/[zZ]|[+-]\d\d:\d\d$/.test(value)
-  ) {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be an RFC 3339 timestamp with an offset`);
+  }
+  const match = RFC_3339_PATTERN.exec(value);
+  if (match === null || !validCalendarDate(match[1], match[2], match[3])) {
     throw new Error(`${field} must be an RFC 3339 timestamp with an offset`);
   }
   return value;
+}
+
+function validCalendarDate(
+  yearText: string | undefined,
+  monthText: string | undefined,
+  dayText: string | undefined,
+): boolean {
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  if (!Number.isInteger(year) || year < 1 || month < 1 || month > 12 || day < 1) return false;
+  return day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
 }
 
 function rejectUnknown(

--- a/src/job-progress/validation.ts
+++ b/src/job-progress/validation.ts
@@ -84,6 +84,9 @@ export function validateJobProgressSnapshot(value: unknown): JobProgressSnapshot
   if (!isTerminal(state) && finishedAt !== undefined) {
     throw new Error("job progress.finishedAt is allowed only for a terminal state");
   }
+  if (isTerminal(state) && tracks.some((track) => !isTerminalTrack(track))) {
+    throw new Error("job progress tracks must be terminal when the job state is terminal");
+  }
 
   return {
     schema: JOB_PROGRESS_SCHEMA,
@@ -104,7 +107,9 @@ export function validateJobProgressSnapshot(value: unknown): JobProgressSnapshot
   };
 }
 
-export function isTerminalJobProgressState(state: JobProgressState): boolean {
+export function isTerminalJobProgressState(
+  state: JobProgressState,
+): state is "completed" | "failed" | "cancelled" {
   return isTerminal(state);
 }
 
@@ -235,4 +240,12 @@ function isControlCharacter(character: string): boolean {
 
 function isTerminal(state: JobProgressState): boolean {
   return state === "completed" || state === "failed" || state === "cancelled";
+}
+
+function isTerminalTrack(track: JobProgressTrack): boolean {
+  return (
+    track.data.status === "completed" ||
+    track.data.status === "failed" ||
+    track.data.status === "cancelled"
+  );
 }

--- a/src/job-progress/validation.ts
+++ b/src/job-progress/validation.ts
@@ -78,6 +78,9 @@ export function validateJobProgressSnapshot(value: unknown): JobProgressSnapshot
   if (finishedAt !== undefined && Date.parse(finishedAt) < Date.parse(startedAt)) {
     throw new Error("job progress.finishedAt must not be before startedAt");
   }
+  if (finishedAt !== undefined && Date.parse(finishedAt) > Date.parse(updatedAt)) {
+    throw new Error("job progress.finishedAt must not be after updatedAt");
+  }
   if (isTerminal(state) && finishedAt === undefined) {
     throw new Error("job progress.finishedAt is required for a terminal state");
   }

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -381,13 +381,20 @@ describe("durable job progress", () => {
   it("estimates remaining time from repeated durable snapshots", () => {
     const result = estimateJobProgress(
       [
+        snapshot({ sequence: 3, updatedAt: "2026-08-17T10:02:00.000Z", tracks: [track(40)] }),
         snapshot({ sequence: 1, updatedAt: "2026-08-17T10:00:00.000Z", tracks: [track(0)] }),
         snapshot({ sequence: 2, updatedAt: "2026-08-17T10:01:00.000Z", tracks: [track(20)] }),
-        snapshot({ sequence: 3, updatedAt: "2026-08-17T10:02:00.000Z", tracks: [track(40)] }),
       ],
       new Date("2026-08-17T10:02:00.000Z"),
     );
+    expect(result.snapshot.sequence).toBe(3);
     expect(result.estimates[0]?.remainingMedianMs).toBe(180_000);
     expect(result.tracks[0]?.samples).toHaveLength(3);
+  });
+
+  it("rejects duplicate snapshot sequences", () => {
+    expect(() =>
+      estimateJobProgress([snapshot({ sequence: 1 }), snapshot({ sequence: 1 })]),
+    ).toThrow("sequence 1 is duplicated");
   });
 });

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -175,10 +175,15 @@ describe("durable job progress", () => {
 
     const report = reporter.report({ tracks: [track(1)] });
     const flush = reporter.flush();
+    const coalesced = await reporter.report({ tracks: [track(2)] });
     await vi.waitFor(() => expect(release).toBeTypeOf("function"));
     release?.();
-    await Promise.all([report, flush]);
+    const [, flushResult] = await Promise.all([report, flush]);
     expect(calls).toBe(1);
+    expect(flushResult.snapshot.sequence).toBe(1);
+    expect(flushResult.snapshot.tracks[0]?.data.completed).toBe(1);
+    expect(coalesced.snapshot.sequence).toBe(2);
+    expect(coalesced.published).toBe(false);
   });
 
   it("keeps an aborted write serialized until its storage operation settles", async () => {

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createJobProgressReporter,
+  estimateJobProgress,
+  JOB_PROGRESS_SCHEMA,
+  validateJobProgressSnapshot,
+  type JobProgressSnapshot,
+  type JobProgressTrack,
+} from "../src/job-progress/index.js";
+
+const STARTED_AT = "2026-08-17T10:00:00.000Z";
+
+function track(completed: number, total = 100, phase = "processing"): JobProgressTrack {
+  return {
+    key: "records",
+    data: {
+      schema: "pi-workflows.progress.v1",
+      status: "running",
+      phase,
+      completed,
+      total,
+      unit: "records",
+    },
+  };
+}
+
+function snapshot(overrides: Partial<JobProgressSnapshot> = {}): JobProgressSnapshot {
+  return {
+    schema: JOB_PROGRESS_SCHEMA,
+    application: "example",
+    component: "worker",
+    jobId: "job-123",
+    sourceRevision: "abc123",
+    contractHash: "def456",
+    sequence: 1,
+    state: "running",
+    phase: "processing",
+    startedAt: STARTED_AT,
+    updatedAt: "2026-08-17T10:01:00.000Z",
+    tracks: [track(10)],
+    ...overrides,
+  };
+}
+
+function reporterOptions(
+  publish: (value: JobProgressSnapshot, signal: AbortSignal) => Promise<void>,
+  now: () => Date,
+) {
+  return {
+    application: "example",
+    component: "worker",
+    jobId: "job-123",
+    sourceRevision: "abc123",
+    contractHash: "def456",
+    startedAt: STARTED_AT,
+    initialTracks: [track(0)],
+    publish,
+    now,
+  };
+}
+
+describe("durable job progress", () => {
+  it("strictly validates and normalizes a snapshot", () => {
+    expect(validateJobProgressSnapshot(snapshot())).toEqual(snapshot());
+    expect(() => validateJobProgressSnapshot({ ...snapshot(), token: "secret" })).toThrow(
+      "job progress.token is not supported",
+    );
+    expect(() =>
+      validateJobProgressSnapshot({ ...snapshot(), tracks: [track(1), track(2)] }),
+    ).toThrow("job progress track key records is duplicated");
+  });
+
+  it("snapshots mutable track input", () => {
+    const input = snapshot();
+    const validated = validateJobProgressSnapshot(input);
+    const data = input.tracks[0]?.data;
+    if (data !== undefined) data.completed = 99;
+    expect(validated.tracks[0]?.data.completed).toBe(10);
+  });
+
+  it("requires terminal timestamps and rejects timestamps on active states", () => {
+    expect(() => validateJobProgressSnapshot({ ...snapshot(), state: "completed" })).toThrow(
+      "finishedAt is required",
+    );
+    expect(() =>
+      validateJobProgressSnapshot({ ...snapshot(), finishedAt: "2026-08-17T10:02:00.000Z" }),
+    ).toThrow("allowed only for a terminal state");
+  });
+
+  it("publishes the first update, coalesces frequent updates, and flushes the latest one", async () => {
+    const published: JobProgressSnapshot[] = [];
+    let nowMs = Date.parse("2026-08-17T10:00:01.000Z");
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async (value) => void published.push(value),
+        () => new Date(nowMs),
+      ),
+      minimumIntervalMs: 30_000,
+    });
+
+    expect((await reporter.report({ tracks: [track(1)] })).published).toBe(true);
+    nowMs += 10_000;
+    expect((await reporter.report({ tracks: [track(2)] })).published).toBe(false);
+    expect(published.map((value) => value.tracks[0]?.data.completed)).toEqual([1]);
+    expect((await reporter.flush()).published).toBe(true);
+    expect(published.map((value) => value.tracks[0]?.data.completed)).toEqual([1, 2]);
+    expect(published.map((value) => value.sequence)).toEqual([1, 2]);
+  });
+
+  it("publishes phase changes and terminal states immediately", async () => {
+    const published: JobProgressSnapshot[] = [];
+    let nowMs = Date.parse("2026-08-17T10:00:01.000Z");
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async (value) => void published.push(value),
+        () => new Date(nowMs),
+      ),
+      minimumIntervalMs: 60_000,
+    });
+
+    await reporter.report({ tracks: [track(1)] });
+    nowMs += 1_000;
+    await reporter.report({ phase: "publishing", tracks: [track(0, 10, "publishing")] });
+    nowMs += 1_000;
+    const result = await reporter.report({
+      state: "completed",
+      phase: "complete",
+      tracks: [
+        {
+          ...track(10, 10, "complete"),
+          data: { ...track(10, 10, "complete").data, status: "completed" },
+        },
+      ],
+    });
+
+    expect(published).toHaveLength(3);
+    expect(result.snapshot.finishedAt).toBe("2026-08-17T10:00:03.000Z");
+    expect(() => reporter.report({ phase: "late" })).rejects.toThrow(
+      "cannot change after a terminal state",
+    );
+  });
+
+  it("rejects counter regressions but permits a new phase epoch", async () => {
+    let nowMs = Date.parse("2026-08-17T10:00:01.000Z");
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async () => undefined,
+        () => new Date(nowMs),
+      ),
+      minimumIntervalMs: 0,
+    });
+    await reporter.report({ tracks: [track(20)] });
+    nowMs += 1_000;
+    await expect(reporter.report({ tracks: [track(19)] })).rejects.toThrow(
+      "completed value must not decrease",
+    );
+    await reporter.report({ phase: "next", tracks: [track(0, 50, "next")] });
+    expect(reporter.snapshot().tracks[0]?.data.completed).toBe(0);
+  });
+
+  it("keeps the latest snapshot after a transient publication failure", async () => {
+    let calls = 0;
+    let nowMs = Date.parse("2026-08-17T10:00:01.000Z");
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw new Error("temporary Bucket failure");
+        },
+        () => new Date(nowMs),
+      ),
+      minimumIntervalMs: 30_000,
+    });
+
+    await expect(reporter.report({ tracks: [track(1)] })).rejects.toThrow(
+      "temporary Bucket failure",
+    );
+    nowMs += 1_000;
+    expect((await reporter.report({ tracks: [track(2)] })).published).toBe(false);
+    expect((await reporter.flush()).published).toBe(true);
+    expect(calls).toBe(2);
+    expect(reporter.snapshot().tracks[0]?.data.completed).toBe(2);
+  });
+
+  it("aborts a publication that exceeds its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const reporter = createJobProgressReporter({
+        ...reporterOptions(
+          async (_value, signal) =>
+            new Promise<void>((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+            }),
+          () => new Date(STARTED_AT),
+        ),
+        publishTimeoutMs: 50,
+      });
+      const pending = reporter.report({ tracks: [track(1)] });
+      const rejection = expect(pending).rejects.toThrow(
+        "job progress publication timed out after 50 ms",
+      );
+      await vi.advanceTimersByTimeAsync(50);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("estimates remaining time from repeated durable snapshots", () => {
+    const result = estimateJobProgress(
+      [
+        snapshot({ sequence: 1, updatedAt: "2026-08-17T10:00:00.000Z", tracks: [track(0)] }),
+        snapshot({ sequence: 2, updatedAt: "2026-08-17T10:01:00.000Z", tracks: [track(20)] }),
+        snapshot({ sequence: 3, updatedAt: "2026-08-17T10:02:00.000Z", tracks: [track(40)] }),
+      ],
+      new Date("2026-08-17T10:02:00.000Z"),
+    );
+    expect(result.estimates[0]?.remainingMedianMs).toBe(180_000);
+    expect(result.tracks[0]?.samples).toHaveLength(3);
+  });
+});

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -116,6 +116,30 @@ describe("durable job progress", () => {
     expect(published.map((value) => value.sequence)).toEqual([1, 2]);
   });
 
+  it("joins an in-flight publication when flush sees the same sequence", async () => {
+    let release: (() => void) | undefined;
+    let calls = 0;
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async () => {
+          calls += 1;
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+        },
+        () => new Date("2026-08-17T10:00:01.000Z"),
+      ),
+      minimumIntervalMs: 30_000,
+    });
+
+    const report = reporter.report({ tracks: [track(1)] });
+    const flush = reporter.flush();
+    await vi.waitFor(() => expect(release).toBeTypeOf("function"));
+    release?.();
+    await Promise.all([report, flush]);
+    expect(calls).toBe(1);
+  });
+
   it("publishes phase changes and terminal states immediately", async () => {
     const published: JobProgressSnapshot[] = [];
     let nowMs = Date.parse("2026-08-17T10:00:01.000Z");

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -78,6 +78,15 @@ describe("durable job progress", () => {
     expect(validated.tracks[0]?.data.completed).toBe(10);
   });
 
+  it("rejects normalized and partial timestamp values", () => {
+    expect(() =>
+      validateJobProgressSnapshot({ ...snapshot(), updatedAt: "2026-02-31T10:00:00Z" }),
+    ).toThrow("must be an RFC 3339 timestamp");
+    expect(() => validateJobProgressSnapshot({ ...snapshot(), updatedAt: "not-a-date-Z" })).toThrow(
+      "must be an RFC 3339 timestamp",
+    );
+  });
+
   it("requires terminal timestamps and rejects timestamps on active states", () => {
     expect(() => validateJobProgressSnapshot({ ...snapshot(), state: "completed" })).toThrow(
       "finishedAt is required",
@@ -204,6 +213,24 @@ describe("durable job progress", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not estimate a track removed from the latest snapshot", () => {
+    const oldTrack: JobProgressTrack = {
+      key: "old-phase",
+      data: {
+        schema: "pi-workflows.progress.v1",
+        status: "running",
+        completed: 1,
+        total: 2,
+        unit: "items",
+      },
+    };
+    const result = estimateJobProgress([
+      snapshot({ sequence: 1, tracks: [track(10), oldTrack] }),
+      snapshot({ sequence: 2, updatedAt: "2026-08-17T10:02:00.000Z", tracks: [track(20)] }),
+    ]);
+    expect(result.estimates.map((estimate) => estimate.key)).toEqual(["records"]);
   });
 
   it("estimates remaining time from repeated durable snapshots", () => {

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -65,6 +65,9 @@ describe("durable job progress", () => {
     expect(() => validateJobProgressSnapshot({ ...snapshot(), token: "secret" })).toThrow(
       "job progress.token is not supported",
     );
+    expect(() => validateJobProgressSnapshot({ ...snapshot(), tracks: [] })).toThrow(
+      "tracks must contain at least one entry",
+    );
     expect(() =>
       validateJobProgressSnapshot({ ...snapshot(), tracks: [track(1), track(2)] }),
     ).toThrow("job progress track key records is duplicated");
@@ -121,6 +124,30 @@ describe("durable job progress", () => {
     expect((await reporter.flush()).published).toBe(true);
     expect(published.map((value) => value.tracks[0]?.data.completed)).toEqual([1, 2]);
     expect(published.map((value) => value.sequence)).toEqual([1, 2]);
+  });
+
+  it("returns the exact snapshot written by an in-flight report", async () => {
+    let release: (() => void) | undefined;
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          }),
+        () => new Date("2026-08-17T10:00:01.000Z"),
+      ),
+      minimumIntervalMs: 30_000,
+    });
+
+    const first = reporter.report({ tracks: [track(1)] });
+    const second = await reporter.report({ tracks: [track(2)] });
+    await vi.waitFor(() => expect(release).toBeTypeOf("function"));
+    release?.();
+    const firstResult = await first;
+    expect(firstResult.snapshot.sequence).toBe(1);
+    expect(firstResult.snapshot.tracks[0]?.data.completed).toBe(1);
+    expect(second.snapshot.sequence).toBe(2);
+    expect(second.published).toBe(false);
   });
 
   it("joins an in-flight publication when flush sees the same sequence", async () => {

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -95,13 +95,20 @@ describe("durable job progress", () => {
       "finishedAt is required",
     );
     expect(() =>
-      validateJobProgressSnapshot({ ...snapshot(), finishedAt: "2026-08-17T10:02:00.000Z" }),
+      validateJobProgressSnapshot({ ...snapshot(), finishedAt: "2026-08-17T10:01:00.000Z" }),
     ).toThrow("allowed only for a terminal state");
     expect(() =>
       validateJobProgressSnapshot({
         ...snapshot(),
         state: "completed",
         finishedAt: "2026-08-17T10:02:00.000Z",
+      }),
+    ).toThrow("finishedAt must not be after updatedAt");
+    expect(() =>
+      validateJobProgressSnapshot({
+        ...snapshot(),
+        state: "completed",
+        finishedAt: "2026-08-17T10:01:00.000Z",
       }),
     ).toThrow("tracks must be terminal");
   });
@@ -224,6 +231,21 @@ describe("durable job progress", () => {
     const result = await reporter.report({ tracks: [track(51)] });
     expect(result.snapshot.sequence).toBe(8);
     expect(published[0]?.sequence).toBe(8);
+  });
+
+  it("treats a resumed snapshot as already published", async () => {
+    const published: JobProgressSnapshot[] = [];
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async (value) => void published.push(value),
+        () => new Date("2026-08-17T10:01:10.000Z"),
+      ),
+      previousSnapshot: snapshot({ sequence: 7, tracks: [track(50)] }),
+      minimumIntervalMs: 30_000,
+    });
+    expect((await reporter.flush()).published).toBe(false);
+    expect((await reporter.report({ tracks: [track(51)] })).published).toBe(false);
+    expect(published).toHaveLength(0);
   });
 
   it("publishes phase changes and terminal states immediately", async () => {

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -140,6 +140,58 @@ describe("durable job progress", () => {
     expect(calls).toBe(1);
   });
 
+  it("keeps an aborted write serialized until its storage operation settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const calls: number[] = [];
+      let releaseFirst: (() => void) | undefined;
+      const reporter = createJobProgressReporter({
+        ...reporterOptions(
+          async (value) => {
+            calls.push(value.sequence);
+            if (value.sequence === 1) {
+              await new Promise<void>((resolve) => {
+                releaseFirst = resolve;
+              });
+            }
+          },
+          () => new Date("2026-08-17T10:00:01.000Z"),
+        ),
+        minimumIntervalMs: 0,
+        publishTimeoutMs: 50,
+      });
+
+      const first = reporter.report({ tracks: [track(1)] });
+      const firstRejection = expect(first).rejects.toThrow("publication timed out after 50 ms");
+      await vi.advanceTimersByTimeAsync(50);
+      await firstRejection;
+      const second = reporter.report({ phase: "next", tracks: [track(0, 10, "next")] });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(calls).toEqual([1]);
+      releaseFirst?.();
+      await second;
+      expect(calls).toEqual([1, 2]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes sequence numbers from a prior snapshot", async () => {
+    const published: JobProgressSnapshot[] = [];
+    const prior = snapshot({ sequence: 7, tracks: [track(50)] });
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async (value) => void published.push(value),
+        () => new Date("2026-08-17T10:02:00.000Z"),
+      ),
+      previousSnapshot: prior,
+      minimumIntervalMs: 0,
+    });
+    const result = await reporter.report({ tracks: [track(51)] });
+    expect(result.snapshot.sequence).toBe(8);
+    expect(published[0]?.sequence).toBe(8);
+  });
+
   it("publishes phase changes and terminal states immediately", async () => {
     const published: JobProgressSnapshot[] = [];
     let nowMs = Date.parse("2026-08-17T10:00:01.000Z");

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -94,6 +94,13 @@ describe("durable job progress", () => {
     expect(() =>
       validateJobProgressSnapshot({ ...snapshot(), finishedAt: "2026-08-17T10:02:00.000Z" }),
     ).toThrow("allowed only for a terminal state");
+    expect(() =>
+      validateJobProgressSnapshot({
+        ...snapshot(),
+        state: "completed",
+        finishedAt: "2026-08-17T10:02:00.000Z",
+      }),
+    ).toThrow("tracks must be terminal");
   });
 
   it("publishes the first update, coalesces frequent updates, and flushes the latest one", async () => {
@@ -220,9 +227,22 @@ describe("durable job progress", () => {
 
     expect(published).toHaveLength(3);
     expect(result.snapshot.finishedAt).toBe("2026-08-17T10:00:03.000Z");
-    expect(() => reporter.report({ phase: "late" })).rejects.toThrow(
+    await expect(reporter.report({ phase: "late" })).rejects.toThrow(
       "cannot change after a terminal state",
     );
+  });
+
+  it("makes carried tracks terminal when the job completes", async () => {
+    const reporter = createJobProgressReporter({
+      ...reporterOptions(
+        async () => undefined,
+        () => new Date("2026-08-17T10:01:00.000Z"),
+      ),
+      previousSnapshot: snapshot({ sequence: 2, tracks: [track(50)] }),
+    });
+    const result = await reporter.report({ state: "completed", phase: "complete" });
+    expect(result.snapshot.tracks[0]?.data.status).toBe("completed");
+    expect(result.snapshot.finishedAt).toBe("2026-08-17T10:01:00.000Z");
   });
 
   it("rejects counter regressions but permits a new phase epoch", async () => {

--- a/test/job-progress.test.ts
+++ b/test/job-progress.test.ts
@@ -73,6 +73,58 @@ describe("durable job progress", () => {
     ).toThrow("job progress track key records is duplicated");
   });
 
+  it("rejects malformed snapshot fields at strict boundaries", () => {
+    const invalid: Array<[unknown, string]> = [
+      [null, "must be an object"],
+      [{ ...snapshot(), schema: "other" }, "schema must equal"],
+      [{ ...snapshot(), sequence: -1 }, "sequence must be a non-negative safe integer"],
+      [{ ...snapshot(), state: "sleeping" }, "state is invalid"],
+      [{ ...snapshot(), phase: "bad\nphase" }, "phase must not contain control characters"],
+      [{ ...snapshot(), updatedAt: "2026-08-17T09:59:00.000Z" }, "updatedAt must not be before"],
+      [{ ...snapshot(), deadlineAt: STARTED_AT }, "deadlineAt must be after"],
+      [
+        {
+          ...snapshot(),
+          state: "failed",
+          updatedAt: "2026-08-17T10:02:00.000Z",
+          finishedAt: "2026-08-17T09:59:00.000Z",
+          tracks: [{ ...track(1), data: { ...track(1).data, status: "failed" } }],
+        },
+        "finishedAt must not be before",
+      ],
+      [{ ...snapshot(), tracks: [null] }, "tracks[0] must be an object"],
+      [{ ...snapshot(), tracks: [{ key: "bad key", data: track(1).data }] }, "key must match"],
+      [{ ...snapshot(), tracks: [{ key: "records", data: null }] }, "data must be an object"],
+      [{ ...snapshot(), cost: null }, "cost must be an object"],
+      [
+        { ...snapshot(), cost: { settledUsd: -1, reservedUsd: 0 } },
+        "settledUsd must be a finite non-negative number",
+      ],
+      [
+        { ...snapshot(), cost: { settledUsd: 0, reservedUsd: 0, token: "secret" } },
+        "cost.token is not supported",
+      ],
+    ];
+    for (const [value, message] of invalid) {
+      expect(() => validateJobProgressSnapshot(value)).toThrow(message);
+    }
+  });
+
+  it("rejects excessive track and snapshot sizes", () => {
+    expect(() =>
+      validateJobProgressSnapshot({
+        ...snapshot(),
+        tracks: Array.from({ length: 129 }, (_value, index) => ({
+          ...track(1),
+          key: `track-${index}`,
+        })),
+      }),
+    ).toThrow("at most 128 entries");
+    expect(() =>
+      validateJobProgressSnapshot({ ...snapshot(), application: "x".repeat(70_000) }),
+    ).toThrow("at most 65536 bytes");
+  });
+
   it("snapshots mutable track input", () => {
     const input = snapshot();
     const validated = validateJobProgressSnapshot(input);
@@ -111,6 +163,27 @@ describe("durable job progress", () => {
         finishedAt: "2026-08-17T10:01:00.000Z",
       }),
     ).toThrow("tracks must be terminal");
+  });
+
+  it("rejects invalid reporter bounds", () => {
+    expect(() =>
+      createJobProgressReporter({
+        ...reporterOptions(
+          async () => undefined,
+          () => new Date(STARTED_AT),
+        ),
+        minimumIntervalMs: -1,
+      }),
+    ).toThrow("minimumIntervalMs must be a non-negative safe integer");
+    expect(() =>
+      createJobProgressReporter({
+        ...reporterOptions(
+          async () => undefined,
+          () => new Date(STARTED_AT),
+        ),
+        publishTimeoutMs: 0,
+      }),
+    ).toThrow("publishTimeoutMs must be a positive safe integer");
   });
 
   it("publishes the first update, coalesces frequent updates, and flushes the latest one", async () => {
@@ -251,6 +324,31 @@ describe("durable job progress", () => {
     expect((await reporter.flush()).published).toBe(false);
     expect((await reporter.report({ tracks: [track(51)] })).published).toBe(false);
     expect(published).toHaveLength(0);
+  });
+
+  it("rejects an incompatible or terminal prior snapshot", () => {
+    expect(() =>
+      createJobProgressReporter({
+        ...reporterOptions(
+          async () => undefined,
+          () => new Date(STARTED_AT),
+        ),
+        previousSnapshot: snapshot({ application: "other" }),
+      }),
+    ).toThrow("previous snapshot application does not match");
+    expect(() =>
+      createJobProgressReporter({
+        ...reporterOptions(
+          async () => undefined,
+          () => new Date(STARTED_AT),
+        ),
+        previousSnapshot: snapshot({
+          state: "completed",
+          finishedAt: "2026-08-17T10:01:00.000Z",
+          tracks: [{ ...track(10), data: { ...track(10).data, status: "completed" } }],
+        }),
+      }),
+    ).toThrow("cannot resume from a terminal snapshot");
   });
 
   it("publishes phase changes and terminal states immediately", async () => {
@@ -395,6 +493,15 @@ describe("durable job progress", () => {
     expect(result.snapshot.sequence).toBe(3);
     expect(result.estimates[0]?.remainingMedianMs).toBe(180_000);
     expect(result.tracks[0]?.samples).toHaveLength(3);
+  });
+
+  it("rejects sample time regression across increasing sequences", () => {
+    expect(() =>
+      estimateJobProgress([
+        snapshot({ sequence: 1, updatedAt: "2026-08-17T10:02:00.000Z" }),
+        snapshot({ sequence: 2, updatedAt: "2026-08-17T10:01:00.000Z" }),
+      ]),
+    ).toThrow("updatedAt must not decrease");
   });
 
   it("rejects duplicate snapshot sequences", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@osolmaz/pi-workflows": ["./src/workflows/index.ts"],
       "@osolmaz/pi-workflows/controllers": ["./src/controllers/index.ts"],
+      "@osolmaz/pi-workflows/job-progress": ["./src/job-progress/index.ts"],
       "pi-workflows/extension": ["./src/extension/index.ts"]
     }
   },


### PR DESCRIPTION
## Summary

Remote Jobs can now report durable progress without inventing a new ETA system.
The new API writes strict snapshots through an application-owned storage callback, reuses existing Pi Workflows progress tracks, and lets monitors calculate remaining time from measured samples.
It also defines how Jobs resume sequence numbers after a restart and how monitors discover snapshots in an existing remote store.

## What Changed

The package now has one storage-neutral API for remote Job progress.
It keeps receipts and final artifacts authoritative while making live phases, counts, and cost facts observable.

- Added `@osolmaz/pi-workflows/job-progress` with the `pi-workflows.job-progress.v1` schema.
- Added strict snapshot validation, bounded snapshot size, identity checks, monotonic counters, terminal-state rules, and restart support.
- Added a coalescing reporter with bounded writes, abort signals, ordered storage writes, terminal flushes, and transient-failure recovery.
- Added snapshot-history estimation through the existing `pi-workflows.progress.v1` estimator.
- Added monitor discovery labels and documentation for Bucket-backed Jobs.
- Bumped the npm package to `0.8.0` because this adds a public pre-1.0 API.

## Testing

The full local quality gate passes.
Pi Reviewer was run repeatedly against `main`; all P0/P1 findings are resolved.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `npm pack --dry-run --json`

The first repeated full check had three unrelated controller-host tests exceed their five-second limit under local load. A clean rerun passed all 731 tests.

## Risks

The API cannot force a storage client to stop after abort.
To prevent an old mutable write from overwriting a newer snapshot, later writes wait until the underlying timed-out write settles.
Storage adapters must honor the supplied abort signal and settle promptly.

Progress snapshots are operational data only.
They do not replace receipts, hashes, manifests, or application-specific completion checks.
