### PR TITLE
feat(herdr): open workflow runs in piw

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ The npm package also includes the simpler `pi-workflows` snapshot viewer. To
 link that command from a clone, run `npm install && npm run build && npm link`,
 or run it in place with `npx tsx src/viewer/cli.ts`.
 
+## Herdr integration
+
+Pi Workflows also ships as a [Herdr](https://herdr.dev) plugin. After installing
+`piw` and Pi Workflows, link the bundled plugin once:
+
+```bash
+pi-workflows herdr setup
+```
+
+When Pi runs inside Herdr, a workflow widget shows `Ctrl+Shift+R piw`. When the widget has hidden rows, this call to action shares the existing scroll-controls line instead of taking another line.
+The shortcut opens the exact run bundle and lets you choose a split, tab, or new
+workspace. `/piw` opens the same menu, and `/piw right`, `/piw below`, `/piw
+left`, `/piw above`, `/piw tab`, or `/piw workspace` selects a placement
+directly. If a viewer for that run already exists, Pi Workflows focuses it
+instead of opening a duplicate.
+
+The plugin uses Herdr's public pane APIs and runs no service or polling loop. It
+is also available through the [Herdr plugin marketplace](https://herdr.dev/plugins/).
+
 ## Quick start
 
 Put a workflow file in `.pi/workflows/` (project) or `~/.pi/agent/workflows/`

--- a/docs/2026-08-18-herdr-piw-plan.md
+++ b/docs/2026-08-18-herdr-piw-plan.md
@@ -1,0 +1,73 @@
+---
+title: Native Herdr piw integration plan
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-18
+---
+
+# Native Herdr piw integration plan
+
+## Purpose
+
+When Pi Workflows runs inside Herdr, show a shortcut that opens the current run in `piw`. The integration must belong to Pi Workflows and ship as one package, repository, version, and release. The same repository must also qualify for Herdr's public plugin marketplace.
+
+## Requirements
+
+- Detect a live Herdr pane without polling.
+- Show `Ctrl+Shift+R piw` inside the existing workflow widget only when the integration is available. Put it on the scroll-controls line when that line exists.
+- Add `/piw` as a command fallback.
+- Let the user open the viewer to the right, below, left, above, in a new tab, or in a new workspace.
+- Open the exact run bundle rather than the runs list.
+- Focus an existing viewer for the same run instead of opening a duplicate, including after Pi reload.
+- Keep the workflow engine and run-bundle format independent of Herdr.
+- Use Herdr's public plugin, pane, workspace, tab, label, and snapshot APIs. Do not construct commands from run data.
+- Add the public repository to Herdr's plugin marketplace through the `herdr-plugin` topic.
+
+## Design
+
+### One package with two host entry points
+
+The package root will contain `herdr-plugin.toml`. Pi loads the existing extension entry point. Herdr loads a `piw` pane entry point from the same package root. A small checked-in JavaScript launcher validates `PI_WORKFLOWS_RUN_DIR` and starts `piw` with an argv array.
+
+`pi-workflows herdr setup` explicitly links the current package root with `herdr plugin link`. It is idempotent and never changes plugin registration during normal Pi startup.
+
+### Native extension adapter
+
+A Herdr adapter under `src/extension/` will own capability checks and topology operations. It will use Pi's documented `pi.exec` API with bounded timeouts. The adapter will resolve the caller with `herdr pane current --current` on every open action, parse bounded JSON, and use only returned IDs.
+
+The extension will keep a view target containing the exact run ID, workflow name, and bundle directory. The target starts after the bundle exists and lasts as long as the workflow widget. The widget renderer will keep the shortcut inside Pi's ten-line limit. It will append the call to action to the existing `shift+↑/↓ scroll` line when rows are hidden, and use a short standalone line only when no scroll-controls line exists.
+
+### Placement
+
+Right and below use Herdr plugin splits. Left and above create the corresponding right or down split and then swap the new viewer with the caller. A tab uses the current workspace. A workspace is created transactionally; if plugin pane creation fails, only that new workspace is closed.
+
+### Viewer discovery
+
+Herdr's public snapshot does not expose plugin metadata tokens. The launcher will therefore set an exact pane label derived from the run ID before starting `piw`. The adapter will inspect Herdr's public snapshot to find and focus an existing viewer after reload. It will discard stale pane references without adding a state file.
+
+## Non-goals
+
+- Do not change Herdr core or `piw`.
+- Do not add a companion Pi extension, event bridge, protocol version, daemon, poller, or new state store.
+- Do not install or link the Herdr plugin automatically during Pi startup.
+- Do not expose viewer control to the model-visible workflow tool.
+
+## Acceptance criteria
+
+- A workflow started in a normal Pi TUI outside Herdr has unchanged UI and behavior.
+- A workflow started in Herdr shows the shortcut and opens its exact bundle in `piw`.
+- All six placements work and preserve the calling pane unless the user selects a focused viewer.
+- Repeated opens and Pi reloads focus the existing run viewer.
+- Failures produce bounded, useful messages and leave no empty tab or workspace.
+- The package tarball contains the Herdr manifest and launcher.
+- `osolmaz/pi-workflows` is public, has a root `herdr-plugin.toml`, and has the `herdr-plugin` GitHub topic.
+
+## Verification
+
+- `npm run check`
+- `npm run test:e2e`
+- `npx slophammer-ts@latest dry .`
+- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
+- `npx -y @simpledoc/simpledoc check`
+- `npm pack --dry-run`
+- Link the package with `pi-workflows herdr setup` in a disposable Herdr test session.
+- Start a finite test workflow in real Pi, open `piw` with `Ctrl+Shift+R`, verify the exact run ID, then test pane reuse and cleanup.

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -30,6 +30,20 @@ cargo install pi-workflows
 Direct filesystem mode and connected mode use the same semantic run view.
 The protocol is the network form of that view.
 
+## Herdr
+
+The npm package contains a native Herdr plugin. Link the installed package with
+`pi-workflows herdr setup`. A workflow running in Pi inside Herdr then shows
+`Ctrl+Shift+R piw` in its widget. When rows are hidden, the call to action shares
+the scroll-controls line. The shortcut and `/piw` command open
+the current bundle directly in a managed Herdr pane. The placement menu supports
+right, below, left, above, a new tab, and a new workspace.
+
+The integration resolves the calling pane at invocation time and uses returned
+Herdr IDs for every layout change. Existing viewers are found from their exact
+run title and focused after Pi reload. Normal Pi sessions do not probe Herdr or
+show the shortcut.
+
 ## Layout
 
 The normal layout contains a run browser, graph, inspector, and two-line replay

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,0 +1,12 @@
+id = "osolmaz.pi-workflows"
+name = "Pi Workflows"
+version = "0.9.0"
+min_herdr_version = "0.7.0"
+description = "Open the active Pi Workflows run in piw from a managed Herdr pane."
+platforms = ["linux", "macos"]
+
+[[panes]]
+id = "piw"
+title = "piw"
+placement = "split"
+command = ["node", "plugins/herdr/viewer.mjs"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"
@@ -23,6 +23,8 @@
     "skills",
     "examples",
     "docs",
+    "plugins/herdr",
+    "herdr-plugin.toml",
     "README.md",
     "LICENSE"
   ],

--- a/plugins/herdr/viewer.mjs
+++ b/plugins/herdr/viewer.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const runId = process.env.PI_WORKFLOWS_RUN_ID ?? "";
+const runDir = process.env.PI_WORKFLOWS_RUN_DIR ?? "";
+
+if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/u.test(runId)) {
+  fail("PI_WORKFLOWS_RUN_ID is missing or invalid.");
+}
+if (!path.isAbsolute(runDir) || path.basename(runDir) !== runId) {
+  fail("PI_WORKFLOWS_RUN_DIR must be the absolute bundle directory for the selected run.");
+}
+if (!fs.existsSync(path.join(runDir, "manifest.json"))) {
+  fail(`Workflow bundle not found: ${runDir}`);
+}
+
+const paneId = process.env.HERDR_PANE_ID ?? "";
+if (!/^[A-Za-z0-9]+:p[A-Za-z0-9]+$/u.test(paneId)) {
+  fail("HERDR_PANE_ID is missing or invalid.");
+}
+
+const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+const label = `piw · ${runId}`;
+const labeled = spawnSync(herdr, ["pane", "rename", paneId, label], {
+  encoding: "utf8",
+  stdio: ["ignore", "ignore", "pipe"],
+});
+if (labeled.error) fail(`Could not label the Herdr viewer pane: ${labeled.error.message}`);
+if (labeled.status !== 0) {
+  fail(`Could not label the Herdr viewer pane: ${bounded(labeled.stderr) || "unknown error"}`);
+}
+
+const viewer = spawn("piw", [runDir], { stdio: "inherit" });
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => viewer.kill(signal));
+}
+viewer.on("error", (error) => fail(`Could not start piw: ${error.message}`));
+viewer.on("exit", (code, signal) => {
+  process.exitCode = signal ? 1 : (code ?? 1);
+});
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function bounded(value) {
+  const compact = String(value ?? "")
+    .replace(/[\r\n\t]+/gu, " ")
+    .replace(/ +/gu, " ")
+    .trim();
+  return compact.length <= 300 ? compact : `${compact.slice(0, 299)}…`;
+}

--- a/slophammer.yml
+++ b/slophammer.yml
@@ -37,13 +37,17 @@ typescript:
         - src/builtins
         - src/controllers
         - src/render
+        - src/herdr
     # The host runs headlessly; it spawns pi but never embeds it.
     - from: src/host
       allow:
         - src/workflows
         - src/builtins
         - src/controllers
-    # The viewer only reads run bundles and dispatches the host command; it
+    # Herdr setup is a standalone host integration with no engine imports.
+    - from: src/herdr
+      allow: []
+    # The viewer only reads run bundles and dispatches host commands; it
     # must never import the extension.
     - from: src/viewer
       allow:
@@ -51,3 +55,4 @@ typescript:
         - src/controllers
         - src/render
         - src/host
+        - src/herdr

--- a/src/extension/herdr-viewer.ts
+++ b/src/extension/herdr-viewer.ts
@@ -1,0 +1,350 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { HERDR_PLUGIN_ENTRYPOINT, HERDR_PLUGIN_ID } from "../herdr/constants.js";
+export const PIW_SHORTCUT = "ctrl+shift+r";
+export const PIW_SHORTCUT_HINT = "Ctrl+Shift+R piw";
+
+const COMMAND_TIMEOUT_MS = 5_000;
+const MAX_JSON_CHARS = 1_000_000;
+const VIEWER_LABEL_PREFIX = "piw · ";
+
+export const VIEWER_PLACEMENTS = ["right", "below", "left", "above", "tab", "workspace"] as const;
+
+export type ViewerPlacement = (typeof VIEWER_PLACEMENTS)[number];
+
+export type WorkflowViewTarget = {
+  runId: string;
+  workflowName: string;
+  runDir: string;
+};
+
+export type HerdrCapability = { available: true } | { available: false; reason: string };
+
+type Exec = ExtensionAPI["exec"];
+
+type HerdrPane = {
+  paneId: string;
+  tabId: string;
+  workspaceId: string;
+  label?: string;
+};
+
+type OpenedPane = {
+  paneId: string;
+  tabId: string;
+  workspaceId: string;
+};
+
+export class HerdrWorkflowViewer {
+  constructor(
+    private readonly exec: Exec,
+    private readonly env: NodeJS.ProcessEnv = process.env,
+  ) {}
+
+  async probe(): Promise<HerdrCapability> {
+    if (this.env.HERDR_ENV !== "1") {
+      return { available: false, reason: "Pi is not running in Herdr." };
+    }
+    try {
+      await this.currentPane();
+      const plugin = await this.runJson("herdr", [
+        "plugin",
+        "list",
+        "--plugin",
+        HERDR_PLUGIN_ID,
+        "--json",
+      ]);
+      if (!pluginIsEnabled(plugin)) {
+        return {
+          available: false,
+          reason: `Herdr plugin ${HERDR_PLUGIN_ID} is not linked and enabled.`,
+        };
+      }
+      await this.run("piw", ["--version"]);
+      return { available: true };
+    } catch (error) {
+      return { available: false, reason: errorMessage(error) };
+    }
+  }
+
+  async focusExisting(target: WorkflowViewTarget): Promise<boolean> {
+    const existing = await this.find(target);
+    if (existing === undefined) return false;
+    try {
+      await this.run("herdr", ["plugin", "pane", "focus", existing.paneId]);
+      return true;
+    } catch {
+      // The pane can close between the snapshot and focus request.
+      return false;
+    }
+  }
+
+  async open(
+    target: WorkflowViewTarget,
+    placement: ViewerPlacement,
+    cwd: string,
+  ): Promise<{ paneId: string; reused: boolean }> {
+    const existing = await this.find(target);
+    if (existing !== undefined) {
+      try {
+        await this.run("herdr", ["plugin", "pane", "focus", existing.paneId]);
+        return { paneId: existing.paneId, reused: true };
+      } catch {
+        // Continue with a new pane when the old pane closed after discovery.
+      }
+    }
+
+    const caller = await this.currentPane();
+    if (placement === "workspace") {
+      return { paneId: await this.openWorkspace(target, cwd), reused: false };
+    }
+
+    const opened = await this.openPluginPane(target, placement, caller, cwd);
+    if (placement === "left" || placement === "above") {
+      try {
+        await this.run("herdr", [
+          "pane",
+          "swap",
+          "--source-pane",
+          opened.paneId,
+          "--target-pane",
+          caller.paneId,
+        ]);
+      } catch (error) {
+        await this.closePane(opened.paneId);
+        throw error;
+      }
+    }
+    return { paneId: opened.paneId, reused: false };
+  }
+
+  async find(target: WorkflowViewTarget): Promise<HerdrPane | undefined> {
+    const snapshot = await this.runJson("herdr", ["api", "snapshot"]);
+    return snapshotPanes(snapshot).find((pane) => pane.label === viewerPaneLabel(target.runId));
+  }
+
+  private async currentPane(): Promise<HerdrPane> {
+    return parseCurrentPane(await this.runJson("herdr", ["pane", "current", "--current"]));
+  }
+
+  private async openPluginPane(
+    target: WorkflowViewTarget,
+    placement: Exclude<ViewerPlacement, "workspace">,
+    caller: HerdrPane,
+    cwd: string,
+  ): Promise<OpenedPane> {
+    const args = [
+      "plugin",
+      "pane",
+      "open",
+      "--plugin",
+      HERDR_PLUGIN_ID,
+      "--entrypoint",
+      HERDR_PLUGIN_ENTRYPOINT,
+      "--cwd",
+      cwd,
+      "--env",
+      `PI_WORKFLOWS_RUN_ID=${target.runId}`,
+      "--env",
+      `PI_WORKFLOWS_RUN_DIR=${target.runDir}`,
+      "--focus",
+    ];
+    if (placement === "tab") {
+      args.push("--placement", "tab", "--workspace", caller.workspaceId);
+    } else {
+      args.push(
+        "--placement",
+        "split",
+        "--target-pane",
+        caller.paneId,
+        "--direction",
+        placement === "below" || placement === "above" ? "down" : "right",
+      );
+    }
+    return parseOpenedPane(await this.runJson("herdr", args));
+  }
+
+  private async openWorkspace(target: WorkflowViewTarget, cwd: string): Promise<string> {
+    const created = parseCreatedWorkspace(
+      await this.runJson("herdr", [
+        "workspace",
+        "create",
+        "--cwd",
+        cwd,
+        "--label",
+        workspaceLabel(target.workflowName),
+        "--no-focus",
+      ]),
+    );
+    try {
+      const opened = parseOpenedPane(
+        await this.runJson("herdr", [
+          "plugin",
+          "pane",
+          "open",
+          "--plugin",
+          HERDR_PLUGIN_ID,
+          "--entrypoint",
+          HERDR_PLUGIN_ENTRYPOINT,
+          "--placement",
+          "tab",
+          "--workspace",
+          created.workspaceId,
+          "--cwd",
+          cwd,
+          "--env",
+          `PI_WORKFLOWS_RUN_ID=${target.runId}`,
+          "--env",
+          `PI_WORKFLOWS_RUN_DIR=${target.runDir}`,
+          "--focus",
+        ]),
+      );
+      await this.run("herdr", ["tab", "close", created.bootstrapTabId]);
+      return opened.paneId;
+    } catch (error) {
+      await this.run("herdr", ["workspace", "close", created.workspaceId]).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  private async closePane(paneId: string): Promise<void> {
+    await this.run("herdr", ["plugin", "pane", "close", paneId]).catch(() => undefined);
+  }
+
+  private async run(command: string, args: string[]): Promise<string> {
+    const result = await this.exec(command, args, { timeout: COMMAND_TIMEOUT_MS });
+    if (result.killed) {
+      throw new Error(`${command} timed out.`);
+    }
+    if (result.code !== 0) {
+      const message = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+      throw new Error(`${command} failed: ${boundedText(message)}`);
+    }
+    return result.stdout;
+  }
+
+  private async runJson(command: string, args: string[]): Promise<unknown> {
+    const stdout = await this.run(command, args);
+    if (stdout.length > MAX_JSON_CHARS) {
+      throw new Error(`${command} returned too much data.`);
+    }
+    try {
+      return JSON.parse(stdout) as unknown;
+    } catch {
+      throw new Error(`${command} returned invalid JSON.`);
+    }
+  }
+}
+
+export function parseViewerPlacement(value: string): ViewerPlacement | undefined {
+  return VIEWER_PLACEMENTS.find((placement) => placement === value);
+}
+
+export function viewerPaneLabel(runId: string): string {
+  return `${VIEWER_LABEL_PREFIX}${runId}`;
+}
+
+function pluginIsEnabled(value: unknown): boolean {
+  const result = recordValue(value, "result");
+  const plugins = result === undefined ? undefined : arrayValue(result, "plugins");
+  return (
+    plugins?.some(
+      (plugin) =>
+        recordValue(plugin, "plugin_id") === HERDR_PLUGIN_ID &&
+        recordValue(plugin, "enabled") === true,
+    ) === true
+  );
+}
+
+function parseCurrentPane(value: unknown): HerdrPane {
+  const result = requiredRecord(value, "result", "Herdr pane response");
+  return paneFromValue(requiredRecord(result, "pane", "Herdr pane response"));
+}
+
+function parseOpenedPane(value: unknown): OpenedPane {
+  const result = requiredRecord(value, "result", "Herdr plugin pane response");
+  const pluginPane = requiredRecord(result, "plugin_pane", "Herdr plugin pane response");
+  return paneFromValue(requiredRecord(pluginPane, "pane", "Herdr plugin pane response"));
+}
+
+function parseCreatedWorkspace(value: unknown): {
+  workspaceId: string;
+  bootstrapTabId: string;
+} {
+  const result = requiredRecord(value, "result", "Herdr workspace response");
+  const workspace = requiredRecord(result, "workspace", "Herdr workspace response");
+  const rootPane = requiredRecord(result, "root_pane", "Herdr workspace response");
+  return {
+    workspaceId: requiredString(workspace, "workspace_id", "Herdr workspace response"),
+    bootstrapTabId: requiredString(rootPane, "tab_id", "Herdr workspace response"),
+  };
+}
+
+function snapshotPanes(value: unknown): HerdrPane[] {
+  const result = requiredRecord(value, "result", "Herdr snapshot");
+  const snapshot = requiredRecord(result, "snapshot", "Herdr snapshot");
+  const panes = arrayValue(snapshot, "panes");
+  if (panes === undefined) throw new Error("Herdr snapshot has no panes.");
+  return panes.flatMap((pane) => {
+    try {
+      return [paneFromValue(pane)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function paneFromValue(value: unknown): HerdrPane {
+  if (!isRecord(value)) throw new Error("Herdr returned an invalid pane.");
+  const label = recordValue(value, "label");
+  return {
+    paneId: requiredString(value, "pane_id", "Herdr pane"),
+    tabId: requiredString(value, "tab_id", "Herdr pane"),
+    workspaceId: requiredString(value, "workspace_id", "Herdr pane"),
+    ...(typeof label === "string" ? { label } : {}),
+  };
+}
+
+function workspaceLabel(workflowName: string): string {
+  const compact = workflowName.replace(/[\r\n\t]+/gu, " ").trim();
+  return `piw · ${(compact || "workflow").slice(0, 60)}`;
+}
+
+function requiredRecord(value: unknown, key: string, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} is invalid.`);
+  const nested = value[key];
+  if (!isRecord(nested)) throw new Error(`${label} has no ${key}.`);
+  return nested;
+}
+
+function requiredString(value: Record<string, unknown>, key: string, label: string): string {
+  const nested = value[key];
+  if (typeof nested !== "string" || nested.length === 0) {
+    throw new Error(`${label} has no ${key}.`);
+  }
+  return nested;
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function arrayValue(value: unknown, key: string): unknown[] | undefined {
+  const nested = recordValue(value, key);
+  return Array.isArray(nested) ? nested : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function boundedText(value: string): string {
+  const compact = value
+    .replace(/[\r\n\t]+/gu, " ")
+    .replace(/ +/gu, " ")
+    .trim();
+  return compact.length <= 300 ? compact : `${compact.slice(0, 299)}…`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/extension/herdr-viewer.ts
+++ b/src/extension/herdr-viewer.ts
@@ -19,6 +19,12 @@ export type WorkflowViewTarget = {
 
 export type HerdrCapability = { available: true } | { available: false; reason: string };
 
+export type ViewerOpenResult = {
+  paneId: string;
+  reused: boolean;
+  warning?: string;
+};
+
 type Exec = ExtensionAPI["exec"];
 
 type HerdrPane = {
@@ -35,6 +41,9 @@ type OpenedPane = {
 };
 
 export class HerdrWorkflowViewer {
+  private readonly knownPanes = new Map<string, string>();
+  private readonly opening = new Map<string, Promise<ViewerOpenResult>>();
+
   constructor(
     private readonly exec: Exec,
     private readonly env: NodeJS.ProcessEnv = process.env,
@@ -67,35 +76,39 @@ export class HerdrWorkflowViewer {
   }
 
   async focusExisting(target: WorkflowViewTarget): Promise<boolean> {
-    const existing = await this.find(target);
-    if (existing === undefined) return false;
-    try {
-      await this.run("herdr", ["plugin", "pane", "focus", existing.paneId]);
-      return true;
-    } catch {
-      // The pane can close between the snapshot and focus request.
-      return false;
-    }
+    return (await this.findAndFocus(target)) !== undefined;
   }
 
   async open(
     target: WorkflowViewTarget,
     placement: ViewerPlacement,
     cwd: string,
-  ): Promise<{ paneId: string; reused: boolean }> {
-    const existing = await this.find(target);
-    if (existing !== undefined) {
-      try {
-        await this.run("herdr", ["plugin", "pane", "focus", existing.paneId]);
-        return { paneId: existing.paneId, reused: true };
-      } catch {
-        // Continue with a new pane when the old pane closed after discovery.
-      }
+  ): Promise<ViewerOpenResult> {
+    const pending = this.opening.get(target.runId);
+    if (pending !== undefined) return await pending;
+
+    const opening = this.openOnce(target, placement, cwd).finally(() => {
+      if (this.opening.get(target.runId) === opening) this.opening.delete(target.runId);
+    });
+    this.opening.set(target.runId, opening);
+    return await opening;
+  }
+
+  private async openOnce(
+    target: WorkflowViewTarget,
+    placement: ViewerPlacement,
+    cwd: string,
+  ): Promise<ViewerOpenResult> {
+    const existingPaneId = await this.findAndFocus(target);
+    if (existingPaneId !== undefined) {
+      return { paneId: existingPaneId, reused: true };
     }
 
     const caller = await this.currentPane();
     if (placement === "workspace") {
-      return { paneId: await this.openWorkspace(target, cwd), reused: false };
+      const opened = await this.openWorkspace(target, cwd);
+      this.knownPanes.set(target.runId, opened.paneId);
+      return { ...opened, reused: false };
     }
 
     const opened = await this.openPluginPane(target, placement, caller, cwd);
@@ -114,7 +127,31 @@ export class HerdrWorkflowViewer {
         throw error;
       }
     }
+    this.knownPanes.set(target.runId, opened.paneId);
     return { paneId: opened.paneId, reused: false };
+  }
+
+  private async findAndFocus(target: WorkflowViewTarget): Promise<string | undefined> {
+    const knownPaneId = this.knownPanes.get(target.runId);
+    if (knownPaneId !== undefined) {
+      try {
+        await this.run("herdr", ["plugin", "pane", "focus", knownPaneId]);
+        return knownPaneId;
+      } catch {
+        this.knownPanes.delete(target.runId);
+      }
+    }
+
+    const existing = await this.find(target);
+    if (existing === undefined) return undefined;
+    try {
+      await this.run("herdr", ["plugin", "pane", "focus", existing.paneId]);
+      this.knownPanes.set(target.runId, existing.paneId);
+      return existing.paneId;
+    } catch {
+      // The pane can close between the snapshot and focus request.
+      return undefined;
+    }
   }
 
   async find(target: WorkflowViewTarget): Promise<HerdrPane | undefined> {
@@ -163,7 +200,10 @@ export class HerdrWorkflowViewer {
     return parseOpenedPane(await this.runJson("herdr", args));
   }
 
-  private async openWorkspace(target: WorkflowViewTarget, cwd: string): Promise<string> {
+  private async openWorkspace(
+    target: WorkflowViewTarget,
+    cwd: string,
+  ): Promise<{ paneId: string; warning?: string }> {
     const created = parseCreatedWorkspace(
       await this.runJson("herdr", [
         "workspace",
@@ -175,8 +215,9 @@ export class HerdrWorkflowViewer {
         "--no-focus",
       ]),
     );
+    let opened: OpenedPane;
     try {
-      const opened = parseOpenedPane(
+      opened = parseOpenedPane(
         await this.runJson("herdr", [
           "plugin",
           "pane",
@@ -198,11 +239,19 @@ export class HerdrWorkflowViewer {
           "--focus",
         ]),
       );
-      await this.run("herdr", ["tab", "close", created.bootstrapTabId]);
-      return opened.paneId;
     } catch (error) {
       await this.run("herdr", ["workspace", "close", created.workspaceId]).catch(() => undefined);
       throw error;
+    }
+
+    try {
+      await this.run("herdr", ["tab", "close", created.bootstrapTabId]);
+      return { paneId: opened.paneId };
+    } catch (error) {
+      return {
+        paneId: opened.paneId,
+        warning: `The piw viewer opened, but its empty bootstrap tab could not be closed: ${errorMessage(error)}`,
+      };
     }
   }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { builtinWorkflowCatalog } from "../builtins/catalog.js";
@@ -486,7 +487,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     workflowViewTarget = {
       runId: state.runId,
       workflowName: state.workflowName,
-      runDir: new WorkflowRunStore().runDirFor(state.runId),
+      runDir: path.resolve(new WorkflowRunStore().runDirFor(state.runId)),
     };
     renderWidget(ctx);
   };

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -37,6 +37,16 @@ import {
   type PiChildWorkflowStarter,
 } from "./controller-host.js";
 import { ConversationStepExecutor } from "./executor.js";
+import {
+  HerdrWorkflowViewer,
+  parseViewerPlacement,
+  PIW_SHORTCUT,
+  PIW_SHORTCUT_HINT,
+  VIEWER_PLACEMENTS,
+  type HerdrCapability,
+  type ViewerPlacement,
+  type WorkflowViewTarget,
+} from "./herdr-viewer.js";
 import { SessionRecorder } from "./recorder.js";
 import {
   registerWorkflowAgentStepMessageRenderer,
@@ -60,6 +70,18 @@ const MAX_STATUS_ERROR_CHARS = 4_000;
 const MAX_WORKFLOW_LIST_ITEMS = 50;
 const MAX_WORKFLOW_LIST_NAME_CHARS = 3_500;
 const PRESENTATION_TIMEOUT_MS = 30_000;
+
+const PIW_PLACEMENT_LABELS: Readonly<Record<ViewerPlacement, string>> = {
+  right: "Split right",
+  below: "Split below",
+  left: "Split left",
+  above: "Split above",
+  tab: "New tab",
+  workspace: "New workspace",
+};
+const PIW_PLACEMENT_BY_LABEL = new Map(
+  VIEWER_PLACEMENTS.map((placement) => [PIW_PLACEMENT_LABELS[placement], placement] as const),
+);
 
 class PresentationSupersededError extends Error {}
 class PresentationTimeoutError extends Error {}
@@ -228,6 +250,17 @@ type WorkflowWidgetContent = string[] | WorkflowWidgetFactory;
 
 export default function piWorkflows(pi: ExtensionAPI) {
   registerWorkflowAgentStepMessageRenderer(pi);
+
+  const herdrEnabled = process.env.HERDR_ENV === "1";
+  const herdrViewer = new HerdrWorkflowViewer((command, args, options) =>
+    pi.exec(command, args, options),
+  );
+  let herdrCapability: HerdrCapability = {
+    available: false,
+    reason: "Herdr integration has not been checked.",
+  };
+  let workflowViewTarget: WorkflowViewTarget | null = null;
+  let herdrProbeGeneration = 0;
 
   // One runner identity per session; it names this session in run claims.
   const runnerId = randomUUID();
@@ -408,6 +441,12 @@ export default function piWorkflows(pi: ExtensionAPI) {
         width,
         theme,
         widgetSource.updateHistory,
+        ctx.mode === "tui" &&
+          herdrEnabled &&
+          herdrCapability.available &&
+          workflowViewTarget?.runId === widgetSource.state.runId
+          ? PIW_SHORTCUT_HINT
+          : undefined,
       );
       widgetShownScroll = view.scroll;
       widgetMaxScroll = view.maxScroll;
@@ -444,14 +483,73 @@ export default function piWorkflows(pi: ExtensionAPI) {
       snapshot,
       ...(updateHistory !== undefined ? { updateHistory: [...updateHistory] } : {}),
     };
+    workflowViewTarget = {
+      runId: state.runId,
+      workflowName: state.workflowName,
+      runDir: new WorkflowRunStore().runDirFor(state.runId),
+    };
     renderWidget(ctx);
   };
 
   const clearWidget = (ctx: ExtensionContext) => {
     widgetSource = null;
+    workflowViewTarget = null;
     widgetScroll = null;
     setWidget(ctx, undefined);
     setStatus(ctx, undefined);
+  };
+
+  const refreshHerdrCapability = async (ctx: ExtensionContext): Promise<HerdrCapability> => {
+    const generation = ++herdrProbeGeneration;
+    const capability = await herdrViewer.probe();
+    if (!sessionClosed && generation === herdrProbeGeneration) {
+      herdrCapability = capability;
+      renderWidget(ctx);
+    }
+    return capability;
+  };
+
+  const selectPiwPlacement = async (
+    ctx: ExtensionContext,
+  ): Promise<ViewerPlacement | undefined> => {
+    if (!ctx.hasUI || ctx.mode !== "tui") return undefined;
+    const label = await ctx.ui.select(
+      "Open workflow in piw",
+      VIEWER_PLACEMENTS.map((placement) => PIW_PLACEMENT_LABELS[placement]),
+    );
+    return label === undefined ? undefined : PIW_PLACEMENT_BY_LABEL.get(label);
+  };
+
+  const openPiw = async (
+    ctx: ExtensionContext,
+    requestedPlacement?: ViewerPlacement,
+  ): Promise<void> => {
+    const target = workflowViewTarget;
+    if (target === null) {
+      notify(ctx, "No workflow run is available to open in piw.", "warning");
+      return;
+    }
+    const capability = await refreshHerdrCapability(ctx);
+    if (!capability.available) {
+      notify(ctx, capability.reason, "warning");
+      return;
+    }
+    try {
+      if (await herdrViewer.focusExisting(target)) {
+        notify(ctx, `Focused the piw viewer for ${target.workflowName}.`);
+        return;
+      }
+      const placement = requestedPlacement ?? (await selectPiwPlacement(ctx));
+      if (placement === undefined) {
+        if (!ctx.hasUI || ctx.mode !== "tui") {
+          notify(ctx, "Specify a piw placement: right, below, left, above, tab, or workspace.");
+        }
+        return;
+      }
+      await herdrViewer.open(target, placement, ctx.cwd);
+    } catch (error) {
+      notify(ctx, `Could not open piw: ${errorMessage(error)}`, "error");
+    }
   };
 
   const scrollWidget = (ctx: ExtensionContext, delta: number) => {
@@ -890,6 +988,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
       run.renewTimer.unref?.();
     }
     clearWidgetTimer();
+    workflowViewTarget = null;
     startWidgetTicker(ctx, run);
     if (!options.quiet) {
       notify(ctx, `Workflow ${workflow.name} started. Follow it live with: pi-workflows view`);
@@ -1462,6 +1561,25 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
   };
 
+  pi.registerCommand("piw", {
+    description: "Open the current workflow run in piw through Herdr",
+    getArgumentCompletions: async (prefix: string) => {
+      const items = VIEWER_PLACEMENTS.filter((placement) => placement.startsWith(prefix)).map(
+        (placement) => ({ value: placement, label: placement }),
+      );
+      return items.length > 0 ? items : null;
+    },
+    handler: async (args, ctx) => {
+      const value = args.trim();
+      const placement = value.length === 0 ? undefined : parseViewerPlacement(value);
+      if (value.length > 0 && placement === undefined) {
+        notify(ctx, "piw placement must be right, below, left, above, tab, or workspace.", "error");
+        return;
+      }
+      await openPiw(ctx, placement);
+    },
+  });
+
   pi.registerCommand("workflow", {
     description:
       "Run or manage a workflow: /workflow <name-or-path> [task | --input-json {…}]; also: status, pause, resume, cancel, answer",
@@ -1698,6 +1816,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
     },
   });
 
+  if (herdrEnabled) {
+    pi.registerShortcut(PIW_SHORTCUT, {
+      description: "Open the current workflow run in piw",
+      handler: async (ctx) => await openPiw(ctx),
+    });
+  }
+
   pi.registerShortcut("shift+up", {
     description: "Scroll the workflow widget up",
     handler: (ctx) => scrollWidget(ctx, -WIDGET_SCROLL_STEP),
@@ -1711,6 +1836,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     sessionClosed = false;
     controllerContext = ctx;
+    if (herdrEnabled) void refreshHerdrCapability(ctx);
     try {
       const queue = ensureRunQueueStore(ctx.cwd);
       const migration = await migrateLegacyWorkflowSources({
@@ -1859,6 +1985,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async () => {
     sessionClosed = true;
+    herdrProbeGeneration += 1;
     systemTurnAbort = null;
     suppressWorkflowAssistantTail = false;
     supersedePresentation();
@@ -1889,6 +2016,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     clearWidgetTimer();
     stopWidgetTicker();
     widgetSource = null;
+    workflowViewTarget = null;
     widgetScroll = null;
   });
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -547,7 +547,8 @@ export default function piWorkflows(pi: ExtensionAPI) {
         }
         return;
       }
-      await herdrViewer.open(target, placement, ctx.cwd);
+      const opened = await herdrViewer.open(target, placement, ctx.cwd);
+      if (opened.warning !== undefined) notify(ctx, opened.warning, "warning");
     } catch (error) {
       notify(ctx, `Could not open piw: ${errorMessage(error)}`, "error");
     }

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -372,7 +372,7 @@ function windowLines(
   theme?: WidgetTheme,
   actionHint?: string,
 ): { lines: string[]; scroll: number; maxScroll: number } {
-  if (lines.length <= budget) {
+  if (lines.length <= budget && actionHint === undefined) {
     return { lines, scroll: 0, maxScroll: 0 };
   }
   const inner = Math.max(1, budget - 1);

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -78,6 +78,7 @@ export function buildWidgetView(
   width = Number.POSITIVE_INFINITY,
   theme?: WidgetTheme,
   updateHistory?: WorkflowUpdateRecord[],
+  actionHint?: string,
 ): WidgetView {
   const availableWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : width;
   if (availableWidth === 0) return { lines: [], scroll: 0, maxScroll: 0 };
@@ -102,12 +103,18 @@ export function buildWidgetView(
       paint(theme, "warning", `  waiting on checkpoint: ${sanitizeText(state.waitingOn)}`),
     );
   }
-
+  const hint = actionHint?.trim() ? sanitizeText(actionHint) : undefined;
   const progress = progressLines(state, now, updateHistory).slice(0, 4);
-  const budget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
+  const baseBudget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
   const nodes = displayNodeIds(snapshot).map((nodeId) =>
     compactNodeLine(state, snapshot, nodeId, now, paused, theme),
   );
+  const combineHintWithWindow =
+    hint !== undefined && nodes.length > 0 && nodes.length + 1 > baseBudget;
+  if (hint !== undefined && !combineHintWithWindow) {
+    footer.push(paint(theme, "dim", `  ${hint}`));
+  }
+  const budget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
   if (nodes.length === 0 || budget <= 0) {
     return {
       lines: fitLines(
@@ -120,7 +127,14 @@ export function buildWidgetView(
   }
 
   const anchor = scroll ?? compactFocusIndex(state, snapshot);
-  const windowed = windowLines(nodes, budget, anchor, scroll !== null, theme);
+  const windowed = windowLines(
+    nodes,
+    budget,
+    anchor,
+    scroll !== null,
+    theme,
+    combineHintWithWindow ? hint : undefined,
+  );
   const indentation = availableWidth >= 3 ? "  " : "";
   return {
     lines: fitLines(
@@ -356,6 +370,7 @@ function windowLines(
   anchor: number,
   anchorIsStart: boolean,
   theme?: WidgetTheme,
+  actionHint?: string,
 ): { lines: string[]; scroll: number; maxScroll: number } {
   if (lines.length <= budget) {
     return { lines, scroll: 0, maxScroll: 0 };
@@ -369,7 +384,10 @@ function windowLines(
   const directions = [above > 0 ? `↑ ${above}` : "", below > 0 ? `↓ ${below}` : ""]
     .filter(Boolean)
     .join(" · ");
-  out.push(paint(theme, "dim", `${directions} more · shift+↑/↓ scroll`));
+  const controls = [`${directions} more`, "shift+↑/↓ scroll", actionHint]
+    .filter((item): item is string => Boolean(item))
+    .join(" · ");
+  out.push(paint(theme, "dim", controls));
   return { lines: out, scroll: start, maxScroll: Math.max(0, lines.length - inner) };
 }
 

--- a/src/herdr/constants.ts
+++ b/src/herdr/constants.ts
@@ -1,0 +1,2 @@
+export const HERDR_PLUGIN_ID = "osolmaz.pi-workflows";
+export const HERDR_PLUGIN_ENTRYPOINT = "piw";

--- a/src/herdr/setup.ts
+++ b/src/herdr/setup.ts
@@ -1,0 +1,93 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { HERDR_PLUGIN_ID } from "./constants.js";
+
+export type HerdrSetupResult = {
+  changed: boolean;
+  message: string;
+};
+
+type Spawn = (command: string, args: readonly string[]) => SpawnSyncReturns<string>;
+
+export function setupHerdrPlugin(packageRoot: string, spawn: Spawn = runCommand): HerdrSetupResult {
+  const root = path.resolve(packageRoot);
+  const manifest = path.join(root, "herdr-plugin.toml");
+  if (!fs.existsSync(manifest)) {
+    throw new Error(`Herdr plugin manifest not found: ${manifest}`);
+  }
+
+  const listed = spawn("herdr", ["plugin", "list", "--plugin", HERDR_PLUGIN_ID, "--json"]);
+  if (listed.error) throw new Error(`Could not run Herdr: ${listed.error.message}`);
+  if (listed.status !== 0) {
+    throw new Error(`Could not inspect Herdr plugins: ${bounded(listed.stderr || listed.stdout)}`);
+  }
+  const installed = installedPlugin(listed.stdout);
+  if (installed !== undefined) {
+    if (path.resolve(installed.root) !== root) {
+      throw new Error(
+        `Herdr plugin ${HERDR_PLUGIN_ID} is already registered from ${installed.root}. Unlink it before linking ${root}.`,
+      );
+    }
+    if (installed.enabled) {
+      return { changed: false, message: `Herdr plugin ${HERDR_PLUGIN_ID} is already linked.` };
+    }
+    const enabled = spawn("herdr", ["plugin", "enable", HERDR_PLUGIN_ID]);
+    if (enabled.error) throw new Error(`Could not run Herdr: ${enabled.error.message}`);
+    if (enabled.status !== 0) {
+      throw new Error(
+        `Could not enable the Herdr plugin: ${bounded(enabled.stderr || enabled.stdout)}`,
+      );
+    }
+    return { changed: true, message: `Enabled Herdr plugin ${HERDR_PLUGIN_ID}.` };
+  }
+
+  const linked = spawn("herdr", ["plugin", "link", root]);
+  if (linked.error) throw new Error(`Could not run Herdr: ${linked.error.message}`);
+  if (linked.status !== 0) {
+    throw new Error(`Could not link the Herdr plugin: ${bounded(linked.stderr || linked.stdout)}`);
+  }
+  return { changed: true, message: `Linked Herdr plugin ${HERDR_PLUGIN_ID} from ${root}.` };
+}
+
+function installedPlugin(stdout: string): { root: string; enabled: boolean } | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout) as unknown;
+  } catch {
+    throw new Error("Herdr returned invalid plugin JSON.");
+  }
+  if (!isRecord(value) || !isRecord(value.result) || !Array.isArray(value.result.plugins)) {
+    throw new Error("Herdr returned an invalid plugin list.");
+  }
+  for (const plugin of value.result.plugins) {
+    if (
+      isRecord(plugin) &&
+      plugin.plugin_id === HERDR_PLUGIN_ID &&
+      typeof plugin.plugin_root === "string" &&
+      typeof plugin.enabled === "boolean"
+    ) {
+      return { root: plugin.plugin_root, enabled: plugin.enabled };
+    }
+  }
+  return undefined;
+}
+
+function runCommand(command: string, args: readonly string[]): SpawnSyncReturns<string> {
+  return spawnSync(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function bounded(value: string): string {
+  const compact = value
+    .replace(/[\r\n\t]+/gu, " ")
+    .replace(/ +/gu, " ")
+    .trim();
+  return compact.length <= 300 ? compact : `${compact.slice(0, 299)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import fs, { realpathSync } from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { SqliteControllerStore } from "../controllers/sqlite.js";
 import { projectControllerStoreBaseDir } from "../controllers/store.js";
+import { setupHerdrPlugin } from "../herdr/setup.js";
 import { sanitizeText } from "../render/ansi.js";
 import { listRunBundles, readRunBundle, workflowRunsBaseDir } from "../workflows/store.js";
 import {
@@ -23,6 +24,7 @@ Usage:
   pi-workflows controllers [--controller-dir <dir>]
   pi-workflows controller <controller> <key> [--controller-dir <dir>]
   pi-workflows host [--project <dir>] [-- <extra pi args>]
+  pi-workflows herdr setup
 
 Commands:
   view          Open the live workflow TUI. With --once, print a snapshot.
@@ -30,6 +32,7 @@ Commands:
   controllers   List durable controller resources.
   controller    Show one resource, its effects, child workflows, and events.
   host          Run the always-on workflow host in the foreground.
+  herdr         Set up the bundled Herdr plugin.
 
 Options:
   --dir <runsDir>          Runs directory (default: ~/.pi/agent/workflows/runs)
@@ -43,6 +46,7 @@ export type CliArgs = {
   runId?: string;
   controllerName?: string;
   resourceKey?: string;
+  herdrAction?: string;
   dir: string;
   controllerDir: string;
   once: boolean;
@@ -97,6 +101,12 @@ export function parseCliArgs(argv: string[]): CliArgs {
       controllerDir,
       once,
     };
+  }
+  if (command === "herdr") {
+    if (positionals.length !== 1 || positionals[0] !== "setup") {
+      throw new Error("herdr requires the setup action");
+    }
+    return { command, herdrAction: positionals[0], dir, controllerDir, once };
   }
   if (positionals.length > 1) {
     throw new Error(`Unexpected argument: ${positionals[1]}`);
@@ -229,6 +239,11 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     if (args.command === "host") {
       return await runHost(args.project ?? process.cwd(), args.piArgs);
     }
+    if (args.command === "herdr") {
+      const result = setupHerdrPlugin(packageRoot());
+      process.stdout.write(`${result.message}\n`);
+      return 0;
+    }
     if (args.command === "view") {
       if (args.once || !process.stdout.isTTY) {
         await printOnce(args.dir, args.runId);
@@ -269,6 +284,10 @@ function openControllerStore(controllerDir: string): SqliteControllerStore | und
     return undefined;
   }
   return new SqliteControllerStore(file, { readOnly: true });
+}
+
+function packageRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 }
 
 function requiredValue(args: string[], option: string): string {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -73,6 +73,10 @@ describe("parseCliArgs", () => {
       controllerDir: "/tmp/controllers",
     });
     expect(parseCliArgs(["--help"]).command).toBe("help");
+    expect(parseCliArgs(["herdr", "setup"])).toMatchObject({
+      command: "herdr",
+      herdrAction: "setup",
+    });
   });
 
   it("parses the host command with project and passthrough args", () => {
@@ -203,6 +207,10 @@ describe("pi-workflows CLI", () => {
 
     expect(await main(["controller", "missing"])).toBe(2);
     expect(stderr).toContain("requires <controller> and <key>");
+
+    stderr = "";
+    expect(await main(["herdr", "wrong"])).toBe(2);
+    expect(stderr).toContain("herdr requires the setup action");
 
     stderr = "";
     expect(await main(["frobnicate"])).toBe(2);

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -79,6 +79,7 @@ type FakeContext = {
     notify: (message: string, type?: string) => void;
     setWidget: (key: string, content: string[] | WidgetFactory | undefined) => void;
     setStatus: (key: string, text: string | undefined) => void;
+    select: (title: string, options: string[]) => Promise<string | undefined>;
   };
 };
 
@@ -92,6 +93,11 @@ function makeHarness(options: {
   respond: (prompt: string, tool: RegisteredTool) => void;
   sessionId?: string;
   mode?: "tui" | "rpc";
+  select?: (title: string, choices: string[]) => Promise<string | undefined>;
+  exec?: (
+    command: string,
+    args: string[],
+  ) => Promise<{ stdout: string; stderr: string; code: number; killed: boolean }>;
 }) {
   const notifications: string[] = [];
   const widgets: (string[] | WidgetFactory | undefined)[] = [];
@@ -103,7 +109,7 @@ function makeHarness(options: {
     string,
     ((event?: unknown, ctx?: FakeContext) => void | Promise<void>)[]
   >();
-  const shortcuts = new Map<string, (ctx: FakeContext) => void>();
+  const shortcuts = new Map<string, (ctx: FakeContext) => void | Promise<void>>();
   const commands = new Map<string, RegisteredCommand>();
   let tool: RegisteredTool | null = null;
   let idle = true;
@@ -128,6 +134,7 @@ function makeHarness(options: {
       notify: (message) => notifications.push(message),
       setWidget: (_key, content) => widgets.push(content),
       setStatus: (_key, text) => statuses.push(text),
+      select: async (title, choices) => await options.select?.(title, choices),
     },
   };
 
@@ -148,9 +155,14 @@ function makeHarness(options: {
           ),
       };
     },
-    registerShortcut: (key: string, spec: { handler: (ctx: FakeContext) => void }) => {
+    registerShortcut: (
+      key: string,
+      spec: { handler: (ctx: FakeContext) => void | Promise<void> },
+    ) => {
       shortcuts.set(key, spec.handler);
     },
+    exec:
+      options.exec ?? (async () => ({ stdout: "", stderr: "unavailable", code: 1, killed: false })),
     registerMessageRenderer: (customType: string, renderer: unknown) => {
       messageRenderers.set(customType, renderer);
     },
@@ -334,6 +346,7 @@ describe("pi-workflows extension", () => {
     // Interactive runs are tracked in the project run queue; keep that
     // store inside a temp dir so tests never touch the real home state.
     vi.stubEnv("PI_WORKFLOWS_CONTROLLER_DIR", await makeTempDir("pi-workflows-ext-controllers"));
+    vi.stubEnv("HERDR_ENV", "0");
   });
 
   it("runs a workflow end to end through the command and tool", async () => {
@@ -401,6 +414,119 @@ describe("pi-workflows extension", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+
+  it("shows the native Herdr shortcut and opens the exact run bundle in piw", async () => {
+    const cwd = await makeTempDir("pi-workflows-herdr-ext");
+    const runsDir = await makeTempDir("pi-workflows-herdr-ext-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    vi.stubEnv("HERDR_ENV", "1");
+    const execCalls: { command: string; args: string[] }[] = [];
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({
+        cwd,
+        select: async (_title, choices) => choices.find((choice) => choice === "Split right"),
+        exec: async (command, args) => {
+          execCalls.push({ command, args: [...args] });
+          const key = `${command} ${args.join(" ")}`;
+          if (key === "piw --version") {
+            return { stdout: "piw 0.1.0\n", stderr: "", code: 0, killed: false };
+          }
+          if (key === "herdr pane current --current") {
+            return {
+              stdout: JSON.stringify({
+                result: {
+                  pane: { pane_id: "w1:p1", tab_id: "w1:t1", workspace_id: "w1" },
+                },
+              }),
+              stderr: "",
+              code: 0,
+              killed: false,
+            };
+          }
+          if (key.includes("plugin list")) {
+            return {
+              stdout: JSON.stringify({
+                result: {
+                  plugins: [{ plugin_id: "osolmaz.pi-workflows", enabled: true }],
+                },
+              }),
+              stderr: "",
+              code: 0,
+              killed: false,
+            };
+          }
+          if (key === "herdr api snapshot") {
+            return {
+              stdout: JSON.stringify({ result: { snapshot: { panes: [] } } }),
+              stderr: "",
+              code: 0,
+              killed: false,
+            };
+          }
+          if (key.includes("plugin pane open")) {
+            return {
+              stdout: JSON.stringify({
+                result: {
+                  plugin_pane: {
+                    pane: { pane_id: "w1:p2", tab_id: "w1:t1", workspace_id: "w1" },
+                  },
+                },
+              }),
+              stderr: "",
+              code: 0,
+              killed: false,
+            };
+          }
+          return { stdout: "", stderr: `unexpected: ${key}`, code: 1, killed: false };
+        },
+        respond: (prompt, tool) => {
+          const contract = stepFromPrompt(prompt);
+          if (contract) {
+            void tool.execute("call-herdr", {
+              action: "submit",
+              ...contract,
+              output: { reply: "hi" },
+            });
+          }
+        },
+      });
+
+      await harness.emitAsync("session_start", {});
+      await harness.command.handler("mini", harness.ctx);
+      await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
+      await waitFor(() => {
+        const widget = [...harness.widgets].reverse().find((entry) => typeof entry === "function");
+        if (typeof widget !== "function") return false;
+        return stripAnsi(widget(undefined, TEST_THEME).render(120).join("\n")).includes(
+          "Ctrl+Shift+R piw",
+        );
+      });
+
+      expect(harness.commands.has("piw")).toBe(true);
+      expect(harness.shortcuts.has("ctrl+shift+r")).toBe(true);
+      await harness.shortcuts.get("ctrl+shift+r")?.(harness.ctx);
+      const opened = execCalls.find(
+        (call) => call.args.slice(0, 3).join(" ") === "plugin pane open",
+      );
+      const runDirEnv = opened?.args.find((arg) => arg.startsWith("PI_WORKFLOWS_RUN_DIR="));
+      expect(runDirEnv).toBeDefined();
+      expect(
+        runDirEnv?.slice("PI_WORKFLOWS_RUN_DIR=".length).startsWith(`${runsDir}${path.sep}`),
+      ).toBe(true);
+      expect(opened?.args).toContain("--target-pane");
+      expect(opened?.args.at(-1)).toBe("right");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("does not register the Herdr shortcut outside Herdr", async () => {
+    const cwd = await makeTempDir("pi-workflows-no-herdr-ext");
+    const harness = makeHarness({ cwd, respond: () => {} });
+    expect(harness.commands.has("piw")).toBe(true);
+    expect(harness.shortcuts.has("ctrl+shift+r")).toBe(false);
   });
 
   it("removes assistant tail text after an accepted workflow submission", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -419,7 +419,7 @@ describe("pi-workflows extension", () => {
   it("shows the native Herdr shortcut and opens the exact run bundle in piw", async () => {
     const cwd = await makeTempDir("pi-workflows-herdr-ext");
     const runsDir = await makeTempDir("pi-workflows-herdr-ext-runs");
-    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", path.relative(process.cwd(), runsDir));
     vi.stubEnv("HERDR_ENV", "1");
     const execCalls: { command: string; args: string[] }[] = [];
     try {

--- a/test/herdr-plugin-viewer.test.ts
+++ b/test/herdr-plugin-viewer.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { makeTempDir } from "./helpers.js";
+
+const viewerScript = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../plugins/herdr/viewer.mjs",
+);
+
+describe("Herdr piw plugin launcher", () => {
+  it("sets a discoverable title and opens the exact run bundle with argv", async () => {
+    const temp = await makeTempDir("pi-workflows-herdr-viewer");
+    const bin = path.join(temp, "bin");
+    const runId = "20260818T120000Z-monitor-a1b2c3d4";
+    const runDir = path.join(temp, runId);
+    const herdrArgs = path.join(temp, "herdr-args.json");
+    const piwArgs = path.join(temp, "piw-args.json");
+    await fs.mkdir(bin);
+    await fs.mkdir(runDir);
+    await fs.writeFile(path.join(runDir, "manifest.json"), "{}\n");
+    const herdr = path.join(bin, "herdr");
+    const piw = path.join(bin, "piw");
+    await fs.writeFile(
+      herdr,
+      `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(process.env.HERDR_ARGS_FILE, JSON.stringify(process.argv.slice(2)));\n`,
+    );
+    await fs.writeFile(
+      piw,
+      `#!/usr/bin/env node\nrequire("node:fs").writeFileSync(process.env.PIW_ARGS_FILE, JSON.stringify(process.argv.slice(2)));\n`,
+    );
+    await fs.chmod(herdr, 0o755);
+    await fs.chmod(piw, 0o755);
+
+    const result = spawnSync(process.execPath, [viewerScript], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        HERDR_BIN_PATH: herdr,
+        HERDR_PANE_ID: "w1:p2",
+        HERDR_ARGS_FILE: herdrArgs,
+        PIW_ARGS_FILE: piwArgs,
+        PI_WORKFLOWS_RUN_ID: runId,
+        PI_WORKFLOWS_RUN_DIR: runDir,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    await expect(fs.readFile(herdrArgs, "utf8").then(JSON.parse)).resolves.toEqual([
+      "pane",
+      "rename",
+      "w1:p2",
+      `piw · ${runId}`,
+    ]);
+    await expect(fs.readFile(piwArgs, "utf8").then(JSON.parse)).resolves.toEqual([runDir]);
+  });
+
+  it("rejects a run directory that does not match the run id", async () => {
+    const result = spawnSync(process.execPath, [viewerScript], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PI_WORKFLOWS_RUN_ID: "run-one",
+        PI_WORKFLOWS_RUN_DIR: "/tmp/run-two",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("absolute bundle directory for the selected run");
+  });
+});

--- a/test/herdr-setup.test.ts
+++ b/test/herdr-setup.test.ts
@@ -1,0 +1,118 @@
+import type { SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { HERDR_PLUGIN_ID } from "../src/herdr/constants.js";
+import { setupHerdrPlugin } from "../src/herdr/setup.js";
+import { makeTempDir } from "./helpers.js";
+
+function reply(
+  stdout = "",
+  overrides: Partial<SpawnSyncReturns<string>> = {},
+): SpawnSyncReturns<string> {
+  return {
+    pid: 1,
+    output: [null, stdout, ""],
+    stdout,
+    stderr: "",
+    status: 0,
+    signal: null,
+    ...overrides,
+  };
+}
+
+describe("setupHerdrPlugin", () => {
+  it("links the current package root when the plugin is absent", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+    const calls: { command: string; args: readonly string[] }[] = [];
+    const result = setupHerdrPlugin(root, (command, args) => {
+      calls.push({ command, args });
+      return args.includes("list") ? reply(JSON.stringify({ result: { plugins: [] } })) : reply();
+    });
+
+    expect(result).toEqual({
+      changed: true,
+      message: `Linked Herdr plugin ${HERDR_PLUGIN_ID} from ${root}.`,
+    });
+    expect(calls).toEqual([
+      {
+        command: "herdr",
+        args: ["plugin", "list", "--plugin", HERDR_PLUGIN_ID, "--json"],
+      },
+      { command: "herdr", args: ["plugin", "link", root] },
+    ]);
+  });
+
+  it("is idempotent for the same linked package root", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+    const result = setupHerdrPlugin(root, () =>
+      reply(
+        JSON.stringify({
+          result: {
+            plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: true }],
+          },
+        }),
+      ),
+    );
+
+    expect(result.changed).toBe(false);
+    expect(result.message).toContain("already linked");
+  });
+
+  it("enables a disabled plugin from the same package root", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+    const calls: { command: string; args: readonly string[] }[] = [];
+    const result = setupHerdrPlugin(root, (command, args) => {
+      calls.push({ command, args });
+      return args.includes("list")
+        ? reply(
+            JSON.stringify({
+              result: {
+                plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
+              },
+            }),
+          )
+        : reply();
+    });
+
+    expect(result).toEqual({
+      changed: true,
+      message: `Enabled Herdr plugin ${HERDR_PLUGIN_ID}.`,
+    });
+    expect(calls.at(-1)).toEqual({
+      command: "herdr",
+      args: ["plugin", "enable", HERDR_PLUGIN_ID],
+    });
+  });
+
+  it("refuses to replace a plugin registered from another root", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+
+    expect(() =>
+      setupHerdrPlugin(root, () =>
+        reply(
+          JSON.stringify({
+            result: {
+              plugins: [
+                {
+                  plugin_id: HERDR_PLUGIN_ID,
+                  plugin_root: "/other/pi-workflows",
+                  enabled: true,
+                },
+              ],
+            },
+          }),
+        ),
+      ),
+    ).toThrow("Unlink it before linking");
+  });
+
+  it("fails before calling Herdr when the package has no manifest", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    expect(() => setupHerdrPlugin(root, () => reply())).toThrow("manifest not found");
+  });
+});

--- a/test/herdr-setup.test.ts
+++ b/test/herdr-setup.test.ts
@@ -111,6 +111,110 @@ describe("setupHerdrPlugin", () => {
     ).toThrow("Unlink it before linking");
   });
 
+  it("reports Herdr inspection and registration failures", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+
+    expect(() =>
+      setupHerdrPlugin(root, () => reply("", { error: new Error("missing Herdr") })),
+    ).toThrow("Could not run Herdr: missing Herdr");
+    expect(() =>
+      setupHerdrPlugin(root, () => reply("", { status: 1, stderr: "socket unavailable" })),
+    ).toThrow("Could not inspect Herdr plugins: socket unavailable");
+    expect(() => setupHerdrPlugin(root, () => reply("not json"))).toThrow("invalid plugin JSON");
+    expect(() => setupHerdrPlugin(root, () => reply(JSON.stringify({ result: {} })))).toThrow(
+      "invalid plugin list",
+    );
+
+    const listEmpty = JSON.stringify({ result: { plugins: [] } });
+    let calls = 0;
+    expect(() =>
+      setupHerdrPlugin(root, () => {
+        calls += 1;
+        return calls === 1 ? reply(listEmpty) : reply("", { status: 1, stderr: "link refused" });
+      }),
+    ).toThrow("Could not link the Herdr plugin: link refused");
+
+    calls = 0;
+    expect(() =>
+      setupHerdrPlugin(root, () => {
+        calls += 1;
+        return calls === 1
+          ? reply(listEmpty)
+          : reply("", { error: new Error("link executable failed") });
+      }),
+    ).toThrow("Could not run Herdr: link executable failed");
+
+    calls = 0;
+    expect(() =>
+      setupHerdrPlugin(root, () => {
+        calls += 1;
+        return calls === 1 ? reply(listEmpty) : reply("", { status: 1, stderr: "x".repeat(400) });
+      }),
+    ).toThrow(/Could not link the Herdr plugin: x+…/u);
+  });
+
+  it("reports failures while enabling a linked plugin", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+    let calls = 0;
+
+    expect(() =>
+      setupHerdrPlugin(root, () => {
+        calls += 1;
+        return calls === 1
+          ? reply(
+              JSON.stringify({
+                result: {
+                  plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
+                },
+              }),
+            )
+          : reply("", { status: 1, stderr: "enable refused" });
+      }),
+    ).toThrow("Could not enable the Herdr plugin: enable refused");
+
+    calls = 0;
+    expect(() =>
+      setupHerdrPlugin(root, () => {
+        calls += 1;
+        return calls === 1
+          ? reply(
+              JSON.stringify({
+                result: {
+                  plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
+                },
+              }),
+            )
+          : reply("", { error: new Error("enable executable failed") });
+      }),
+    ).toThrow("Could not run Herdr: enable executable failed");
+  });
+
+  it("ignores incomplete plugin records and links the complete package", async () => {
+    const root = await makeTempDir("pi-workflows-herdr-setup");
+    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+    let calls = 0;
+    const result = setupHerdrPlugin(root, () => {
+      calls += 1;
+      return calls === 1
+        ? reply(
+            JSON.stringify({
+              result: {
+                plugins: [
+                  null,
+                  { plugin_id: HERDR_PLUGIN_ID, plugin_root: root },
+                  { plugin_id: "other.plugin", plugin_root: root, enabled: true },
+                ],
+              },
+            }),
+          )
+        : reply();
+    });
+
+    expect(result.changed).toBe(true);
+  });
+
   it("fails before calling Herdr when the package has no manifest", async () => {
     const root = await makeTempDir("pi-workflows-herdr-setup");
     expect(() => setupHerdrPlugin(root, () => reply())).toThrow("manifest not found");

--- a/test/herdr-viewer.test.ts
+++ b/test/herdr-viewer.test.ts
@@ -15,12 +15,12 @@ const target: WorkflowViewTarget = {
 type Call = { command: string; args: string[] };
 type Reply = { stdout?: string; stderr?: string; code?: number; killed?: boolean };
 
-function execHarness(respond: (call: Call) => Reply) {
+function execHarness(respond: (call: Call) => Reply | Promise<Reply>) {
   const calls: Call[] = [];
   const exec = async (command: string, args: string[]) => {
     const call = { command, args: [...args] };
     calls.push(call);
-    const reply = respond(call);
+    const reply = await respond(call);
     return {
       stdout: reply.stdout ?? "",
       stderr: reply.stderr ?? "",
@@ -197,6 +197,35 @@ describe("HerdrWorkflowViewer", () => {
     expect(harness.calls.map(commandKey)).toContain("herdr tab close w2:t1");
   });
 
+  it("keeps a launched workspace viewer when bootstrap-tab cleanup fails", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("workspace create")) {
+        return {
+          stdout: json({
+            result: {
+              workspace: { workspace_id: "w2" },
+              root_pane: { pane_id: "w2:p1", tab_id: "w2:t1", workspace_id: "w2" },
+            },
+          }),
+        };
+      }
+      if (key.includes("plugin pane open")) {
+        return { stdout: json(openedPane("w2:p2", "w2:t2", "w2")) };
+      }
+      if (key === "herdr tab close w2:t1") return { code: 1, stderr: "temporary failure" };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    const result = await viewer.open(target, "workspace", "/repo");
+    expect(result).toMatchObject({ paneId: "w2:p2", reused: false });
+    expect(result.warning).toContain("viewer opened");
+    expect(harness.calls.map(commandKey)).not.toContain("herdr workspace close w2");
+  });
+
   it("rolls back a new workspace after plugin launch failure", async () => {
     const harness = execHarness((call) => {
       const key = commandKey(call);
@@ -252,6 +281,37 @@ describe("HerdrWorkflowViewer", () => {
       "herdr api snapshot",
       "herdr plugin pane focus w9:p4",
     ]);
+  });
+
+  it("serializes concurrent opens before the launcher labels its pane", async () => {
+    let releaseOpen: (() => void) | undefined;
+    const openGate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const harness = execHarness(async (call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin pane open")) {
+        await openGate;
+        return { stdout: json(openedPane()) };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    const first = viewer.open(target, "right", "/repo");
+    const second = viewer.open(target, "below", "/repo");
+    await Promise.resolve();
+    releaseOpen?.();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { paneId: "w1:p2", reused: false },
+      { paneId: "w1:p2", reused: false },
+    ]);
+    expect(
+      harness.calls.filter((call) => call.args.slice(0, 3).join(" ") === "plugin pane open"),
+    ).toHaveLength(1);
   });
 
   it("opens a replacement when a discovered viewer closes before focus", async () => {

--- a/test/herdr-viewer.test.ts
+++ b/test/herdr-viewer.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest";
+import {
+  HerdrWorkflowViewer,
+  PIW_SHORTCUT,
+  viewerPaneLabel,
+  type WorkflowViewTarget,
+} from "../src/extension/herdr-viewer.js";
+
+const target: WorkflowViewTarget = {
+  runId: "20260818T120000Z-monitor-a1b2c3d4",
+  workflowName: "monitor",
+  runDir: "/tmp/runs/20260818T120000Z-monitor-a1b2c3d4",
+};
+
+type Call = { command: string; args: string[] };
+type Reply = { stdout?: string; stderr?: string; code?: number; killed?: boolean };
+
+function execHarness(respond: (call: Call) => Reply) {
+  const calls: Call[] = [];
+  const exec = async (command: string, args: string[]) => {
+    const call = { command, args: [...args] };
+    calls.push(call);
+    const reply = respond(call);
+    return {
+      stdout: reply.stdout ?? "",
+      stderr: reply.stderr ?? "",
+      code: reply.code ?? 0,
+      killed: reply.killed ?? false,
+    };
+  };
+  return { calls, exec };
+}
+
+function json(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function currentPane() {
+  return {
+    id: "current",
+    result: {
+      type: "pane_current",
+      pane: { pane_id: "w1:p1", tab_id: "w1:t1", workspace_id: "w1" },
+    },
+  };
+}
+
+function snapshot(panes: unknown[] = []) {
+  return { id: "snapshot", result: { type: "snapshot", snapshot: { panes } } };
+}
+
+function openedPane(paneId = "w1:p2", tabId = "w1:t1", workspaceId = "w1") {
+  return {
+    id: "open",
+    result: {
+      type: "plugin_pane_opened",
+      plugin_pane: {
+        pane: { pane_id: paneId, tab_id: tabId, workspace_id: workspaceId },
+      },
+    },
+  };
+}
+
+function commandKey(call: Call): string {
+  return `${call.command} ${call.args.join(" ")}`;
+}
+
+describe("HerdrWorkflowViewer", () => {
+  it("does no work outside Herdr", async () => {
+    const harness = execHarness(() => ({}));
+    const viewer = new HerdrWorkflowViewer(harness.exec, {});
+
+    await expect(viewer.probe()).resolves.toEqual({
+      available: false,
+      reason: "Pi is not running in Herdr.",
+    });
+    expect(harness.calls).toEqual([]);
+  });
+
+  it("checks the caller, linked plugin, and piw", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin list")) {
+        return {
+          stdout: json({
+            result: {
+              plugins: [{ plugin_id: "osolmaz.pi-workflows", enabled: true }],
+            },
+          }),
+        };
+      }
+      if (key === "piw --version") return { stdout: "piw 0.1.0\n" };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.probe()).resolves.toEqual({ available: true });
+    expect(harness.calls.map(commandKey)).toEqual([
+      "herdr pane current --current",
+      "herdr plugin list --plugin osolmaz.pi-workflows --json",
+      "piw --version",
+    ]);
+  });
+
+  it("opens right and below splits with exact argv and run environment", async () => {
+    for (const placement of ["right", "below"] as const) {
+      const harness = execHarness((call) => {
+        const key = commandKey(call);
+        if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+        if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+        if (key.includes("plugin pane open")) return { stdout: json(openedPane()) };
+        throw new Error(`Unexpected command: ${key}`);
+      });
+      const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+      await expect(viewer.open(target, placement, "/repo")).resolves.toEqual({
+        paneId: "w1:p2",
+        reused: false,
+      });
+      const open = harness.calls.find(
+        (call) => call.args.slice(0, 3).join(" ") === "plugin pane open",
+      );
+      expect(open?.command).toBe("herdr");
+      expect(open?.args).toContain(`PI_WORKFLOWS_RUN_ID=${target.runId}`);
+      expect(open?.args).toContain(`PI_WORKFLOWS_RUN_DIR=${target.runDir}`);
+      expect(open?.args).toContain("--target-pane");
+      expect(open?.args.at(-1)).toBe(placement === "below" ? "down" : "right");
+    }
+  });
+
+  it("places left and above by splitting and swapping explicit panes", async () => {
+    for (const placement of ["left", "above"] as const) {
+      const harness = execHarness((call) => {
+        const key = commandKey(call);
+        if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+        if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+        if (key.includes("plugin pane open")) return { stdout: json(openedPane()) };
+        if (key === "herdr pane swap --source-pane w1:p2 --target-pane w1:p1") return {};
+        throw new Error(`Unexpected command: ${key}`);
+      });
+      const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+      await viewer.open(target, placement, "/repo");
+      expect(harness.calls.map(commandKey)).toContain(
+        "herdr pane swap --source-pane w1:p2 --target-pane w1:p1",
+      );
+    }
+  });
+
+  it("opens a tab in the caller workspace", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin pane open")) return { stdout: json(openedPane("w1:p2", "w1:t2")) };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await viewer.open(target, "tab", "/repo");
+    const open = harness.calls.find(
+      (call) => call.args.slice(0, 3).join(" ") === "plugin pane open",
+    );
+    expect(open?.args).toContain("tab");
+    expect(open?.args).toContain("w1");
+    expect(open?.args).not.toContain("--target-pane");
+  });
+
+  it("creates a plugin tab in a new workspace and removes its bootstrap tab", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("workspace create")) {
+        return {
+          stdout: json({
+            result: {
+              workspace: { workspace_id: "w2" },
+              root_pane: { pane_id: "w2:p1", tab_id: "w2:t1", workspace_id: "w2" },
+            },
+          }),
+        };
+      }
+      if (key.includes("plugin pane open")) {
+        return { stdout: json(openedPane("w2:p2", "w2:t2", "w2")) };
+      }
+      if (key === "herdr tab close w2:t1") return {};
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.open(target, "workspace", "/repo")).resolves.toEqual({
+      paneId: "w2:p2",
+      reused: false,
+    });
+    expect(harness.calls.map(commandKey)).toContain("herdr tab close w2:t1");
+  });
+
+  it("rolls back a new workspace after plugin launch failure", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("workspace create")) {
+        return {
+          stdout: json({
+            result: {
+              workspace: { workspace_id: "w2" },
+              root_pane: { pane_id: "w2:p1", tab_id: "w2:t1", workspace_id: "w2" },
+            },
+          }),
+        };
+      }
+      if (key.includes("plugin pane open")) return { code: 1, stderr: "launch failed" };
+      if (key === "herdr workspace close w2") return {};
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.open(target, "workspace", "/repo")).rejects.toThrow("launch failed");
+    expect(harness.calls.map(commandKey)).toContain("herdr workspace close w2");
+  });
+
+  it("rediscovers and focuses an existing viewer by its pane label", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") {
+        return {
+          stdout: json(
+            snapshot([
+              {
+                pane_id: "w9:p4",
+                tab_id: "w9:t2",
+                workspace_id: "w9",
+                label: viewerPaneLabel(target.runId),
+              },
+            ]),
+          ),
+        };
+      }
+      if (key === "herdr plugin pane focus w9:p4") return {};
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.open(target, "right", "/repo")).resolves.toEqual({
+      paneId: "w9:p4",
+      reused: true,
+    });
+    expect(harness.calls.map(commandKey)).toEqual([
+      "herdr api snapshot",
+      "herdr plugin pane focus w9:p4",
+    ]);
+  });
+
+  it("opens a replacement when a discovered viewer closes before focus", async () => {
+    let snapshots = 0;
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") {
+        snapshots += 1;
+        return {
+          stdout: json(
+            snapshot(
+              snapshots === 1
+                ? [
+                    {
+                      pane_id: "w9:p4",
+                      tab_id: "w9:t2",
+                      workspace_id: "w9",
+                      label: viewerPaneLabel(target.runId),
+                    },
+                  ]
+                : [],
+            ),
+          ),
+        };
+      }
+      if (key === "herdr plugin pane focus w9:p4") return { code: 1, stderr: "pane closed" };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin pane open")) return { stdout: json(openedPane()) };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.open(target, "right", "/repo")).resolves.toEqual({
+      paneId: "w1:p2",
+      reused: false,
+    });
+  });
+
+  it("uses the requested Ctrl+Shift shortcut", () => {
+    expect(PIW_SHORTCUT).toBe("ctrl+shift+r");
+  });
+});

--- a/test/herdr-viewer.test.ts
+++ b/test/herdr-viewer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   HerdrWorkflowViewer,
+  parseViewerPlacement,
   PIW_SHORTCUT,
   viewerPaneLabel,
   type WorkflowViewTarget,
@@ -103,6 +104,83 @@ describe("HerdrWorkflowViewer", () => {
     ]);
   });
 
+  it("reports unavailable plugin, piw, and malformed Herdr responses", async () => {
+    const missingPlugin = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin list")) {
+        return {
+          stdout: json({
+            result: {
+              plugins: [
+                { plugin_id: "osolmaz.pi-workflows", enabled: false },
+                { plugin_id: "other.plugin", enabled: true },
+                null,
+              ],
+            },
+          }),
+        };
+      }
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    await expect(
+      new HerdrWorkflowViewer(missingPlugin.exec, { HERDR_ENV: "1" }).probe(),
+    ).resolves.toEqual({
+      available: false,
+      reason: "Herdr plugin osolmaz.pi-workflows is not linked and enabled.",
+    });
+
+    const missingPiw = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin list")) {
+        return {
+          stdout: json({
+            result: { plugins: [{ plugin_id: "osolmaz.pi-workflows", enabled: true }] },
+          }),
+        };
+      }
+      if (key === "piw --version") return { code: 1, stderr: "piw missing" };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    await expect(
+      new HerdrWorkflowViewer(missingPiw.exec, { HERDR_ENV: "1" }).probe(),
+    ).resolves.toEqual({ available: false, reason: "piw failed: piw missing" });
+
+    const malformed = execHarness(() => ({ stdout: "not json" }));
+    await expect(
+      new HerdrWorkflowViewer(malformed.exec, { HERDR_ENV: "1" }).probe(),
+    ).resolves.toEqual({ available: false, reason: "herdr returned invalid JSON." });
+  });
+
+  it("bounds command, timeout, and malformed snapshot failures", async () => {
+    const killed = execHarness(() => ({ killed: true }));
+    await expect(new HerdrWorkflowViewer(killed.exec, { HERDR_ENV: "1" }).probe()).resolves.toEqual(
+      { available: false, reason: "herdr timed out." },
+    );
+
+    const large = execHarness(() => ({ stdout: "x".repeat(1_000_001) }));
+    await expect(new HerdrWorkflowViewer(large.exec, { HERDR_ENV: "1" }).probe()).resolves.toEqual({
+      available: false,
+      reason: "herdr returned too much data.",
+    });
+
+    const missingPanes = execHarness(() => ({ stdout: json({ result: { snapshot: {} } }) }));
+    await expect(
+      new HerdrWorkflowViewer(missingPanes.exec, { HERDR_ENV: "1" }).find(target),
+    ).rejects.toThrow("snapshot has no panes");
+
+    const longFailure = execHarness(() => ({ code: 1, stderr: "x".repeat(400) }));
+    const capability = await new HerdrWorkflowViewer(longFailure.exec, {
+      HERDR_ENV: "1",
+    }).probe();
+    expect(capability.available).toBe(false);
+    if (!capability.available) {
+      expect(capability.reason.length).toBeLessThan(330);
+      expect(capability.reason).toMatch(/…$/u);
+    }
+  });
+
   it("opens right and below splits with exact argv and run environment", async () => {
     for (const placement of ["right", "below"] as const) {
       const harness = execHarness((call) => {
@@ -148,6 +226,22 @@ describe("HerdrWorkflowViewer", () => {
     }
   });
 
+  it("closes a new split when left-side placement cannot swap", async () => {
+    const harness = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin pane open")) return { stdout: json(openedPane()) };
+      if (key.includes("pane swap")) return { code: 1, stderr: "swap failed" };
+      if (key === "herdr plugin pane close w1:p2") return {};
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    const viewer = new HerdrWorkflowViewer(harness.exec, { HERDR_ENV: "1" });
+
+    await expect(viewer.open(target, "left", "/repo")).rejects.toThrow("swap failed");
+    expect(harness.calls.map(commandKey)).toContain("herdr plugin pane close w1:p2");
+  });
+
   it("opens a tab in the caller workspace", async () => {
     const harness = execHarness((call) => {
       const key = commandKey(call);
@@ -165,6 +259,38 @@ describe("HerdrWorkflowViewer", () => {
     expect(open?.args).toContain("tab");
     expect(open?.args).toContain("w1");
     expect(open?.args).not.toContain("--target-pane");
+  });
+
+  it("rejects malformed pane and workspace creation responses", async () => {
+    const malformedPane = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("plugin pane open")) return { stdout: json({ result: {} }) };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    await expect(
+      new HerdrWorkflowViewer(malformedPane.exec, { HERDR_ENV: "1" }).open(
+        target,
+        "right",
+        "/repo",
+      ),
+    ).rejects.toThrow("plugin pane response has no plugin_pane");
+
+    const malformedWorkspace = execHarness((call) => {
+      const key = commandKey(call);
+      if (key === "herdr api snapshot") return { stdout: json(snapshot()) };
+      if (key === "herdr pane current --current") return { stdout: json(currentPane()) };
+      if (key.includes("workspace create")) return { stdout: json({ result: {} }) };
+      throw new Error(`Unexpected command: ${key}`);
+    });
+    await expect(
+      new HerdrWorkflowViewer(malformedWorkspace.exec, { HERDR_ENV: "1" }).open(
+        target,
+        "workspace",
+        "/repo",
+      ),
+    ).rejects.toThrow("workspace response has no workspace");
   });
 
   it("creates a plugin tab in a new workspace and removes its bootstrap tab", async () => {
@@ -258,6 +384,7 @@ describe("HerdrWorkflowViewer", () => {
         return {
           stdout: json(
             snapshot([
+              null,
               {
                 pane_id: "w9:p4",
                 tab_id: "w9:t2",
@@ -350,7 +477,9 @@ describe("HerdrWorkflowViewer", () => {
     });
   });
 
-  it("uses the requested Ctrl+Shift shortcut", () => {
+  it("parses placements and uses the requested Ctrl+Shift shortcut", () => {
+    expect(parseViewerPlacement("workspace")).toBe("workspace");
+    expect(parseViewerPlacement("diagonal")).toBeUndefined();
     expect(PIW_SHORTCUT).toBe("ctrl+shift+r");
   });
 });

--- a/test/package-resources.test.ts
+++ b/test/package-resources.test.ts
@@ -8,6 +8,7 @@ const packageJsonPath = path.join(repoRoot, "package.json");
 const skillsRoot = path.join(repoRoot, "skills");
 
 interface PackageManifest {
+  version: string;
   files?: string[];
   pi?: {
     extensions?: string[];
@@ -47,6 +48,8 @@ describe("Pi package resources", () => {
     const manifest = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as PackageManifest;
 
     expect(manifest.files).toContain("skills");
+    expect(manifest.files).toContain("plugins/herdr");
+    expect(manifest.files).toContain("herdr-plugin.toml");
     expect(manifest.pi?.extensions).toEqual(["./src/extension/index.ts"]);
     expect(manifest.pi?.skills).toEqual(["./skills"]);
 
@@ -57,6 +60,16 @@ describe("Pi package resources", () => {
     }
     await expect(fs.stat(path.join(repoRoot, extensionPath))).resolves.toBeDefined();
     await expect(fs.stat(path.join(repoRoot, skillPath))).resolves.toBeDefined();
+  });
+
+  it("ships one matching Herdr plugin from the package root", async () => {
+    const manifest = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as PackageManifest;
+    const herdrManifest = await fs.readFile(path.join(repoRoot, "herdr-plugin.toml"), "utf8");
+
+    expect(herdrManifest).toContain('id = "osolmaz.pi-workflows"');
+    expect(herdrManifest).toContain(`version = "${manifest.version}"`);
+    expect(herdrManifest).toContain('command = ["node", "plugins/herdr/viewer.mjs"]');
+    await expect(fs.stat(path.join(repoRoot, "plugins/herdr/viewer.mjs"))).resolves.toBeDefined();
   });
 
   it("ships valid uniquely named skills", async () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -616,6 +616,36 @@ describe("buildWidgetLines", () => {
     expect(controls).toContain("shift+↑/↓ scroll · Ctrl+Shift+R piw");
     expect(view.lines.length).toBeLessThanOrEqual(10);
     expect(view.lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+
+    const exactNodes = Object.fromEntries(
+      Array.from({ length: 9 }, (_value, index) => [`n${index}`, compute({ run: () => index })]),
+    );
+    const exact = createDefinitionSnapshot(
+      defineWorkflow({
+        name: "exact",
+        startAt: "n0",
+        nodes: exactNodes,
+        edges: Array.from({ length: 8 }, (_value, index) => ({
+          from: `n${index}`,
+          to: `n${index + 1}`,
+        })),
+      }),
+    );
+    const exactView = buildWidgetView(
+      makeState({ workflowName: "exact", currentNode: "n0" }),
+      exact,
+      undefined,
+      null,
+      false,
+      80,
+      undefined,
+      undefined,
+      "Ctrl+Shift+R piw",
+    );
+    expect(stripAnsi(exactView.lines.at(-1) ?? "")).toContain(
+      "shift+↑/↓ scroll · Ctrl+Shift+R piw",
+    );
+    expect(exactView.lines.length).toBe(10);
   });
 
   it("reports no scroll range when the node list fits", () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -585,6 +585,39 @@ describe("buildWidgetLines", () => {
     expect(bottom.lines.length).toBeLessThanOrEqual(10);
   });
 
+  it("reserves a bounded footer line for an optional viewer shortcut", () => {
+    const nodes = Object.fromEntries(
+      Array.from({ length: 20 }, (_value, index) => [`n${index}`, compute({ run: () => index })]),
+    );
+    const tall = createDefinitionSnapshot(
+      defineWorkflow({
+        name: "tall",
+        startAt: "n0",
+        nodes,
+        edges: Array.from({ length: 19 }, (_value, index) => ({
+          from: `n${index}`,
+          to: `n${index + 1}`,
+        })),
+      }),
+    );
+    const view = buildWidgetView(
+      makeState({ workflowName: "tall", currentNode: "n10" }),
+      tall,
+      undefined,
+      null,
+      false,
+      80,
+      undefined,
+      undefined,
+      "Ctrl+Shift+R piw",
+    );
+
+    const controls = stripAnsi(view.lines.at(-1) ?? "");
+    expect(controls).toContain("shift+↑/↓ scroll · Ctrl+Shift+R piw");
+    expect(view.lines.length).toBeLessThanOrEqual(10);
+    expect(view.lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+  });
+
   it("reports no scroll range when the node list fits", () => {
     const view = buildWidgetView(makeState(), snapshot);
     expect(view.maxScroll).toBe(0);

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.7.0"
+version = "0.9.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Pi Workflows can now open its current run directly in `piw` when Pi runs inside Herdr.
The feature ships as one Pi Workflows package that also contains the Herdr plugin.
`Ctrl+Shift+R` opens a placement menu, and the widget packs the call to action onto its existing scroll-controls line when possible.

## What Changed

Pi Workflows now owns the full integration without changing the portable workflow engine or run-bundle format.
The same package root is loaded by Pi and linked by Herdr.

- Added the native Herdr adapter, `/piw` command, and `Ctrl+Shift+R` shortcut.
- Added right, below, left, above, tab, and transactional workspace placement.
- Added exact-run viewer discovery and reuse through Herdr pane labels.
- Added a root `herdr-plugin.toml` and an argv-only `piw` launcher.
- Added the idempotent `pi-workflows herdr setup` command.
- Kept the widget within Pi's ten-line limit by sharing the overflow controls line.
- Added package, adapter, setup, launcher, extension, placement, rollback, and widget tests.
- Prepared the compatible feature release as `0.9.0` for both npm and crates.io.

## Testing

The TypeScript package, real-Pi end-to-end suite, Rust viewer, package contents, and Herdr integration all pass.
A live Herdr test proved that the modified shortcut is delivered distinctly, opens the placement menu, launches the exact bundle in `piw`, labels the pane with the run ID, and focuses the existing viewer instead of opening a duplicate.

- `npm run check` — 734 tests passed with coverage above all 85% thresholds
- `npm run test:e2e` — 11 tests passed against real Pi
- `cargo test --manifest-path tui/Cargo.toml` — 40 Rust tests passed
- `npx slophammer-ts@latest dry .` — no findings
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — no findings
- `npm pack --dry-run --json` — includes `herdr-plugin.toml` and `plugins/herdr/viewer.mjs`
- `git diff --check` — passed

The repository-wide SimpleDoc check still reports existing filename migrations outside this change.

## Risks

The integration is inactive outside Herdr and does not change workflow execution.
Herdr and `piw` are checked before the shortcut is shown, all commands use argv arrays and bounded timeouts, and failed workspace creation rolls back only the newly created workspace.

The Herdr marketplace listing will become eligible after merge by adding the `herdr-plugin` topic to this public repository.
