### PR TITLE
feat(workflows): rename autodevise to autoplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ Or try the npm package without installing it:
 pi -e npm:@osolmaz/pi-workflows
 ```
 
-The Pi package includes the extension and two optional skills:
+The Pi package includes the extension and five optional skills:
 
 - `pi-workflows` teaches the agent how to operate and author workflows.
 - `monitor` starts and operates the built-in monitor workflow.
+- `autoplan` selects the best practical solution and writes an implementation plan.
+- `autodoc` records an existing plan in canonical documentation.
+- `autoimplement` implements an existing plan and verifies the result.
 
-Pi discovers both skills when it loads the package. Use `pi config` to disable
+Pi discovers these skills when it loads the package. Use `pi config` to disable
 the extension, all bundled skills, or one skill independently. The equivalent
 settings entry below keeps the extension and disables only `monitor`:
 
@@ -56,7 +59,7 @@ settings entry below keeps the extension and disables only `monitor`:
 }
 ```
 
-Set `"skills": []` to disable both bundled skills while keeping the extension.
+Set `"skills": []` to disable all bundled skills while keeping the extension.
 Set `"extensions": []` to keep the skills without loading the extension.
 
 Install the interactive terminal viewer separately from crates.io. The crate
@@ -145,14 +148,14 @@ A workflow can import another workflow and connect its named exits without copyi
 
 ```typescript
 import { compute, defineWorkflow, includeWorkflow } from "@osolmaz/pi-workflows";
-import autodevise from "./autodevise.workflow.js";
+import autoplan from "./autoplan.workflow.js";
 
 export default defineWorkflow({
   source: import.meta.url,
   name: "parent",
   startAt: "start",
   includes: {
-    design: includeWorkflow(autodevise, {
+    design: includeWorkflow(autoplan, {
       input: ({ outputs }) => ({ problem: String(outputs.start) }),
     }),
   },
@@ -185,7 +188,7 @@ waits with a normal shell action, and loops until its stop condition or check
 limit. Its input supports `task`, `everyMinutes`, `stopWhen`, `maxChecks`, and
 an optional `checkTimeoutMinutes`.
 
-Monitor is observation-only by default. An explicit `repair` policy authorizes its composed `autodevise` and `autoimplement` path. The monitor checks the target again after repair and stops when the same issue and target evidence return without progress. Project and global workflows can replace the built-in `monitor` by using the same file name.
+Monitor is observation-only by default. An explicit `repair` policy authorizes its composed `autoplan` and `autoimplement` path. The monitor checks the target again after repair and stops when the same issue and target evidence return without progress. Project and global workflows can replace the built-in `monitor` by using the same file name.
 
 A monitor occupies the session's one active workflow slot. If its Pi runner
 stops during the shell wait, the run parks and repeats that wait node when a
@@ -193,12 +196,13 @@ runner resumes it.
 
 Because the workflow runs in your current conversation, you can have a long
 discussion first and then trigger a workflow that builds on it. The
-`autodevise` example does exactly that. It frames the problem and scope, devises
+`autoplan` example does exactly that. It frames the problem and scope, devises
 an elegant production-ready solution, and compares it with the holy grail. It
 then selects the best practical in-scope solution without asking the user to
 resolve the gap. The ideal can win when it is feasible, but work outside the
 current authority cannot block a valid practical solution. The workflow ends
-with a detailed implementation plan.
+with a detailed implementation plan. `autoplan` replaces the earlier
+`autodevise` name; the old command and export are not retained.
 
 ## Watching a run
 
@@ -332,7 +336,7 @@ example set. Copy any of them into `.pi/workflows/` to use them:
   while they run.
 - `two-turn` chains three agent steps that build on each other's outputs in
   the same conversation.
-- `autodevise` turns the current problem into a chosen practical solution and
+- `autoplan` turns the current problem into a chosen practical solution and
   a detailed implementation plan, using the ideal end state as guidance rather
   than an out-of-scope requirement.
 - `autoimplement` finds a clear existing plan, documents it when needed,
@@ -340,11 +344,11 @@ example set. Copy any of them into `.pi/workflows/` to use them:
   tracks P0 through P2, handles PR comments and CI, and
   finalizes the PR. P0 and P1 fixes require another review. P2-only work is
   verified without another reviewer round. A five-minute CI wait routes to
-  additional useful local testing. New evidence can route through autodevise
+  additional useful local testing. New evidence can route through autoplan
   and autodoc before implementation resumes.
 - `human-decision` shows a reusable verified-human gate with plain choices and
   exact replan text.
-- `approved-plan` composes autodevise, autodoc, and the reusable plan-approval
+- `approved-plan` composes autoplan, autodoc, and the reusable plan-approval
   workflow without copying their internal nodes.
 - `autoresearch` runs an iterative feature-search loop in the style of
   [karpathy/autoresearch](https://github.com/karpathy/autoresearch): setup

--- a/docs/HUMAN_DECISIONS.md
+++ b/docs/HUMAN_DECISIONS.md
@@ -4,6 +4,12 @@ Pi Workflows needs a reusable way to stop at a proposal and wait for a person. T
 
 This document defines that behavior. The implementation is tracked in the [human decision gates plan](plans/2026-08-19-human-decision-gates-plan.md).
 
+The current request contract can render a structured `body` as JSON. The planned
+[human decision presentation contract](HUMAN_DECISION_PRESENTATIONS.md) separates
+canonical subject data from the complete readable message shown in Pi and
+Telegram. Its [implementation plan](plans/2026-08-19-human-decision-presentations-plan.md)
+preserves v1 records without rewriting them.
+
 ## Goals
 
 A workflow author can:
@@ -259,15 +265,15 @@ SQLite may index pending decisions and channel leases, but immutable decision fi
 
 Pi Workflows keeps solution choice, documentation, and implementation in separate built-ins:
 
-- `autodevise` chooses a solution or revises one after new evidence.
+- `autoplan` chooses a solution or revises one after new evidence.
 - `autodoc` records an already selected solution in the canonical specification and implementation plan. It does not choose a solution or implement it.
 - `autoimplement` executes a clear existing plan.
 
 `autodoc` runs by itself and as an included workflow. It returns a documented-plan record with the plan, plan digest, document paths, document digests, and check results. If the canonical documents already describe the selected plan, it adopts them without rewriting files.
 
-`autoimplement` first finds the clear existing plan in its input, the conversation, or referenced canonical documents. It blocks when no clear plan exists. A caller can bypass discovery and autodoc only by supplying both the explicit plan and a `documentation` receipt whose plan digest matches it. A plan without that current-document evidence enters autodoc so the canonical documents are inspected and adopted or updated. The absence of a structured `plan` input never authorizes `autodevise`.
+`autoimplement` first finds the clear existing plan in its input, the conversation, or referenced canonical documents. It blocks when no clear plan exists. A caller can bypass discovery and autodoc only by supplying both the explicit plan and a `documentation` receipt whose plan digest matches it. A plan without that current-document evidence enters autodoc so the canonical documents are inspected and adopted or updated. The absence of a structured `plan` input never authorizes `autoplan`.
 
-If later implementation, verification, review, comments, or CI evidence invalidates the plan, autoimplement runs `autodevise`, sends the revised plan through `autodoc`, and then resumes implementation. An optional approval policy inserts `plan-approval` after the revised documentation.
+If later implementation, verification, review, comments, or CI evidence invalidates the plan, autoimplement runs `autoplan`, sends the revised plan through `autodoc`, and then resumes implementation. An optional approval policy inserts `plan-approval` after the revised documentation.
 
 ## Reusable plan approval workflow
 
@@ -291,9 +297,9 @@ includes: {
 },
 ```
 
-A `replan` exit returns to `autodevise` with the previous plan and the exact human instructions as new evidence. The revised plan passes through `autodoc`, receives a new digest, and enters a new approval decision. Step limits bound repeated replanning.
+A `replan` exit returns to `autoplan` with the previous plan and the exact human instructions as new evidence. The revised plan passes through `autodoc`, receives a new digest, and enters a new approval decision. Step limits bound repeated replanning.
 
-Monitor repair composes `autodevise`, `autodoc`, optional `plan-approval`, `autoimplement`, and a fresh target check. Autoimplement can mount the same approval workflow after evidence-driven redesign. Existing behavior stays unchanged when no approval policy is present.
+Monitor repair composes `autoplan`, `autodoc`, optional `plan-approval`, `autoimplement`, and a fresh target check. Autoimplement can mount the same approval workflow after evidence-driven redesign. Existing behavior stays unchanged when no approval policy is present.
 
 ## Recovery and cancellation
 

--- a/docs/HUMAN_DECISION_PRESENTATIONS.md
+++ b/docs/HUMAN_DECISION_PRESENTATIONS.md
@@ -1,0 +1,319 @@
+# Human decision presentations
+
+This contract is planned. The current human decision request uses `body` and can display a
+structured body as JSON. This specification defines the replacement contract.
+The implementation plan is in
+[the human decision presentations plan](plans/2026-08-19-human-decision-presentations-plan.md).
+
+A human decision contains machine data and a separate message for the operator.
+Pi Workflows stores and validates the machine data. Pi and Telegram render only
+the operator message, and future channels follow the same rule.
+
+## Minimal example
+
+```typescript
+approve: humanDecision({
+  audience: "operator",
+  choices,
+  request: () => ({
+    title: "Approve the implementation plan",
+    subject: {
+      task: "Add readable human decisions",
+      plan: selectedPlan,
+      planDigest,
+      revision: 1,
+    },
+    presentation: {
+      schema: "pi-workflows.decision-presentation.v1",
+      summary: "Replace raw JSON decisions with readable messages.",
+      blocks: [
+        { kind: "section", title: "Changes" },
+        {
+          kind: "bullets",
+          items: [
+            "Keep structured data as the durable source.",
+            "Show the same readable message in Pi and Telegram.",
+          ],
+        },
+        {
+          kind: "fields",
+          items: [{ label: "Plan revision", value: "1" }],
+        },
+      ],
+    },
+  }),
+});
+```
+
+The operator sees the summary and sections along with lists and fields. The operator does
+not see `subject` unless the workflow explicitly copies selected text into
+`presentation`.
+
+## Request contract
+
+A new request uses `pi-workflows.human-decision-request.v2`. It contains:
+
+| Field                | Required | Meaning                                         |
+| -------------------- | -------- | ----------------------------------------------- |
+| `title`              | Yes      | Short decision title shown by every channel.    |
+| `subject`            | Yes      | Canonical JSON data used by the workflow.       |
+| `presentation`       | Yes      | Human-readable content defined below.           |
+| `audience`           | Yes      | Named audience resolved by the host.            |
+| `choices`            | Yes      | Typed choices and optional input contracts.     |
+| `revision`           | Yes      | Positive decision revision.                     |
+| `subjectDigest`      | Yes      | SHA-256 digest of the canonical subject.        |
+| `presentationDigest` | Yes      | SHA-256 digest of the normalized presentation.  |
+| `requestDigest`      | Yes      | SHA-256 digest that binds the complete request. |
+
+The runtime adds the usual run binding and lifecycle fields as it does for
+current decisions.
+
+A request that supplies `subject` without `presentation` is invalid. A channel
+must not derive a presentation from `subject`.
+
+## Presentation contract
+
+`pi-workflows.decision-presentation.v1` is a small ordered document:
+
+```typescript
+type DecisionPresentation = {
+  schema: "pi-workflows.decision-presentation.v1";
+  summary: string;
+  blocks: DecisionPresentationBlock[];
+};
+```
+
+`summary` is required and non-empty. Every channel shows it first. `blocks` can be empty. Block
+order is meaningful and every channel preserves it.
+
+### Blocks
+
+The first version supports five flat block types.
+
+#### Paragraph
+
+```json
+{ "kind": "paragraph", "text": "This change affects active workflows." }
+```
+
+#### Section
+
+```json
+{ "kind": "section", "title": "Verification" }
+```
+
+A section labels the blocks that follow it until the next section. Sections do
+not contain nested blocks.
+
+#### Bullets
+
+```json
+{
+  "kind": "bullets",
+  "items": ["Run the unit tests.", "Run the real-Pi test."]
+}
+```
+
+#### Fields
+
+```json
+{
+  "kind": "fields",
+  "items": [
+    { "label": "Repository", "value": "pi-workflows" },
+    { "label": "Action", "value": "Update the decision contract" }
+  ]
+}
+```
+
+#### Preformatted text
+
+```json
+{
+  "kind": "preformatted",
+  "text": "npm run check\nnpm run test:e2e"
+}
+```
+
+Preformatted text preserves spacing and line breaks. It does not permit HTML,
+Markdown, terminal escape sequences, or executable channel instructions.
+
+## Validation and normalization
+
+The authoring API validates the presentation before it creates a pending
+request.
+
+- Unknown fields and unknown block kinds are invalid.
+- Display values are strings. Arbitrary nested objects are invalid.
+- The summary, section titles, labels, bullet items, and field values must not
+  be empty after whitespace checks.
+- The normalizer converts CRLF and CR line endings to LF.
+- The normalizer preserves block order, item order, Unicode text, and other
+  spacing.
+- Terminal control characters are invalid. Paragraph and preformatted text can
+  contain LF and tab. Titles and labels plus bullet items cannot contain control
+  characters.
+- The complete normalized presentation is limited to 64,000 UTF-16 code units.
+- A presentation can contain at most 256 blocks.
+- One bullets or fields block can contain at most 256 items.
+- One string can contain at most 16,000 UTF-16 code units.
+- A renderer can produce at most 20 transport parts for one recipient.
+
+If a presentation exceeds a limit, request creation fails with the exact limit
+and observed value. The runtime does not create a pending request and does not
+send a partial message.
+
+## Digests
+
+The runtime uses canonical JSON with a trailing newline, as defined by the run
+bundle contract.
+
+```text
+subjectDigest = sha256(canonicalJson(subject))
+presentationDigest = sha256(canonicalJson(normalizedPresentation))
+requestDigest = sha256(canonicalJson(requestBasis))
+```
+
+`requestBasis` contains the request schema and run binding. It also contains the
+audience, title, subject, normalized presentation, choices, typed input
+contracts, revision and optional expiry. It does not contain the three digest
+fields or the derived decision ID.
+
+An answer must match the exact request revision and request digest. A change to
+only the subject, visible text, choice label, or input prompt makes an older
+answer stale.
+
+Channels can show a short prefix of `presentationDigest` so an operator can
+compare the decision in Pi and Telegram. The viewer shows the same fingerprint.
+The complete digest remains in the durable request and accepted answer evidence.
+
+## Channel rendering
+
+The workflow creates one presentation. It does not contain channel names,
+Telegram markup, terminal colors, message limits, buttons, or callback data.
+
+Each channel can change spacing and wrapping as well as styling, navigation, or
+controls. It must preserve the title and summary together with block order and
+contents. It must also preserve every choice and input prompt. A channel must
+not omit or reinterpret approval-relevant content.
+
+### Telegram
+
+Telegram uses plain text without a parse mode. Text that resembles HTML,
+Markdown, a command, or a mention remains inert text.
+
+The renderer:
+
+1. Renders the complete normalized presentation.
+2. Splits at block and paragraph boundaries before splitting a line.
+3. Splits a long line at Unicode-safe boundaries only when required.
+4. Reserves space for `Part n/N` and a short presentation fingerprint.
+5. Keeps every Telegram message below the Telegram limit.
+6. Adds choice buttons only to the final part.
+7. Stores durable part indexes and content digests.
+8. Keeps chat and message IDs only in the private channel projection.
+
+The renderer never adds an ellipsis in place of omitted decision content.
+
+The channel records intent before sending. It records each part after an
+unambiguous response. If a send result is ambiguous, it marks delivery unknown
+and does not retry that part or later parts automatically. Another configured
+channel can still answer the decision.
+
+### Pi
+
+Pi uses the documented extension TUI API. A custom decision component shows the
+complete presentation and fingerprint together with the choices and optional
+text prompt. It wraps and scrolls while responding to resize, theme, cancellation,
+and `AbortSignal` events.
+
+When Telegram or another channel accepts the decision, the signal closes the Pi
+dialog. Pi Workflows does not modify Pi core or use undocumented TUI state.
+
+### Other channels
+
+A new channel consumes the normalized presentation and typed interaction
+contract. It must pass the same conformance tests. It cannot access the subject
+for display.
+
+## Plan presentation
+
+Pi Workflows provides a reusable plan presenter for built-in workflows. It
+derives a presentation from the same typed plan stored as the subject.
+
+The presenter uses these sections when data exists:
+
+1. Goal
+2. Proposed changes
+3. Verification
+4. Boundaries
+5. Risks and mitigations
+6. Evidence
+
+It omits absent sections. It never serializes the plan object. `plan-approval`,
+`monitor`, `autoplan`, `autodoc`, and `autoimplement` reuse this presenter where
+they ask a person to approve a plan.
+
+## Compatibility
+
+Current v1 requests remain immutable.
+
+- A v1 string body becomes one readable paragraph at delivery time.
+- A v1 object body uses a deterministic compatibility formatter. It converts
+  stable key order into readable labels and fields with sections and lists.
+- The compatibility formatter reads only the historical `body`, which was
+  already the display field. It never reads a new structured subject.
+- V1 request bytes and digests do not change.
+- Pending and accepted v1 decisions continue to use v1 validation and digest
+  rules.
+- New preferred authoring emits v2. The existing body form remains a deprecated
+  compatibility overload until a separate removal is approved.
+
+No migration rewrites run bundles or decision records.
+
+## Privacy and security
+
+The presentation is an explicit display allowlist. Data does not become visible
+because it exists in the subject.
+
+Channel adapters do not receive the subject. Durable public records do not
+contain Telegram chat IDs, message IDs, bot tokens, credential profile values,
+or private audience configuration. The private channel projection retains only
+the transport identifiers required for recovery and settlement.
+
+Workflow authors remain responsible for not putting a secret in the explicit
+presentation. Renderers treat all text as untrusted and inert.
+
+## Failure behavior
+
+- Invalid or excessive content fails before a request becomes pending.
+- A renderer that cannot represent every block fails closed.
+- Confirmed multipart delivery requires a receipt for every part.
+- Ambiguous Telegram delivery remains unknown and is not retried blindly.
+- A channel failure does not choose a default answer.
+- Rules for the first valid answer and stale answers remain unchanged, as do
+  cancellation and settlement rules together with exactly-once continuation.
+
+## Verification
+
+Implementation must pass:
+
+```bash
+npm run check
+npm run test:e2e
+cargo test --manifest-path tui/Cargo.toml
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+```
+
+Tests must cover schema validation, canonical digests, readable legacy bodies,
+plan rendering, Pi and Telegram content parity, unsafe text, Unicode, multipart
+delivery, ambiguous sends, recovery, stale answers, viewer output, and proof
+that no channel serializes a subject as JSON.
+
+## Boundaries
+
+This contract does not add a new workflow node, template language, rich text
+framework, translation service, delivery relay, Telegram resource, credential,
+or Pi core change.

--- a/docs/MONITOR.md
+++ b/docs/MONITOR.md
@@ -38,7 +38,7 @@ The monitor checks a target, sends one status notification after every accepted 
 
 `repair` must set `authorized: true`. It can constrain scope, repository, base branch, merge behavior, and other implementation constraints. Omitted `merge` means the repair can prepare but cannot merge a pull request; merging requires explicit `merge: true`. Without this object the monitor is observation-only. Repair authority does not permit a protected model, benchmark, credential, hardware, spending, or scope change.
 
-`repair.approval` is optional. It contains a logical `audience` and `maxReplans` from 1 through 20. When present, monitor sends the documented repair plan through the reusable human `plan-approval` workflow. Continue starts implementation, stop ends the repair truthfully, and replan preserves exact operator text before autodevise and autodoc run again. The model-facing workflow tool cannot approve the gate.
+`repair.approval` is optional. It contains a logical `audience` and `maxReplans` from 1 through 20. When present, monitor sends the documented repair plan through the reusable human `plan-approval` workflow. Continue starts implementation, stop ends the repair truthfully, and replan preserves exact operator text before autoplan and autodoc run again. The model-facing workflow tool cannot approve the gate.
 
 `reportWhen` is removed. The monitor always reports after every accepted check.
 
@@ -102,7 +102,7 @@ prepare
       ├─ continue → schedule → sleep → check
       └─ repair → repairGuard
            ├─ blocked → repairBlocked → repairReport → finish
-           └─ initialDesign: autodevise
+           └─ initialDesign: autoplan
                 ├─ blocked → repairBlocked
                 └─ documentation: autodoc
                      ├─ blocked → repairBlocked
@@ -122,7 +122,7 @@ prepare
 - `report` is a `notify` node that queues exactly one report.
 - `decide` is a `compute` node that applies the route and check safety limit.
 - `repairGuard` stops a repeated issue when a completed repair did not change its fingerprint or observed target state.
-- `initialDesign`, `documentation`, optional `approval`, and `implementation` are included workflows. Replan returns exact operator text to initialDesign. Autoimplement can enter nested `autodevise`, then autodoc, when later evidence requires redesign.
+- `initialDesign`, `documentation`, optional `approval`, and `implementation` are included workflows. Replan returns exact operator text to initialDesign. Autoimplement can enter nested `autoplan`, then autodoc, when later evidence requires redesign.
 - `repairBlocked` and `repairReport` preserve a truthful blocked result and user notification.
 - `schedule` is a function `action` that publishes the next-check time.
 - `sleep` is the existing runtime-owned shell wait.
@@ -282,7 +282,7 @@ The monitor skill must disclose a surfaced host limit and must never invent a sm
 
 ## Safety boundaries
 
-An observation-only request authorizes only observation and scheduled checks. Automatic repair also requires the explicit `repair` input object. An optional `repair.approval` object names a logical audience and inserts human plan approval after autodoc. Continue starts implementation, stop ends truthfully, and replan sends the exact human text back to autodevise before autodoc and approval run again.
+An observation-only request authorizes only observation and scheduled checks. Automatic repair also requires the explicit `repair` input object. An optional `repair.approval` object names a logical audience and inserts human plan approval after autodoc. Continue starts implementation, stop ends truthfully, and replan sends the exact human text back to autoplan before autodoc and approval run again.
 
 When the user asks the monitor to keep an objective running or finish it, the monitor skill may record routine, bounded work in `task` and the repair policy. This can include retries, restarts, pinned task code, tests, configuration repairs, and temporary cleanup. The task must preserve the exact objective and state every mutation boundary.
 

--- a/docs/WORKFLOW_COMPOSITION.md
+++ b/docs/WORKFLOW_COMPOSITION.md
@@ -257,15 +257,15 @@ monitor
       plan
 ```
 
-## Autodevise, autodoc, and autoimplement
+## Autoplan, autodoc, and autoimplement
 
-`autodevise` accepts the problem, scope, constraints, an optional previous plan, and new evidence. It automatically selects the best practical in-scope solution. The ideal end state can win when it is feasible, but an unavailable upstream change cannot block a valid practical solution. It exits through `ready` or `blocked` and returns a plan digest and change status.
+`autoplan` accepts the problem, scope, constraints, an optional previous plan, and new evidence. It automatically selects the best practical in-scope solution. The ideal end state can win when it is feasible, but an unavailable upstream change cannot block a valid practical solution. It exits through `ready` or `blocked` and returns a plan digest and change status.
 
 `autodoc` accepts an already selected plan or finds it in the active conversation and referenced canonical documents. It adopts current documentation or updates the canonical specification and implementation plan, runs documentation checks, and returns a documented-plan record. It never selects a solution or implements one.
 
-`autoimplement` requires a clear existing plan, but the structured `plan` input is optional because the plan can already be in conversation context or canonical documentation. It blocks when it cannot find a clear plan. It skips autodoc when documentation is current and includes autodoc when documentation is missing or stale. The absence of `input.plan` never routes to initial autodevise.
+`autoimplement` requires a clear existing plan, but the structured `plan` input is optional because the plan can already be in conversation context or canonical documentation. It blocks when it cannot find a clear plan. It skips autodoc when documentation is current and includes autodoc when documentation is missing or stale. The absence of `input.plan` never routes to initial autoplan.
 
-Autoimplement includes `autodevise` only as evidence-driven `redesign`. When implementation, verification, review, comments, or CI proves that the approach is wrong, the revised plan passes through autodoc before implementation resumes. Local bugs go to a fix step instead.
+Autoimplement includes `autoplan` only as evidence-driven `redesign`. When implementation, verification, review, comments, or CI proves that the approach is wrong, the revised plan passes through autodoc before implementation resumes. Local bugs go to a fix step instead.
 
 Review rounds record findings at every severity from P0 through P2. P0 or P1 findings require another implementation and review round. A P2-only round can be addressed, but the workflow does not run the reviewer again solely because P2 work changed files.
 
@@ -281,16 +281,16 @@ Monitor remains observation-only unless its input explicitly authorizes mutation
 
 ```text
 check
-  -> initialDesign: autodevise
+  -> initialDesign: autoplan
   -> documentation: autodoc
   -> approval: plan-approval when requested
        -> replan: initialDesign
   -> implementation: autoimplement
-       -> redesign: autodevise -> autodoc when needed
+       -> redesign: autoplan -> autodoc when needed
   -> check
 ```
 
-The outer `autodevise` creates the first plan. Autodoc records it before implementation. An optional plan approval gate can continue, stop, or return exact replan instructions to autodevise. The inner redesign mount revises a plan only when new evidence invalidates it and records the revision through autodoc. The monitor checks the target again after implementation and does not trust a repair claim by itself.
+The outer `autoplan` creates the first plan. Autodoc records it before implementation. An optional plan approval gate can continue, stop, or return exact replan instructions to autoplan. The inner redesign mount revises a plan only when new evidence invalidates it and records the revision through autodoc. The monitor checks the target again after implementation and does not trust a repair claim by itself.
 
 A protected change to model choice, benchmark method, credentials, hardware, spending authority, or another user decision exits as blocked. The workflow never changes the protected part of the task silently.
 

--- a/docs/plans/2026-08-19-human-decision-gates-plan.md
+++ b/docs/plans/2026-08-19-human-decision-gates-plan.md
@@ -30,8 +30,8 @@ Pi and Telegram implement one channel interface. Workflows address a named audie
 - Make autoimplement locate and record an existing plan from input, conversation context, or referenced documents.
 - Block autoimplement when no clear plan exists.
 - Skip autodoc only when plan discovery verifies current canonical documents or an explicit documentation receipt has a matching plan digest.
-- Route every evidence-driven revision through `autodevise`, then `autodoc`, before implementation resumes.
-- Never run initial autodevise only because the structured plan input is absent.
+- Route every evidence-driven revision through `autoplan`, then `autodoc`, before implementation resumes.
+- Never run initial autoplan only because the structured plan input is absent.
 
 ### Public authoring API
 
@@ -78,7 +78,7 @@ Pi and Telegram implement one channel interface. Workflows address a named audie
 
 - Change Pi core or use undocumented Pi APIs.
 - Create a Telegram bot or copy a token without explicit source and destination approval.
-- Add Telegram-specific logic to monitor, autoimplement, autodevise, or user workflows.
+- Add Telegram-specific logic to monitor, autoimplement, autoplan, or user workflows.
 - Run an always-on service when no Pi process is active.
 - Promise exactly-once Telegram message creation after an ambiguous Bot API response.
 - Add arbitrary forms in the first release. Choice buttons and one text input cover the required flows.
@@ -215,7 +215,7 @@ Use a fake Bot API in all automated tests. Do not require a real token or networ
 - Block when discovery finds no clear plan.
 - Skip autodoc for current canonical documents.
 - Route undocumented and revised plans through autodoc.
-- Keep autodevise only on evidence-driven redesign edges.
+- Keep autoplan only on evidence-driven redesign edges.
 
 ### Reusable plan approval
 
@@ -223,7 +223,7 @@ Use a fake Bot API in all automated tests. Do not require a real token or networ
 - Return named `continue`, `stop`, and `replan` exits.
 - Include the accepted decision receipt in every exit.
 - Return exact instructions from `replan`.
-- Add an example that loops through `autodevise`, plan approval, and implementation.
+- Add an example that loops through `autoplan`, plan approval, and implementation.
 - Keep monitor and autoimplement behavior unchanged unless their input requests the approval workflow.
 
 ### Viewers and documentation

--- a/docs/plans/2026-08-19-human-decision-presentations-plan.md
+++ b/docs/plans/2026-08-19-human-decision-presentations-plan.md
@@ -1,0 +1,172 @@
+---
+title: Add readable human decision presentations
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-19
+---
+
+# Add readable human decision presentations
+
+Pi Workflows currently sends a structured human decision body to Telegram with
+`JSON.stringify()`. A plan approval therefore reaches the operator as machine
+JSON. Pi also shows only the decision title in its basic selection prompt.
+
+The operator must receive clear text in every channel. Structured data must
+remain the durable source for validation, routing, and audit evidence. The
+[human decision presentations specification](../HUMAN_DECISION_PRESENTATIONS.md)
+defines the selected contract.
+
+## Outcome
+
+Add one versioned, channel-independent presentation format beside the canonical
+subject. Pi and Telegram render the same complete content with their own native
+layout. The visible presentation and machine subject are both bound to the
+accepted decision.
+
+The design uses the existing checkpoint engine, decision store, channel
+interface, and documented Pi extension APIs. It does not require Pi core,
+another service, or a Telegram change.
+
+## Scope
+
+- Add `DecisionPresentation v1` and `HumanDecisionRequest v2` schemas and types.
+- Add deterministic presentation normalization and digests.
+- Keep the current typed subject as machine truth.
+- Require an explicit presentation for new structured subjects.
+- Add a reusable plan presenter.
+- Render complete readable messages in Pi and Telegram.
+- Add durable multipart delivery evidence and safe recovery.
+- Update TypeScript and Rust viewers.
+- Preserve v1 definitions and immutable run bundles.
+
+## Non-goals
+
+- Do not modify Pi core or use undocumented Pi APIs.
+- Do not change Telegram or create a delivery relay.
+- Do not add a template language or general rich text system.
+- Do not derive new operator text from arbitrary v2 subject data.
+- Do not rewrite v1 requests, accepted answers, or run bundles.
+- Do not store Telegram identifiers or credentials in public durable records.
+
+## Implementation
+
+### 1. Add the durable contracts
+
+Create schemas and TypeScript types for the presentation, v2 request, and
+multipart delivery evidence. Keep all v1 schemas and readers unchanged.
+
+Generate and validate canonical examples. Reject unknown blocks, object-valued
+display fields, missing summaries, missing presentations, and excessive
+content.
+
+### 2. Add deterministic normalization
+
+Add a workflow-core module that validates the flat presentation blocks,
+normalizes line endings, enforces the specification limits, and computes the
+presentation digest. Keep it independent of Pi and Telegram.
+
+Add a v1 compatibility presenter. A string body becomes a paragraph. An object
+body becomes readable sections, labels, fields, and lists in stable key order.
+The adapter reads only the historical display body.
+
+### 3. Update the authoring API and request identity
+
+Add the preferred `subject` plus `presentation` request form. Keep the current
+`body` form as a deprecated compatibility overload. The preferred form fails
+validation when either value is missing.
+
+For v2, compute separate subject and presentation digests and bind the request
+revision, subject, visible presentation, choices, and input prompts into the
+overall request digest. Select the v1 or v2 digest algorithm from the stored
+request schema.
+
+### 4. Add the plan presenter
+
+Create one reusable presenter for plan approvals. Derive its summary and
+sections from the same typed plan stored in the subject. Use it in the built-in
+plan approval path and composed workflows. Do not serialize missing or unknown
+fields.
+
+### 5. Narrow the channel boundary
+
+Normalize the stored request before channel dispatch. Give each channel only
+the normalized presentation and typed choices. Remove direct channel access to
+the subject and remove the `JSON.stringify()` fallback.
+
+### 6. Render complete Telegram messages
+
+Render plain text with no parse mode. Precompute all message parts, split at
+readable boundaries, add deterministic part numbers and a short fingerprint,
+and put buttons on the final part only.
+
+Write intent before sending and one durable content receipt for each confirmed
+part. Keep remote IDs in the private projection. Stop automatic delivery after
+an ambiguous send. Never clip approval content.
+
+### 7. Add the full Pi decision view
+
+Use documented `ctx.ui.custom()` APIs and existing TUI components to show the
+complete presentation, fingerprint, choices, and text prompt. Support wrapping,
+scrolling, resizing, cancellation, and theme changes. Preserve the abort signal
+that closes Pi when another channel wins.
+
+### 8. Update recovery and viewers
+
+Recover confirmed multipart sends without duplication. Resume only when the
+next part is provably unsent. Keep one accepted answer and one continuation.
+
+Update the TypeScript and Rust viewers to show the human presentation by
+default and machine data as separate detail. Continue to render v1 through the
+compatibility presenter without changing stored bytes.
+
+### 9. Verify compatibility and failure handling
+
+Add tests for:
+
+- presentation schemas, normalization, bounds, Unicode, and canonical digests;
+- subject and presentation changes that reject stale answers;
+- old definitions, pending v1 decisions, and accepted v1 decisions;
+- complete and sparse plan presentations;
+- Pi and Telegram content parity;
+- unsafe markup-like text and terminal control characters;
+- single-part and multipart Telegram messages;
+- partial, ambiguous, resumed, and settled delivery;
+- Pi scrolling, input, resize, cancellation, and external settlement;
+- one answer and one continuation under concurrency and crash injection;
+- TypeScript and Rust viewer parity; and
+- absence of raw JSON subject serialization in channel output.
+
+## Rollout
+
+The preferred authoring path starts emitting v2 after release. Existing
+body-based workflows continue to create and read v1 until a separate removal is
+approved. No migration runs. Historical records remain immutable.
+
+A live Telegram smoke can use an already configured private audience profile.
+The test must not print, copy, or persist credentials. Fake Bot API and real-Pi
+end-to-end tests remain the required automated evidence.
+
+## Acceptance criteria
+
+- New structured decisions cannot reach a channel without an explicit readable
+  presentation.
+- Telegram and Pi show the same complete decision meaning.
+- Telegram never shows raw JSON or silently truncates approval content.
+- Pi shows the full decision instead of only its title.
+- The accepted record binds the exact subject and visible presentation.
+- V1 definitions and bundles remain readable without rewrites.
+- Ambiguous Telegram sends fail closed without duplicate messages or
+  continuation.
+- All repository, documentation, privacy, TypeScript, Rust, and real-Pi checks
+  pass.
+
+## Verification
+
+```bash
+npm run check
+npm run test:e2e
+cargo test --manifest-path tui/Cargo.toml
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+npm pack --dry-run --json
+```

--- a/docs/plans/2026-08-19-workflow-composition-plan.md
+++ b/docs/plans/2026-08-19-workflow-composition-plan.md
@@ -14,7 +14,7 @@ The canonical behavior is in [Workflow composition](../WORKFLOW_COMPOSITION.md).
 
 A workflow can run alone or as a typed child in one durable parent run. Authors can import a child definition, map its input, and route from named exits. Dynamic project, global, built-in, and path references remain available.
 
-The package will ship `autodevise`, `autoimplement`, and `monitor` as compatible built-ins. Monitor will remain observation-only by default. An explicitly authorized monitor can run outer solution design, autoimplementation, internal redesign, and a fresh target check without copying workflow nodes.
+The package will ship `autoplan`, `autoimplement`, and `monitor` as compatible built-ins. Monitor will remain observation-only by default. An explicitly authorized monitor can run outer solution design, autoimplementation, internal redesign, and a fresh target check without copying workflow nodes.
 
 ## Scope
 
@@ -49,10 +49,10 @@ The package will ship `autodevise`, `autoimplement`, and `monitor` as compatible
 
 ### Workflow library
 
-- Make `autodevise` accept an existing plan and new evidence.
-- Add `ready` and `blocked` exits to `autodevise`.
+- Make `autoplan` accept an existing plan and new evidence.
+- Add `ready` and `blocked` exits to `autoplan`.
 - Rebuild `autoimplement` around explicit issue routes.
-- Include `autodevise` inside `autoimplement` for redesign.
+- Include `autoplan` inside `autoimplement` for redesign.
 - Track P0, P1, and P2 review findings by round.
 - Rerun review only after P0 or P1 work.
 - Permit P2 work without another reviewer round.
@@ -60,7 +60,7 @@ The package will ship `autodevise`, `autoimplement`, and `monitor` as compatible
 - Track PR comments, CI, merge, and final PR reporting.
 - Bound one CI watch to five minutes.
 - Route a long CI wait to useful local testing before checking CI again.
-- Add authorized repair to monitor through outer `autodevise` and `autoimplement` mounts.
+- Add authorized repair to monitor through outer `autoplan` and `autoimplement` mounts.
 - Detect repeated repair with no changed issue, plan, implementation, evidence, or target state.
 
 ## Non-goals
@@ -168,7 +168,7 @@ A pending result must include a validated `gh` tracking command. The shell actio
 - Keep qualified names in replay and details.
 - Update TypeScript and Rust fixtures together.
 
-### 6. Autodevise
+### 6. Autoplan
 
 - Move the current workflow into the built-in library.
 - Add typed input, `ready`, and `blocked` exits.
@@ -188,7 +188,7 @@ find existing plan
   -> documentation missing or stale -> autodoc -> implement
   -> verify
   -> classify issue
-     -> redesign -> autodevise -> autodoc -> optional approval -> implement
+     -> redesign -> autoplan -> autodoc -> optional approval -> implement
      -> fix -> verify
      -> publish -> write reviewer command -> run reviewer
 
@@ -212,7 +212,7 @@ CI
   -> unavailable or forbidden -> blocked
 ```
 
-The structured plan input is optional because the plan can already exist in conversation context or canonical documentation. Its absence never authorizes initial autodevise. Autoimplement blocks when no clear plan exists, skips autodoc for current documentation, and records every evidence-driven revision through autodoc before continuing.
+The structured plan input is optional because the plan can already exist in conversation context or canonical documentation. Its absence never authorizes initial autoplan. Autoimplement blocks when no clear plan exists, skips autodoc for current documentation, and records every evidence-driven revision through autodoc before continuing.
 
 The workflow will collect all review rounds in its final output. It will never rerun Pi Reviewer solely because P2 work changed files.
 
@@ -220,9 +220,9 @@ The workflow will collect all review rounds in its final output. It will never r
 
 - Add explicit repair authorization to monitor input.
 - Add `repair` to the check result only when authorization is present.
-- Mount outer `autodevise`, `autodoc`, optional `plan-approval`, and `autoimplement`.
+- Mount outer `autoplan`, `autodoc`, optional `plan-approval`, and `autoimplement`.
 - Pass the documented outer plan into autoimplement.
-- Return exact replan instructions to autodevise and ask again.
+- Return exact replan instructions to autoplan and ask again.
 - Check the target again after a reported repair.
 - Stop on repeated no-progress evidence.
 - Keep ordinary monitor calls observation-only and backward compatible.
@@ -242,8 +242,8 @@ The workflow will collect all review rounds in its final output. It will never r
 - Dynamic references resolve through existing precedence rules.
 - Two mounts of one child do not share invocation state.
 - Standalone autodoc adopts current documents, updates stale documents, and blocks without a selected plan.
-- Autoimplement finds a clear existing plan and never invokes initial autodevise because a plan input is absent.
-- Nested redesign uses a fresh autodevise invocation and passes the revised plan through autodoc.
+- Autoimplement finds a clear existing plan and never invokes initial autoplan because a plan input is absent.
+- Nested redesign uses a fresh autoplan invocation and passes the revised plan through autodoc.
 - Source cycles fail before the run bundle is created.
 - Included checkpoints, updates, notifications, pause, cancellation, and resume behave like root nodes.
 - Every mounted source and the resolved digest is durable.
@@ -264,7 +264,7 @@ Run focused checks while implementing:
 ```bash
 npx vitest run test/composition.test.ts test/graph.test.ts test/loader.test.ts
 npx vitest run test/engine.test.ts test/run-resume.test.ts test/store.test.ts
-npx vitest run test/builtin-autodevise.test.ts test/builtin-autoimplement.test.ts test/builtin-monitor.test.ts
+npx vitest run test/builtin-autoplan.test.ts test/builtin-autoimplement.test.ts test/builtin-monitor.test.ts
 ```
 
 Run all repository gates before review:
@@ -292,7 +292,7 @@ Direct imports check mapped input and exit names. `includedResult()` recovers th
 
 The shipped workflows are registered built-ins:
 
-- `autodevise` returns `ready` or `blocked` with plan lineage.
+- `autoplan` returns `ready` or `blocked` with plan lineage.
 - `autodoc` records selected plans as a standalone and included built-in.
 - `autoimplement` finds an existing plan, conditionally documents it, and supports evidence-driven redesign, implementation fixes, exact reviewer and CI commands, P0 through P2 history, bounded CI watches, PR comments, merge, and final reporting.
 - `monitor` remains observation-only by default and enables composed repair only through an explicit repair policy.

--- a/docs/run-bundles.md
+++ b/docs/run-bundles.md
@@ -229,8 +229,8 @@ The full run projection (`WorkflowRunState` in
   "workflowSources": [
     {
       "mountPath": ["redesign"],
-      "workflowName": "autodevise",
-      "source": { "kind": "builtin", "id": "autodevise", "revision": "1" }
+      "workflowName": "autoplan",
+      "source": { "kind": "builtin", "id": "autoplan", "revision": "1" }
     }
   ],
   "definitionDigest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -15,8 +15,11 @@ Files are discovered by suffix (`.workflow.ts`, `.workflow.js`, `.workflow.mts`,
 2. `~/.pi/agent/workflows/` globally
 3. Workflows built into Pi Workflows
 
-Pi Workflows includes a built-in `monitor` workflow. A project or global file
-named `monitor.workflow.ts` replaces it. The package registers each built-in in
+Pi Workflows includes built-in `autoplan`, `autodoc`, `autoimplement`,
+`plan-approval`, and `monitor` workflows. `autoplan` is the current name for the
+planning workflow that was first released as `autodevise`; the old command and
+export are not retained. A project or global file named `monitor.workflow.ts`
+replaces the built-in monitor. The package registers each built-in in
 a process-local catalog with a stable reference such as `builtin:monitor` and
 an explicit revision. Built-ins are imported with the engine when a Pi process
 starts. They are not read from the package directory when a run starts or
@@ -402,9 +405,9 @@ runs.
 
 ### Built-in planning and implementation
 
-The built-in `autodevise` workflow selects a practical in-scope solution and writes a detailed plan. The standalone `autodoc` workflow finds an already selected plan, records it in canonical documentation, verifies those documents, and never devises or implements. The built-in `autoimplement` workflow finds a clear existing plan from explicit input, conversation context, or referenced canonical documents. It blocks when no clear plan exists. An explicit plan bypasses autodoc only when a current-document receipt carries its matching plan digest; otherwise autodoc inspects and adopts or updates the canonical documents. Later invalidating evidence returns to `autodevise` followed by `autodoc`.
+The built-in `autoplan` workflow selects a practical in-scope solution and writes a detailed plan. The standalone `autodoc` workflow finds an already selected plan, records it in canonical documentation, verifies those documents, and never devises or implements. The built-in `autoimplement` workflow finds a clear existing plan from explicit input, conversation context, or referenced canonical documents. It blocks when no clear plan exists. An explicit plan bypasses autodoc only when a current-document receipt carries its matching plan digest; otherwise autodoc inspects and adopts or updates the canonical documents. Later invalidating evidence returns to `autoplan` followed by `autodoc`.
 
-The built-in `plan-approval` workflow offers verified human `continue`, `stop`, and exact-text `replan` exits. It is optional. A replan exit returns the unchanged text to autodevise, documents the revised plan, and asks again through a new plan digest.
+The built-in `plan-approval` workflow offers verified human `continue`, `stop`, and exact-text `replan` exits. It is optional. A replan exit returns the unchanged text to autoplan, documents the revised plan, and asks again through a new plan digest.
 
 Autoimplement writes and runs the exact Pi Reviewer command. It records P0 through P2 by review round. P0 or P1 work requires another review. P2-only work can be addressed and verified without another reviewer run. CI tracking commands are also explicit. One CI watch lasts at most five minutes, after which the model runs more useful local tests before checking CI again.
 
@@ -424,7 +427,7 @@ one looping workflow run. Its input is:
 }
 ```
 
-The first check runs immediately. Omit `repair` for observation-only monitoring. An authorized repair routes through outer `autodevise`, `autodoc`, optional `plan-approval`, `autoimplement`, and internal redesign before the monitor checks the target again. A repeated issue with unchanged target evidence stops as blocked. Add `repair.approval` with a named audience and bounded replan limit only when the operator wants a human decision before implementation.
+The first check runs immediately. Omit `repair` for observation-only monitoring. An authorized repair routes through outer `autoplan`, `autodoc`, optional `plan-approval`, `autoimplement`, and internal redesign before the monitor checks the target again. A repeated issue with unchanged target evidence stops as blocked. Add `repair.approval` with a named audience and bounded replan limit only when the operator wants a human decision before implementation.
 
 `everyMinutes` defaults to 30. Each accepted check must provide one concise report and choose `continue`, `repair` when authorized, or `stop`. The
 runtime queues that report as a workflow notification with `triggerTurn:

--- a/examples/workflows/approved-plan.workflow.ts
+++ b/examples/workflows/approved-plan.workflow.ts
@@ -1,6 +1,6 @@
 import { compute, defineWorkflow, includeWorkflow, includedResult } from "@osolmaz/pi-workflows";
-import autodevise from "../../src/builtins/autodevise.workflow.js";
 import autodoc from "../../src/builtins/autodoc.workflow.js";
+import autoplan from "../../src/builtins/autoplan.workflow.js";
 import planApproval from "../../src/builtins/plan-approval.workflow.js";
 
 export default defineWorkflow({
@@ -8,7 +8,7 @@ export default defineWorkflow({
   startAt: "design",
   maxSteps: 80,
   includes: {
-    design: includeWorkflow(autodevise, {
+    design: includeWorkflow(autoplan, {
       input: ({ input, outputs }) => {
         const prior = outputs.design as { exit?: string; output?: { plan?: unknown } } | undefined;
         const answer = outputs.approval as
@@ -23,7 +23,7 @@ export default defineWorkflow({
     }),
     documentation: includeWorkflow(autodoc, {
       input: ({ input, outputs }) => {
-        const result = includedResult(autodevise, outputs.design);
+        const result = includedResult(autoplan, outputs.design);
         if (result.exit !== "ready") throw new Error("design is not ready");
         return { task: (input as { task: string }).task, plan: result.output.plan };
       },

--- a/examples/workflows/autodevise.workflow.ts
+++ b/examples/workflows/autodevise.workflow.ts
@@ -1,1 +1,0 @@
-export { autodeviseWorkflow as default } from "@osolmaz/pi-workflows/builtins";

--- a/examples/workflows/autoplan.workflow.ts
+++ b/examples/workflows/autoplan.workflow.ts
@@ -1,0 +1,1 @@
+export { autoplanWorkflow as default } from "@osolmaz/pi-workflows/builtins";

--- a/fixtures/layout/example-autoimplement.json
+++ b/fixtures/layout/example-autoimplement.json
@@ -289,21 +289,21 @@
         "mountPath": ["redesign"],
         "localNodeId": "redesign",
         "includeTransition": "entry",
-        "statusDetail": "entering autodevise"
+        "statusDetail": "entering autoplan"
       },
       "redesign/__piw_exit_ready": {
         "nodeType": "compute",
         "mountPath": ["redesign"],
         "localNodeId": "ready",
         "includeTransition": "exit",
-        "statusDetail": "leaving autodevise through ready"
+        "statusDetail": "leaving autoplan through ready"
       },
       "redesign/__piw_exit_blocked": {
         "nodeType": "compute",
         "mountPath": ["redesign"],
         "localNodeId": "blocked",
         "includeTransition": "exit",
-        "statusDetail": "leaving autodevise through blocked"
+        "statusDetail": "leaving autoplan through blocked"
       },
       "redesign/frame": {
         "nodeType": "agent",
@@ -775,7 +775,7 @@
         },
         {
           "mountPath": ["redesign"],
-          "workflowName": "autodevise",
+          "workflowName": "autoplan",
           "entryNode": "redesign",
           "exits": {
             "ready": "redesign/__piw_exit_ready",
@@ -10372,7 +10372,7 @@
         "                                                                                │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │ ◇ blocked                            │      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
         "                                                                                │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
         "                                                                                │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
-        "                                                                                │      │      │      │      │      │      │ … entering autodevise                │      │      │      │      │      │      │      │      │      │      │ … finalizing PR                      │      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
+        "                                                                                │      │      │      │      │      │      │ … entering autoplan                  │      │      │      │      │      │      │      │      │      │      │ … finalizing PR                      │      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
         "                                                                                │      │      │      │      │      │      └──────────────────────────────────────┘      │      │      │      │      │      │      │      │      │      └──────────────────────────────────────┘      │      │      │      │      │      │      │      │      │                                                                                  │ │ │       │       │",
         "                                                                                └──────┼──────┼─┐    └──────┼──────┼─┐                        └───────────────┐         └──────┼──────┼─┐    └──────┼──────┼─┐    └──────┼──────┼────────┐               │ └────── completed ──────┐ │    ┌─┼──────┼──────┘    ┌─┼──────┼──────┘      │      │                                                                                  │ │ │       │       │",
         "                                                                                       └──────┼─┼──────┐    └──────┼─┼──────┐                                 │                └──────┼─┼──────┐    └──────┼─┼──────┐    └──────┼────────┼──────┐        │    ┌────────────────────┼─┘    │ │    ┌─┼───────────┼─┘    ┌─┼─────────────┘      │                                                                                  │ │ │       │       │",
@@ -10471,7 +10471,7 @@
         "                                                                                            │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
         "                                                                                            │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
         "                                                                                            │      │      │      │      │      │                                      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
-        "                                                                                            │      │      │      │      │      │ … leaving autodevise through ready   │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
+        "                                                                                            │      │      │      │      │      │ … leaving autoplan through ready     │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
         "                                                                                            │      │      │      │      │      └──────────────────────────────────────┘      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
         "                                                                                            │      │      │      │      │                          │                         │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
         "                                                                                            │      │      │      │      │                          ▼                         │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │      │                                                                                               │ │ │       │       │",
@@ -10616,7 +10616,7 @@
         "  │                                      │      │      │      │      │                                      │      │      │      │      │                                      │      │ ◇ blocked                            │      │      │ ◇ blocked                            │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │    │ │ │       │       │",
         "  │                                      │      │      │      │      │                                      │      │      │      │      │                                      │      │                                      │      │      │                                      │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │    │ │ │       │       │",
         "  │                                      │      │      │      │      │                                      │      │      │      │      │                                      │      │                                      │      │      │                                      │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │      │    │ │ │       │       │",
-        "  │                                      │      │      │      │      │ … leaving autodoc through blocked    │      │      │      │      │ … leaving autodevise through blocked │      │ … correcting reviewer command        │      │      │ … correcting CI tracking command     │      │      │      │      │      │      │      │ … leaving plan-approval through stop │      │      │      │      │      │      │      │    │ │ │       │       │",
+        "  │                                      │      │      │      │      │ … leaving autodoc through blocked    │      │      │      │      │ … leaving autoplan through blocked   │      │ … correcting reviewer command        │      │      │ … correcting CI tracking command     │      │      │      │      │      │      │      │ … leaving plan-approval through stop │      │      │      │      │      │      │      │    │ │ │       │       │",
         "  └──────────────────────────────────────┘      │      │      │      └──────────────────────────────────────┘      │      │      │      └──────────────────────────────────────┘      └──────────────────────────────────────┘      │      └──────────────────────────────────────┘      │      │      │      │      │      │      └──────────────────────────────────────┘      │      │      │      │      │      │      │    │ │ │       │       │",
         "                      │                         │      │      │                          │                         │      │      │                          │                                             │ └───────────────────────┼──────────────────────────┼───┼─────────────────────┼──────┼──────┼──────┼──────┼──────┼──────────────────────────┼─────────────────────────┼──────┼──────┼──────┼──────┼──────┼──────┼────┼─┼─┘       │       │",
         "                      │                         │      │      │                          │                         │      │      │                          │                                             │                         │                          │   └─────────────────────┼──────┼──────┼──────┼──────┼──────┼──────────────────────────┼─────────────────────────┼──────┼──────┼──────┼──────┼──────┼──────┼────┼─┼─────────┘       │",

--- a/fixtures/layout/example-autoplan.json
+++ b/fixtures/layout/example-autoplan.json
@@ -1,9 +1,9 @@
 {
-  "name": "example-autodevise",
+  "name": "example-autoplan",
   "snapshot": {
     "schema": "pi-workflows.definition-snapshot.v1",
-    "name": "autodevise",
-    "contractId": "pi-workflows.autodevise.v1",
+    "name": "autoplan",
+    "contractId": "pi-workflows.autoplan.v1",
     "startAt": "frame",
     "nodes": {
       "frame": {
@@ -217,8 +217,8 @@
   "state": {
     "schema": "pi-workflows.run-state.v1",
     "traceSeq": 1,
-    "runId": "run-autodevise",
-    "workflowName": "autodevise",
+    "runId": "run-autoplan",
+    "workflowName": "autoplan",
     "startedAt": "2026-01-01T00:00:00.000Z",
     "updatedAt": "2026-01-01T00:01:00.000Z",
     "status": "running",

--- a/skills/autodoc/SKILL.md
+++ b/skills/autodoc/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: autodoc
+description: Use when an existing selected solution or clear implementation plan must be recorded or updated in canonical documentation before implementation, including choosing the right repository and applying SimpleDoc conventions.
+compatibility: Requires Pi Workflows and the built-in autodoc workflow.
+---
+
+# Autodoc
+
+Use the built-in `autodoc` Pi Workflow when it is available. At top level, list workflows, then start `autodoc` once with the task, existing plan, repository, known documents, and evidence from the conversation. Do not manually duplicate stages owned by the workflow.
+
+When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract.
+
+Autodoc records an existing selected solution or clear plan. It does not choose, devise, improve, or revise the solution. If no clear plan exists in the input, conversation, or referenced canonical documents, stop as blocked and use `autoplan` separately.
+
+Outside Pi, or when the workflow is unavailable:
+
+- Prepare or update the canonical plan and documentation without changing the selected solution.
+- Do not take longer than necessary.
+- Preserve the entropy and information in the user's request, including its intent, when writing the plan. Keep the user's concern and any specific wording that carries important meaning near the start of the document, in an introduction that clearly states its intended purpose or goal.
+- Read the relevant code and existing docs before writing. Update the canonical document instead of creating competing sources of truth.
+- Separate user requirements from assumptions and unresolved questions.
+- In plans, state the scope, non-goals, acceptance criteria, and exact verification steps.
+- If there is no plan Markdown document for the task, create one. Do not implement from this skill.
+- Create or update documentation in repositories that the user authorized for documentation changes.
+- For a repository outside the authorized scope, keep the plan in an approved scratch location unless the user explicitly asks to track it in that repository.
+- Create or update the requisite amount of documentation in either existing files or new files in the relevant repos.
+- Avoid unnecessary duplication and keep the relevant existing documentation up to date.
+- When work spans repositories, keep one canonical explanation and link to it rather than copying the same text.
+- After implementation, update the docs to match what actually shipped and record meaningful departures from the plan.
+- Do not spend a long time updating a large set of docs only for this purpose.
+- Use the `plain-writing` skill for all documentation.
+- Read the SimpleDoc specification from the local checkout at `~/repos/SimpleDoc/docs/SIMPLEDOC_SPEC.md`. Do not fetch the specification or related SimpleDoc documentation from online sources.
+- If `~/repos/SimpleDoc` is missing, clone `https://github.com/osolmaz/SimpleDoc.git` there, then read the specification from the local checkout. If the checkout exists, do not switch its branch or modify it only to read the specification.
+- Use the `simpledoc` skill and follow the locally read SimpleDoc convention when creating or updating documentation.
+- Use capitalized filenames for evergreen, long-term documentation and specifications, and dated SimpleDoc filenames for time-bound documents tied to a certain time.
+- Name specification files after the feature itself without `spec` or `specification` in the filename. The document title may include `Spec` or `Specification`.
+- End filenames for non-evergreen implementation plans with `-plan.md`, not `-implementation-plan.md`.
+- Use `cutover` only to describe replacement behavior in prose. Do not use `cutover` or `cutover plan` in filenames, document titles, headings, plan names, issue titles, pull request titles, commit subjects, test names, or other identifiers. Name the target capability directly, adding `plan` only when a plan suffix is useful.
+- Use the `kill-ai-smell` skill for capitalized evergreen documents. AI smell may remain in one-off implementation plans.
+- Test commands and examples when practical.
+- Never place secrets, credentials, private data, or accidental machine-specific paths in tracked documentation.
+- Use `[skip ci]` in the commit message for documentation-only changes.
+- Run `npx -y @simpledoc/simpledoc check` (or `simpledoc check`) locally in each repo where documentation changed.

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: autoimplement
+description: Use when the user asks to implement a plan end-to-end, test it, run Pi Reviewer against the base branch in a loop until no P0/P1 issues remain, and make sure CI/CD is green before finishing.
+compatibility: Requires Pi Workflows and the built-in autoimplement workflow.
+---
+
+Use the built-in `autoimplement` Pi Workflow when it is available. At top level, list workflows, then start `autoimplement` once with the task, existing plan, repository, scope, constraints, base branch, and merge policy from the conversation. Set `merge: true` only when the user explicitly requested merge or an applicable standing instruction authorizes it. Otherwise set it to false. Do not manually duplicate stages already owned by the workflow.
+
+When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract with the available tools.
+
+Outside Pi, or when the workflow is unavailable, do the following in the order that makes sense. Choose the most efficient order for dependencies, and parallelize independent work.
+
+0. Find the clear existing plan in the user's input, conversation, or referenced canonical documents. Do not devise an initial plan. If no clear plan exists, stop as blocked. If the plan exists but its canonical documentation is missing or stale, use `autodoc` to record it before implementation.
+
+1. Implement the given plan end-to-end.
+   - Implement the most elegant and long-term production-ready solution, but do not take longer than necessary.
+   - When implementation, verification, review, or CI produces evidence that invalidates the plan, use `autoplan` with the previous plan and new evidence, then continue from the revised plan. Keep local implementation bugs in the normal fix loop.
+   - Context compaction might happen during implementation or review. If not enough of the plan was preserved after compaction, re-read the written plan to stay on track with the plan.
+   - Finish to completion. If there is a PR open for the implementation plan, do it in the same PR. If there is no PR already, open PR.
+   - Before finishing, commit and push any new or changed documentation, specification, or plan file in the relevant repo or repos, including the `~/scratch` repo when used, unless the user asked not to.
+
+2. Once you finish implementing, make sure to test it.
+   - This will depend on the nature of the problem. If needed, run local smoke tests, spin up dev servers, make requests and such.
+   - Try to test as much as possible, without merging.
+   - State explicitly what could not be tested locally and what still needs staging or production verification.
+   - Do not put mutation testing on the critical path unless repository policy explicitly requires it; keep the mutation test scripts available.
+
+3. Push your latest commits before running review so the review is always against the current PR head.
+   - Run Pi Reviewer with its configured defaults against the base branch: `pi-reviewer --base <branch_name>`. The model and thinking level come from the reviewer's own config, not from this skill.
+   - Use a 10 minute timeout on the tool call available to the model, not the shell `timeout` program. If Pi Reviewer takes more than 10 minutes, kill it.
+   - Do not silently fall back to `codex review` when Pi Reviewer is unavailable; stop and report the missing command or configuration.
+   - Record every review round with separate P0, P1, P2, and lower findings.
+   - Run Pi Reviewer in a loop and address any P0 or P1 issues until there are none left.
+   - If a round reports only P2 or lower findings, address valid proportionate P2 findings, verify and push them, then move to the next stage without running Pi Reviewer again solely because of that P2 work.
+   - Ignore issues about supporting legacy behavior unless the plan requires compatibility.
+   - Look at CI only after Pi Reviewer passes, meaning the last completed run found no issues or only P2 or lower issues.
+
+4. Pi Reviewer reports findings locally and does not post them to the pull request.
+   - Separately check existing inline review comments and PR issue comments, and address valid comments.
+   - Ignore irrelevant comments and stale comments from before the latest commit unless they still apply.
+   - Reply to and resolve each comment either way.
+   - Do not wait a fixed five minutes; wait only when a required review is known to be pending, and keep that wait bounded.
+
+5. In the final step, make sure that CI/CD is green.
+   - Inspect CI once before deciding to wait. If waiting is useful, state and run the exact `gh` tracking command.
+   - Bound one CI watch to five minutes. If CI is still pending, use the next model turn for additional useful local tests or smoke tests instead of waiting. Then inspect CI again.
+   - Ignore the fails unrelated to your changes, others break stuff sometimes and don't fix it.
+   - Make sure whatever changes you did don't break anything.
+   - If CI/CD is not fully green, state explicitly which failures are unrelated and why.
+   - For documentation-only changes, including SimpleDoc changes, relevant local checks are enough; do not wait for CI/CD after they pass.
+
+6. Once CI/CD is green, or the relevant local checks have passed for a documentation-only change, decide whether merge is authorized.
+   - Merge only when the user explicitly requested it or an applicable standing instruction authorizes it. Otherwise leave the PR ready.
+   - Then finish and give a summary with the PR link.
+   - Include the exact validation commands you ran and their outcomes.
+   - Also comment a final report on the PR.
+
+If this skill is queued many times, treat that as a reminder to make sure the work is fully finished. Once the work is fully finished, you can ignore the repeated instructions. If the work is not finished, continue working.

--- a/skills/autoimplement/agents/openai.yaml
+++ b/skills/autoimplement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Autoimplement"
+  short_description: "Finish a plan and ready its PR"
+  default_prompt: "Use $autoimplement to implement the approved plan end-to-end, test it, run `codex review --base <branch>` until no P0/P1 findings remain, clear valid PR feedback, and confirm CI/CD is green without merging."

--- a/skills/autoplan/SKILL.md
+++ b/skills/autoplan/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: autoplan
+description: Use when the user asks to devise, choose, or plan the most elegant long-term production-ready solution, compare it with the ideal end state, and produce the best practical in-scope implementation plan without asking the user to resolve the gap.
+compatibility: Requires Pi Workflows and the built-in autoplan workflow.
+---
+
+# Autoplan
+
+Use the built-in `autoplan` Pi Workflow when it is available. At top level, list workflows, then start `autoplan` once with the problem, authorized scope, constraints, previous plan, and new evidence from the conversation.
+
+When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract.
+
+Outside Pi, or when the workflow is unavailable:
+
+1. Frame the problem, observable success criteria, scope, constraints, and interfaces under our control.
+2. Devise the most elegant long-term production-ready solution within that scope.
+3. Describe the holy grail separately. Name every dependency outside our authority.
+4. Choose the right option without asking the user to decide between them.
+   - Choose the ideal when it is proportionate, production-ready, in scope, and implementable through interfaces we control.
+   - Otherwise choose the strongest practical in-scope solution with a clear path toward the ideal.
+   - Do not block only because the ideal requires an upstream or external change.
+5. Write a detailed implementation plan. For each step, state what changes, where it changes, and how to verify it.
+6. Stop as blocked only when no truthful in-scope solution can meet the success criteria.
+
+When revising a plan, preserve the previous plan and new evidence. State whether the plan changed and why. Do not implement unless the user also requested implementation.

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -35,9 +35,9 @@ When the conversation gives no clear finish criterion, set `stopWhen` to `Stop o
 
 Do not invent a finite check count. Omit `maxChecks` unless the user explicitly requests one. The workflow host can apply its own safety upper bound. Disclose that bound if it appears.
 
-When repair is authorized, route a concrete code or design defect through the monitor's composed repair path. Supply the problem, observed evidence, and a stable fingerprint of the issue plus target state. The workflow runs outer `autodevise`, standalone `autodoc`, optional `plan-approval`, `autoimplement`, and internal redesign when needed, then checks the target again. Do not copy their prompts into the monitor task.
+When repair is authorized, route a concrete code or design defect through the monitor's composed repair path. Supply the problem, observed evidence, and a stable fingerprint of the issue plus target state. The workflow runs outer `autoplan`, standalone `autodoc`, optional `plan-approval`, `autoimplement`, and internal redesign when needed, then checks the target again. Do not copy their prompts into the monitor task.
 
-Add `repair.approval` only when the user requests a human plan decision. Set its named `audience` and a bounded `maxReplans`. A verified continue answer starts implementation. Stop ends the repair truthfully. Replan preserves the exact operator text, sends it back to autodevise, documents the revised plan, and asks again. The model-facing workflow answer tool cannot answer this gate.
+Add `repair.approval` only when the user requests a human plan decision. Set its named `audience` and a bounded `maxReplans`. A verified continue answer starts implementation. Stop ends the repair truthfully. Replan preserves the exact operator text, sends it back to autoplan, documents the revised plan, and asks again. The model-facing workflow answer tool cannot answer this gate.
 
 ## Keep routine work moving
 

--- a/src/builtins/autoimplement.workflow.ts
+++ b/src/builtins/autoimplement.workflow.ts
@@ -13,8 +13,8 @@ import type {
   ShellActionResult,
   WorkflowNodeContext,
 } from "../workflows/types.js";
-import autodeviseWorkflow, { type AutodeviseInput } from "./autodevise.workflow.js";
 import autodocWorkflow, { type AutodocInput } from "./autodoc.workflow.js";
+import autoplanWorkflow, { type AutoplanInput } from "./autoplan.workflow.js";
 import planApprovalWorkflow, { type PlanApprovalInput } from "./plan-approval.workflow.js";
 
 export type AutoimplementInput = {
@@ -490,9 +490,9 @@ export const autoimplementWorkflow = defineWorkflow({
       },
     }),
     redesign: includeWorkflow({
-      workflow: "autodevise",
-      contract: autodeviseWorkflow,
-      input: (context): AutodeviseInput => {
+      workflow: "autoplan",
+      contract: autoplanWorkflow,
+      input: (context): AutoplanInput => {
         const request = context.input as AutoimplementInput;
         return {
           problem: request.task,
@@ -563,7 +563,7 @@ export const autoimplementWorkflow = defineWorkflow({
     }),
     adoptPlan: compute({
       run: ({ outputs }) => {
-        const result = includedResult(autodeviseWorkflow, outputs.redesign);
+        const result = includedResult(autoplanWorkflow, outputs.redesign);
         if (result.exit !== "ready") throw new Error("redesign did not return a ready plan");
         return {
           route: result.output.changed ? "document" : "blocked",

--- a/src/builtins/autoplan.workflow.ts
+++ b/src/builtins/autoplan.workflow.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { agent, compute, defineWorkflow } from "../workflows/definition.js";
 
-export type AutodeviseInput = {
+export type AutoplanInput = {
   problem: string;
   scope?: string;
   constraints?: string[];
@@ -9,7 +9,7 @@ export type AutodeviseInput = {
   newEvidence?: unknown;
 };
 
-export type AutodeviseReady = {
+export type AutoplanReady = {
   status: "ready";
   frame: unknown;
   proposal: unknown;
@@ -21,7 +21,7 @@ export type AutodeviseReady = {
   changed: boolean;
 };
 
-export type AutodeviseBlocked = {
+export type AutoplanBlocked = {
   status: "blocked";
   frame: unknown;
   proposal: unknown;
@@ -44,18 +44,18 @@ function requireString(value: unknown, label: string): string {
   return value.trim();
 }
 
-function parseInput(value: unknown): AutodeviseInput {
-  const input = requireRecord(value, "autodevise input");
+function parseInput(value: unknown): AutoplanInput {
+  const input = requireRecord(value, "autoplan input");
   const constraints = input.constraints;
   if (
     constraints !== undefined &&
     (!Array.isArray(constraints) || constraints.some((item) => typeof item !== "string"))
   ) {
-    throw new Error("autodevise constraints must be an array of strings");
+    throw new Error("autoplan constraints must be an array of strings");
   }
   return {
-    problem: requireString(input.problem, "autodevise problem"),
-    ...(input.scope !== undefined ? { scope: requireString(input.scope, "autodevise scope") } : {}),
+    problem: requireString(input.problem, "autoplan problem"),
+    ...(input.scope !== undefined ? { scope: requireString(input.scope, "autoplan scope") } : {}),
     ...(constraints !== undefined ? { constraints: [...constraints] as string[] } : {}),
     ...(input.previousPlan !== undefined ? { previousPlan: input.previousPlan } : {}),
     ...(input.newEvidence !== undefined ? { newEvidence: input.newEvidence } : {}),
@@ -63,13 +63,13 @@ function parseInput(value: unknown): AutodeviseInput {
 }
 
 function parseSelection(value: unknown): Record<string, unknown> {
-  const selection = requireRecord(value, "autodevise selection");
+  const selection = requireRecord(value, "autoplan selection");
   if (selection.status !== "ready" && selection.status !== "blocked") {
-    throw new Error("autodevise selection status must be ready or blocked");
+    throw new Error("autoplan selection status must be ready or blocked");
   }
-  requireString(selection.selected, "autodevise selected solution");
-  requireString(selection.why, "autodevise selection reason");
-  if (selection.status === "blocked") requireString(selection.blocker, "autodevise blocker");
+  requireString(selection.selected, "autoplan selected solution");
+  requireString(selection.why, "autoplan selection reason");
+  if (selection.status === "blocked") requireString(selection.blocker, "autoplan blocker");
   return selection;
 }
 
@@ -77,12 +77,12 @@ function digest(value: unknown): string {
   return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
-export const autodeviseWorkflow = defineWorkflow({
+export const autoplanWorkflow = defineWorkflow({
   source: import.meta.url,
-  contractId: "pi-workflows.autodevise.v1",
-  name: "autodevise",
+  contractId: "pi-workflows.autoplan.v1",
+  name: "autoplan",
   input: parseInput,
-  title: ({ input }) => `autodevise: ${input.problem.slice(0, 60)}`,
+  title: ({ input }) => `autoplan: ${input.problem.slice(0, 60)}`,
   presentationPrompt: [
     "Present the selected practical solution and its implementation plan.",
     "Briefly state how the ideal informed the choice and what was excluded as outside scope.",
@@ -93,18 +93,18 @@ export const autodeviseWorkflow = defineWorkflow({
   exits: {
     ready: {
       from: "finalize",
-      validate: (value: unknown): AutodeviseReady => value as AutodeviseReady,
+      validate: (value: unknown): AutoplanReady => value as AutoplanReady,
     },
     blocked: {
       from: "blocked",
-      validate: (value: unknown): AutodeviseBlocked => value as AutodeviseBlocked,
+      validate: (value: unknown): AutoplanBlocked => value as AutoplanBlocked,
     },
   },
   nodes: {
     frame: agent({
       statusDetail: "framing the problem",
       prompt: ({ input }) => {
-        const request = input as AutodeviseInput;
+        const request = input as AutoplanInput;
         return [
           `Frame this problem: ${request.problem}`,
           `Authorized scope: ${request.scope ?? "infer it conservatively from the request and current project"}.`,
@@ -116,7 +116,7 @@ export const autodeviseWorkflow = defineWorkflow({
         ].join("\n");
       },
       expectedOutput: `{ "problem": "concise statement", "success": ["criterion"], "inScope": ["change"], "outOfScope": ["change"], "constraints": ["constraint"], "controlBoundary": "what can change" }`,
-      validate: (value) => requireRecord(value, "autodevise frame"),
+      validate: (value) => requireRecord(value, "autoplan frame"),
     }),
     propose: agent({
       statusDetail: "devising a solution",
@@ -129,7 +129,7 @@ export const autodeviseWorkflow = defineWorkflow({
           `Problem frame: ${JSON.stringify(outputs.frame)}`,
         ].join("\n"),
       expectedOutput: `{ "solution": "proposal", "rationale": "why", "parts": ["part"], "tradeoffs": ["trade-off"] }`,
-      validate: (value) => requireRecord(value, "autodevise proposal"),
+      validate: (value) => requireRecord(value, "autoplan proposal"),
     }),
     ideal: agent({
       statusDetail: "describing the ideal end state",
@@ -141,10 +141,10 @@ export const autodeviseWorkflow = defineWorkflow({
           "Explain the practical value beyond the proposal.",
           `Problem frame: ${JSON.stringify(outputs.frame)}`,
           `Proposal: ${JSON.stringify(outputs.propose)}`,
-          `New evidence: ${JSON.stringify((input as AutodeviseInput).newEvidence ?? null)}`,
+          `New evidence: ${JSON.stringify((input as AutoplanInput).newEvidence ?? null)}`,
         ].join("\n"),
       expectedOutput: `{ "ideal": "ideal end state", "outsideDependencies": ["dependency"], "additionalValue": ["benefit"] }`,
-      validate: (value) => requireRecord(value, "autodevise ideal"),
+      validate: (value) => requireRecord(value, "autoplan ideal"),
     }),
     choose: agent({
       statusDetail: "choosing the practical solution",
@@ -177,11 +177,11 @@ export const autodeviseWorkflow = defineWorkflow({
           "Do not implement the plan.",
           `Frame: ${JSON.stringify(outputs.frame)}`,
           `Selection: ${JSON.stringify(outputs.choose)}`,
-          `Previous plan: ${JSON.stringify((input as AutodeviseInput).previousPlan ?? null)}`,
-          `New evidence: ${JSON.stringify((input as AutodeviseInput).newEvidence ?? null)}`,
+          `Previous plan: ${JSON.stringify((input as AutoplanInput).previousPlan ?? null)}`,
+          `New evidence: ${JSON.stringify((input as AutoplanInput).newEvidence ?? null)}`,
         ].join("\n"),
       expectedOutput: `{ "summary": "approach", "steps": [{ "change": "change", "where": "location", "verification": "evidence" }], "contracts": ["impact"], "tests": ["test"], "risks": [{ "risk": "risk", "mitigation": "mitigation" }], "boundaries": ["excluded work"] }`,
-      validate: (value) => requireRecord(value, "autodevise plan"),
+      validate: (value) => requireRecord(value, "autoplan plan"),
     }),
     blocked: compute({
       run: ({ outputs }) => {
@@ -192,13 +192,13 @@ export const autodeviseWorkflow = defineWorkflow({
           proposal: outputs.propose,
           ideal: outputs.ideal,
           selection,
-          reason: requireString(selection.blocker, "autodevise blocker"),
-        } satisfies AutodeviseBlocked;
+          reason: requireString(selection.blocker, "autoplan blocker"),
+        } satisfies AutoplanBlocked;
       },
     }),
     finalize: compute({
       run: ({ outputs, input }) => {
-        const request = input as AutodeviseInput;
+        const request = input as AutoplanInput;
         const planDigest = digest(outputs.plan);
         const previousPlanDigest =
           request.previousPlan === undefined ? undefined : digest(request.previousPlan);
@@ -212,7 +212,7 @@ export const autodeviseWorkflow = defineWorkflow({
           planDigest,
           ...(previousPlanDigest !== undefined ? { previousPlanDigest } : {}),
           changed: previousPlanDigest === undefined || previousPlanDigest !== planDigest,
-        } satisfies AutodeviseReady;
+        } satisfies AutoplanReady;
       },
     }),
   },
@@ -228,4 +228,4 @@ export const autodeviseWorkflow = defineWorkflow({
   ],
 });
 
-export default autodeviseWorkflow;
+export default autoplanWorkflow;

--- a/src/builtins/catalog.ts
+++ b/src/builtins/catalog.ts
@@ -1,18 +1,18 @@
 import { BuiltinWorkflowCatalog } from "../workflows/catalog.js";
-import autodeviseWorkflow from "./autodevise.workflow.js";
 import autodocWorkflow from "./autodoc.workflow.js";
 import autoimplementWorkflow from "./autoimplement.workflow.js";
+import autoplanWorkflow from "./autoplan.workflow.js";
 import monitorWorkflow from "./monitor.workflow.js";
 import planApprovalWorkflow from "./plan-approval.workflow.js";
 
 export const builtinWorkflowCatalog = new BuiltinWorkflowCatalog([
-  { id: "autodevise", revision: "1", definition: autodeviseWorkflow },
+  { id: "autoplan", revision: "1", definition: autoplanWorkflow },
   { id: "autodoc", revision: "1", definition: autodocWorkflow },
-  { id: "autoimplement", revision: "2", definition: autoimplementWorkflow },
+  { id: "autoimplement", revision: "3", definition: autoimplementWorkflow },
   { id: "plan-approval", revision: "1", definition: planApprovalWorkflow },
   {
     id: "monitor",
-    revision: "5",
+    revision: "6",
     definition: monitorWorkflow,
     legacySources: [
       {

--- a/src/builtins/index.ts
+++ b/src/builtins/index.ts
@@ -1,9 +1,9 @@
 export {
-  autodeviseWorkflow,
-  type AutodeviseBlocked,
-  type AutodeviseInput,
-  type AutodeviseReady,
-} from "./autodevise.workflow.js";
+  autoplanWorkflow,
+  type AutoplanBlocked,
+  type AutoplanInput,
+  type AutoplanReady,
+} from "./autoplan.workflow.js";
 export {
   autodocWorkflow,
   type AutodocBlocked,

--- a/src/builtins/monitor.workflow.ts
+++ b/src/builtins/monitor.workflow.ts
@@ -20,9 +20,9 @@ import type {
   WorkflowProgressData,
 } from "../workflows/types.js";
 import { validateProgressData } from "../workflows/updates.js";
-import autodeviseWorkflow from "./autodevise.workflow.js";
 import autodocWorkflow, { type AutodocInput } from "./autodoc.workflow.js";
 import autoimplementWorkflow, { type AutoimplementInput } from "./autoimplement.workflow.js";
+import autoplanWorkflow from "./autoplan.workflow.js";
 import planApprovalWorkflow, { type PlanApprovalInput } from "./plan-approval.workflow.js";
 
 const MIN_INTERVAL_MINUTES = 1;
@@ -346,7 +346,7 @@ function currentRepairPlan(outputs: Record<string, unknown>): {
       documents: documentation.output.documentation?.files ?? [],
     };
   }
-  const design = includedResult(autodeviseWorkflow, outputs.initialDesign);
+  const design = includedResult(autoplanWorkflow, outputs.initialDesign);
   if (design.exit !== "ready") throw new Error("monitor design did not return a ready plan");
   return { plan: design.output.plan, planDigest: design.output.planDigest, documents: [] };
 }
@@ -428,8 +428,8 @@ const monitorWorkflow: WorkflowDefinition = defineWorkflow({
   maxSteps: 200_000,
   includes: {
     initialDesign: includeWorkflow({
-      workflow: "autodevise",
-      contract: autodeviseWorkflow,
+      workflow: "autoplan",
+      contract: autoplanWorkflow,
       input: ({ outputs }) => {
         const config = configFrom(outputs);
         const repair = (outputs.check as MonitorCheck).repair;
@@ -458,7 +458,7 @@ const monitorWorkflow: WorkflowDefinition = defineWorkflow({
       input: ({ outputs }): AutodocInput => {
         const config = configFrom(outputs);
         const repair = (outputs.check as MonitorCheck).repair;
-        const design = includedResult(autodeviseWorkflow, outputs.initialDesign);
+        const design = includedResult(autoplanWorkflow, outputs.initialDesign);
         if (design.exit !== "ready") throw new Error("monitor design did not return a ready plan");
         if (repair === undefined) throw new Error("monitor repair details are missing");
         return {

--- a/test/autoimplement-plan-discovery.test.ts
+++ b/test/autoimplement-plan-discovery.test.ts
@@ -37,7 +37,7 @@ async function run(executor: ScriptedExecutor, input: unknown) {
 }
 
 describe("autoimplement existing-plan startup", () => {
-  it("uses a current plan from context without initial autodevise or autodoc", async () => {
+  it("uses a current plan from context without initial autoplan or autodoc", async () => {
     const plan = { summary: "existing", steps: ["implement"] };
     const executor = blockedImplementation(
       new ScriptedExecutor().respond("findPlan", {

--- a/test/builtin-autoplan.test.ts
+++ b/test/builtin-autoplan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import autodeviseWorkflow from "../src/builtins/autodevise.workflow.js";
+import autoplanWorkflow from "../src/builtins/autoplan.workflow.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import { makeTempDir, ScriptedExecutor } from "./helpers.js";
 
@@ -33,7 +33,7 @@ function commonExecutor(selection: Record<string, unknown>) {
     .respond("choose", { output: selection });
 }
 
-describe("built-in autodevise", () => {
+describe("built-in autoplan", () => {
   it("selects a practical plan and records plan lineage", async () => {
     const previousPlan = { summary: "old plan" };
     const executor = commonExecutor({
@@ -55,10 +55,10 @@ describe("built-in autodevise", () => {
     });
     const engine = new WorkflowEngine({
       executor,
-      outputRoot: await makeTempDir("pi-workflows-autodevise"),
+      outputRoot: await makeTempDir("pi-workflows-autoplan"),
     });
 
-    const { state } = await engine.run(autodeviseWorkflow, {
+    const { state } = await engine.run(autoplanWorkflow, {
       problem: "solve demo",
       previousPlan,
       newEvidence: { failure: "old plan failed" },
@@ -85,10 +85,10 @@ describe("built-in autodevise", () => {
     });
     const engine = new WorkflowEngine({
       executor,
-      outputRoot: await makeTempDir("pi-workflows-autodevise-blocked"),
+      outputRoot: await makeTempDir("pi-workflows-autoplan-blocked"),
     });
 
-    const { state } = await engine.run(autodeviseWorkflow, { problem: "solve demo" });
+    const { state } = await engine.run(autoplanWorkflow, { problem: "solve demo" });
 
     expect(state.status).toBe("completed");
     expect(state.finalOutput).toMatchObject({

--- a/test/bundled-skills.test.ts
+++ b/test/bundled-skills.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(import.meta.dirname, "..");
+const skillRoot = path.join(root, "skills");
+
+function skill(name: string): string {
+  return readFileSync(path.join(skillRoot, name, "SKILL.md"), "utf8");
+}
+
+describe("bundled workflow skills", () => {
+  it("ships one matching skill for each operator-facing built-in", () => {
+    const names = readdirSync(skillRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    expect(names).toEqual(["autodoc", "autoimplement", "autoplan", "monitor", "pi-workflows"]);
+    for (const name of names) {
+      expect(skill(name)).toContain(`name: ${name}`);
+    }
+  });
+
+  it.each(["autodoc", "autoimplement", "autoplan"])(
+    "routes %s through its built-in workflow",
+    (name) => {
+      expect(skill(name)).toContain(`built-in \`${name}\` Pi Workflow`);
+    },
+  );
+
+  it("routes monitor through its built-in workflow", () => {
+    expect(skill("monitor")).toContain("built-in Pi `monitor` workflow");
+  });
+
+  it("keeps initial planning out of autoimplement and autodoc", () => {
+    expect(skill("autoimplement")).toContain("Do not devise an initial plan");
+    expect(skill("autodoc")).toContain("It does not choose, devise, improve, or revise");
+  });
+});

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -1020,7 +1020,7 @@ describe.sequential("pi-workflows end to end", () => {
 
     expect(state.status, state.error).toBe("completed");
     expect(state.workflowName).toBe("monitor");
-    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "5" });
+    expect(state.workflowSource).toEqual({ kind: "builtin", id: "monitor", revision: "6" });
     expect(state.workflowPath).toBeUndefined();
     expect(state.workflowHash).toBeUndefined();
     expect(state.finalOutput).toMatchObject({

--- a/test/helpers/layout-fixtures.ts
+++ b/test/helpers/layout-fixtures.ts
@@ -51,7 +51,7 @@ const EXAMPLES_DIR = path.join(
 );
 
 const EXAMPLE_FILES = [
-  "autodevise.workflow.ts",
+  "autoplan.workflow.ts",
   "autoimplement.workflow.ts",
   "autoresearch.workflow.ts",
   "branch.workflow.ts",

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -50,7 +50,7 @@ describe("discoverWorkflows", () => {
     expect(discovered.map((w) => [w.name, w.source])).toEqual([
       ["local", "project"],
       ["global", "global"],
-      ["autodevise", "builtin"],
+      ["autoplan", "builtin"],
       ["autodoc", "builtin"],
       ["autoimplement", "builtin"],
       ["plan-approval", "builtin"],
@@ -68,7 +68,7 @@ describe("discoverWorkflows", () => {
     expect(discovered).toHaveLength(6);
     expect(discovered[0]?.source).toBe("project");
     expect(discovered.slice(1).map((item) => item.name)).toEqual([
-      "autodevise",
+      "autoplan",
       "autodoc",
       "autoimplement",
       "plan-approval",
@@ -81,7 +81,7 @@ describe("discoverWorkflows", () => {
     const homeDir = await makeTempDir("pi-workflows-empty-home");
     expect(
       (await discoverWorkflows({ cwd, homeDir }, builtinWorkflowCatalog)).map((item) => item.name),
-    ).toEqual(["autodevise", "autodoc", "autoimplement", "plan-approval", "monitor"]);
+    ).toEqual(["autoplan", "autodoc", "autoimplement", "plan-approval", "monitor"]);
   });
 
   it("lets a project workflow override the built-in monitor", async () => {
@@ -128,7 +128,7 @@ describe("resolveWorkflowRef", () => {
     const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir }, builtinWorkflowCatalog);
 
     expect(resolved.sourceKind).toBe("builtin");
-    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "5" });
+    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "6" });
     expect(resolved.definition.name).toBe("monitor");
     expect(resolved.sources.map((item) => item.mountPath.join("/"))).toEqual([
       "approval",
@@ -191,8 +191,8 @@ describe("resolveWorkflowRef", () => {
     const dir = path.join(cwd, ".pi", "workflows");
     const api = JSON.stringify(path.join(REPO_ROOT, "src", "workflows", "index.ts"));
     await fs.writeFile(
-      path.join(dir, "autodevise.workflow.ts"),
-      `import { compute, defineWorkflow } from ${api};\nexport default defineWorkflow({ name: "autodevise", startAt: "done", exits: { wrong: { from: "done" } }, nodes: { done: compute({ run: () => ({}) }) }, edges: [] });\n`,
+      path.join(dir, "autoplan.workflow.ts"),
+      `import { compute, defineWorkflow } from ${api};\nexport default defineWorkflow({ name: "autoplan", startAt: "done", exits: { wrong: { from: "done" } }, nodes: { done: compute({ run: () => ({}) }) }, edges: [] });\n`,
       "utf8",
     );
 

--- a/test/monitor-human-approval.test.ts
+++ b/test/monitor-human-approval.test.ts
@@ -293,7 +293,7 @@ describe("monitor human repair approval", () => {
     );
   });
 
-  it("feeds exact replan text to autodevise, documents the revision, and asks again", async () => {
+  it("feeds exact replan text to autoplan, documents the revision, and asks again", async () => {
     const executor = completedRepairExecutor(2);
     const store = new WorkflowRunStore(await makeTempDir("monitor-replan-runs"));
     const resolved = await resolveWorkflowRef(

--- a/test/package-resources.test.ts
+++ b/test/package-resources.test.ts
@@ -75,6 +75,9 @@ describe("Pi package resources", () => {
   it("ships valid uniquely named skills", async () => {
     const files = await skillFiles();
     expect(files.map((file) => path.relative(skillsRoot, file))).toEqual([
+      "autodoc/SKILL.md",
+      "autoimplement/SKILL.md",
+      "autoplan/SKILL.md",
       "monitor/SKILL.md",
       "pi-workflows/SKILL.md",
     ]);


### PR DESCRIPTION
## Summary

Planning workflows and their matching skills were split across Pi Workflows and OnurPi.
This change makes Pi Workflows own the complete workflow interface, renames `autodevise` to the clearer `autoplan`, and bundles the Autoplan, Autodoc, and Autoimplement skills with their built-ins.
It also records the selected design for readable Pi and Telegram decision messages so future implementation does not send raw plan JSON to operators.

## What Changed

The workflow command, source file, exports, composition mounts, examples, fixtures, tests, and documentation now use `autoplan`.
The old `autodevise` command and export are removed instead of retaining a compatibility alias.

- Added bundled `autoplan`, `autodoc`, and `autoimplement` skills.
- Corrected the Autodoc and Autoimplement skill boundaries so they adopt an existing plan instead of devising one.
- Bumped the affected Autoimplement and Monitor built-in revisions.
- Added the human decision presentation specification and implementation plan.
- Defined separate canonical subject data and human-readable presentation content.
- Defined complete Telegram message splitting, full Pi rendering, digest binding, v1 compatibility, and failure handling.

## Testing

The full TypeScript, real-Pi, Rust, package, dependency-boundary, and documentation-focused checks passed.
SimpleDoc still reports the repository's existing ten-file migration baseline; it did not report a new file-specific problem.

- `npm run check`
- `npm run test:e2e`
- `cargo test --manifest-path tui/Cargo.toml`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `npm pack --dry-run --json`
- `python3 .../kill-ai-smell/check.py docs/HUMAN_DECISION_PRESENTATIONS.md`
- `npx -y @simpledoc/simpledoc check` (existing repository migration baseline only)
- `git diff --check`

## Risks

The rename intentionally removes the old built-in command and TypeScript export.
Existing terminal bundles remain readable, but an active caller must use `autoplan` after updating.

The human-readable presentation work is documentation only in this change.
The current runtime still uses the v1 `body` behavior until that plan is implemented.
