### PR TITLE
fix(herdr): launch viewer from plugin root

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "osolmaz.pi-workflows"
 name = "Pi Workflows"
-version = "0.9.0"
+version = "0.9.1"
 min_herdr_version = "0.7.0"
 description = "Open the active Pi Workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/src/extension/herdr-viewer.ts
+++ b/src/extension/herdr-viewer.ts
@@ -111,7 +111,7 @@ export class HerdrWorkflowViewer {
       return { ...opened, reused: false };
     }
 
-    const opened = await this.openPluginPane(target, placement, caller, cwd);
+    const opened = await this.openPluginPane(target, placement, caller);
     if (placement === "left" || placement === "above") {
       try {
         await this.run("herdr", [
@@ -167,7 +167,6 @@ export class HerdrWorkflowViewer {
     target: WorkflowViewTarget,
     placement: Exclude<ViewerPlacement, "workspace">,
     caller: HerdrPane,
-    cwd: string,
   ): Promise<OpenedPane> {
     const args = [
       "plugin",
@@ -177,8 +176,6 @@ export class HerdrWorkflowViewer {
       HERDR_PLUGIN_ID,
       "--entrypoint",
       HERDR_PLUGIN_ENTRYPOINT,
-      "--cwd",
-      cwd,
       "--env",
       `PI_WORKFLOWS_RUN_ID=${target.runId}`,
       "--env",
@@ -230,8 +227,6 @@ export class HerdrWorkflowViewer {
           "tab",
           "--workspace",
           created.workspaceId,
-          "--cwd",
-          cwd,
           "--env",
           `PI_WORKFLOWS_RUN_ID=${target.runId}`,
           "--env",

--- a/test/herdr-viewer.test.ts
+++ b/test/herdr-viewer.test.ts
@@ -202,6 +202,7 @@ describe("HerdrWorkflowViewer", () => {
       expect(open?.command).toBe("herdr");
       expect(open?.args).toContain(`PI_WORKFLOWS_RUN_ID=${target.runId}`);
       expect(open?.args).toContain(`PI_WORKFLOWS_RUN_DIR=${target.runDir}`);
+      expect(open?.args).not.toContain("--cwd");
       expect(open?.args).toContain("--target-pane");
       expect(open?.args.at(-1)).toBe(placement === "below" ? "down" : "right");
     }
@@ -321,6 +322,15 @@ describe("HerdrWorkflowViewer", () => {
       reused: false,
     });
     expect(harness.calls.map(commandKey)).toContain("herdr tab close w2:t1");
+    const workspaceCreate = harness.calls.find(
+      (call) => call.args.slice(0, 2).join(" ") === "workspace create",
+    );
+    expect(workspaceCreate?.args).toContain("--cwd");
+    expect(workspaceCreate?.args).toContain("/repo");
+    const pluginOpen = harness.calls.find(
+      (call) => call.args.slice(0, 3).join(" ") === "plugin pane open",
+    );
+    expect(pluginOpen?.args).not.toContain("--cwd");
   });
 
   it("keeps a launched workspace viewer when bootstrap-tab cleanup fails", async () => {

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
## Summary

Choosing a Herdr pane location created a pane, but the pane closed before `piw` appeared.
The plugin command was started from the project directory, so its package-relative script path did not exist.
This change lets Herdr start the command from the plugin root and adds regression checks for split and workspace launches.

## What Changed

Herdr now keeps the plugin root as the command directory.
A new workspace still uses the active project directory for its bootstrap workspace, but the plugin process no longer inherits that directory.

- Removed `--cwd` from split, tab, and workspace plugin-pane launch commands.
- Kept `--cwd` on workspace creation, where it sets the intended workspace directory.
- Added assertions that prevent the invalid plugin command directory from returning.
- Bumped the npm package, Herdr manifest, and Rust crate to `0.9.1` for the corrective release.

## Testing

The corrected command was tested in a real Herdr pane through the Pi shortcut.
Both **Split right** and **Split below** opened `piw` for the exact workflow run.

- `npm run check` — 743 tests passed; coverage thresholds passed.
- `npm run test:e2e` — 11 tests passed against the real Pi runtime.
- `cargo test --manifest-path tui/Cargo.toml` — 40 tests passed.
- `npx slophammer-ts@latest dry .` — no candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — no findings.
- `npm pack --dry-run` — package contents and version verified.
- Real Herdr smoke test — right and below placement passed.

## Risks

The change is limited to the working directory used to start the Herdr plugin command.
The viewer reads an absolute workflow bundle path, so it does not need the project directory as its process directory.
