### PR TITLE
feat(herdr): synchronize moved plugin links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,18 @@ or run it in place with `npx tsx src/viewer/cli.ts`.
 ## Herdr integration
 
 Pi Workflows also ships as a [Herdr](https://herdr.dev) plugin. After installing
-`piw` and Pi Workflows, link the bundled plugin once:
+`piw` and Pi Workflows, synchronize the bundled plugin:
 
 ```bash
-pi-workflows herdr setup
+pi-workflows herdr sync
 ```
+
+Run the same command after a Pi Workflows update. It finds the package that
+provides the running CLI and repairs a Herdr link when npm moved that package.
+`pi-workflows herdr setup` remains an alias for existing installations. Use
+`--json` for versioned machine-readable output. The [Herdr plugin sync
+plan](docs/plans/2026-08-20-herdr-plugin-sync-plan.md) defines update and
+recovery behavior.
 
 When Pi runs inside Herdr, a workflow widget shows `Ctrl+Shift+R piw`. When the widget has hidden rows, this call to action shares the existing scroll-controls line instead of taking another line.
 The shortcut opens the exact run bundle and lets you choose a split, tab, or new

--- a/docs/plans/2026-08-20-herdr-plugin-sync-plan.md
+++ b/docs/plans/2026-08-20-herdr-plugin-sync-plan.md
@@ -1,0 +1,104 @@
+---
+title: Keep the Herdr plugin linked after package updates
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-20
+---
+
+# Keep the Herdr plugin linked after package updates
+
+Pi Workflows ships its Herdr plugin inside the npm package. Herdr records the package's absolute path. npm can move an installed package between nested and hoisted `node_modules` directories during an update, which leaves Herdr linked to a path that no longer exists.
+
+Pi Workflows will own one explicit command that finds its own package and repairs this link. OnurPi will call that command after it installs an exact reviewed Pi Workflows release. OnurPi will not contain Herdr paths, manifests, or link-repair rules.
+
+## Outcome
+
+The canonical command is:
+
+```bash
+pi-workflows herdr sync --json
+```
+
+`pi-workflows herdr setup` remains an alias for compatibility.
+
+The command validates the bundled package before it changes Herdr. It then creates a missing link, enables a disabled link, leaves a correct link unchanged, or replaces a link to another package path or version. A successful result requires a new Herdr query that shows the expected plugin ID, package version, package root, manifest path, enabled state, and no warning.
+
+## Scope
+
+### Pi Workflows
+
+- Resolve the installed package root from the running CLI.
+- Validate `package.json`, `herdr-plugin.toml`, and the bundled viewer before changing Herdr.
+- Reconcile the current registration through Herdr's public CLI.
+- Return a versioned JSON result with one of `linked`, `relinked`, `enabled`, `unchanged`, or `unavailable`.
+- Return `unavailable` only when the Herdr executable is absent.
+- Treat malformed package data, malformed Herdr output, command failures, identity conflicts, and failed verification as errors.
+- Keep output bounded and use argument arrays instead of shell commands.
+- Test source and packed-package layouts, including paths that contain spaces.
+
+### OnurPi
+
+- Keep the Pi Workflows dependency pinned to an exact reviewed release.
+- Invoke the local `pi-workflows herdr sync --json` command from an explicit TypeScript sync script after dependency installation.
+- Accept the versioned result and keep Herdr-specific behavior in Pi Workflows.
+- Keep package installation free of `postinstall` side effects.
+
+## Non-goals
+
+- Do not create another Herdr plugin package or release.
+- Do not duplicate the manifest or viewer in OnurPi.
+- Do not add hard-coded `node_modules` paths.
+- Do not edit Herdr state files directly.
+- Do not change Herdr core or Pi core.
+- Do not hot-reload running Pi processes. A running process still needs `/reload` or restart after a package update.
+- Do not add a service, watcher, or implicit package-install mutation.
+
+## Command contract
+
+The JSON result uses schema `pi-workflows.herdr-sync.v1` and contains:
+
+- the result status;
+- whether Herdr state changed;
+- the plugin ID;
+- the expected and effective versions when available;
+- the effective enabled state when available;
+- a plain summary; and
+- an advisory that running Pi processes must reload after a package update.
+
+A missing Herdr executable returns `unavailable` with exit code zero because Herdr is an optional integration. Every other failure returns a nonzero exit code and does not claim success.
+
+The command preflights the new package before unlinking an old registration. Herdr currently exposes separate unlink and link commands, so replacement cannot be atomic. If replacement fails, Pi Workflows makes one restore attempt only when the previous package root still passes the same validation. It then reports the state found by a fresh Herdr query.
+
+Concurrent sync commands converge on the same target. After a failed or ambiguous mutation, the command queries Herdr and adopts the result only when another process already reached the exact expected state. It does not repeat the same mutation blindly.
+
+## Compatibility
+
+Existing `herdr setup` callers use the same implementation. Other Pi Workflows CLI commands do not change. The npm package remains the only source of the plugin manifest and viewer.
+
+OnurPi adds only invocation timing and result handling. It does not parse the Herdr manifest or issue link commands.
+
+## Verification
+
+### Pi Workflows
+
+- Test first link, unchanged link, disabled link, moved package path, stale path, and version update.
+- Test missing Herdr, malformed manifests, malformed plugin records, command failures, post-action mismatches, and bounded restore behavior.
+- Test concurrent adoption and paths with spaces.
+- Run the CLI from `npm pack` contents in nested and hoisted layouts.
+- Run `npm run check`, `npm run test:e2e`, Slophammer, SimpleDoc, and diff checks.
+
+### OnurPi
+
+- Test every structured result and invalid command output with a fake executable.
+- Verify the wrapper contains no plugin ID, manifest copy, Herdr mutation command, or package path.
+- Verify root and wrapper dependency pins remain equal.
+- Run `npm run check`, `npm run slophammer`, SimpleDoc, and diff checks.
+
+### Adoption
+
+After a separately approved Pi Workflows release, update OnurPi to that exact version and run:
+
+```bash
+npm run workflows:sync
+```
+
+Then verify the Herdr plugin list, open `piw`, and start or reload Pi to confirm resource discovery. Repeating the sync must return `unchanged`.

--- a/src/herdr/setup.ts
+++ b/src/herdr/setup.ts
@@ -3,81 +3,467 @@ import fs from "node:fs";
 import path from "node:path";
 import { HERDR_PLUGIN_ID } from "./constants.js";
 
-export type HerdrSetupResult = {
+const PACKAGE_NAME = "@osolmaz/pi-workflows";
+const MANIFEST_NAME = "herdr-plugin.toml";
+const VIEWER_PATH = "plugins/herdr/viewer.mjs";
+const RESULT_SCHEMA = "pi-workflows.herdr-sync.v1" as const;
+const MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024;
+
+export type HerdrSyncStatus = "linked" | "relinked" | "enabled" | "unchanged" | "unavailable";
+
+export type HerdrSyncResult = {
+  schema: typeof RESULT_SCHEMA;
+  status: HerdrSyncStatus;
   changed: boolean;
+  pluginId: string;
+  expectedVersion: string;
+  effectiveVersion: string | null;
+  enabled: boolean | null;
+  runningPiProcessesNeedReload: true;
   message: string;
 };
 
+export type HerdrSetupResult = HerdrSyncResult;
+
 type Spawn = (command: string, args: readonly string[]) => SpawnSyncReturns<string>;
 
-export function setupHerdrPlugin(packageRoot: string, spawn: Spawn = runCommand): HerdrSetupResult {
-  const root = path.resolve(packageRoot);
-  const manifest = path.join(root, "herdr-plugin.toml");
-  if (!fs.existsSync(manifest)) {
-    throw new Error(`Herdr plugin manifest not found: ${manifest}`);
+type PluginPackage = {
+  root: string;
+  manifestPath: string;
+  version: string;
+};
+
+type InstalledPlugin = {
+  root: string;
+  manifestPath: string;
+  version: string;
+  enabled: boolean;
+  warnings: string[];
+};
+
+type Inspection = { available: true; plugin: InstalledPlugin | undefined } | { available: false };
+
+type MutationResult = { ok: true } | { ok: false; error: string };
+
+type RollbackTarget = { package: PluginPackage; enabled: boolean };
+
+export function syncHerdrPlugin(packageRoot: string, spawn: Spawn = runCommand): HerdrSyncResult {
+  const expected = preflightPackage(packageRoot);
+  const initial = inspectHerdr(spawn, true);
+  if (!initial.available) {
+    return result("unavailable", false, expected.version, undefined);
   }
 
+  const installed = initial.plugin;
+  if (installed === undefined) {
+    const linked = mutate(spawn, "link", [expected.root]);
+    const adopted = verifyOrExplain(spawn, expected);
+    if (adopted.plugin !== undefined && matchesExpected(adopted.plugin, expected, true)) {
+      return result("linked", true, expected.version, adopted.plugin);
+    }
+    throw mutationError("link", linked, adopted.problem);
+  }
+
+  if (matchesExpected(installed, expected, true)) {
+    return result("unchanged", false, expected.version, installed);
+  }
+
+  if (matchesExpected(installed, expected, false) && !installed.enabled) {
+    const enabled = mutate(spawn, "enable", [HERDR_PLUGIN_ID]);
+    const adopted = verifyOrExplain(spawn, expected);
+    if (adopted.plugin !== undefined && matchesExpected(adopted.plugin, expected, true)) {
+      return result("enabled", true, expected.version, adopted.plugin);
+    }
+    throw mutationError("enable", enabled, adopted.problem);
+  }
+
+  const rollback = rollbackTarget(installed);
+  const unlinked = mutate(spawn, "unlink", [HERDR_PLUGIN_ID]);
+  const afterUnlink = inspectHerdr(spawn, false);
+  if (!afterUnlink.available) throw new Error("Herdr became unavailable during synchronization.");
+  if (afterUnlink.plugin !== undefined) {
+    if (matchesExpected(afterUnlink.plugin, expected, true)) {
+      return result("relinked", true, expected.version, afterUnlink.plugin);
+    }
+    throw mutationError(
+      "unlink the stale registration",
+      unlinked,
+      "Herdr still reports a conflicting registration.",
+    );
+  }
+
+  const linked = mutate(spawn, "link", [expected.root]);
+  const adopted = verifyOrExplain(spawn, expected);
+  if (adopted.plugin !== undefined && matchesExpected(adopted.plugin, expected, true)) {
+    return result("relinked", true, expected.version, adopted.plugin);
+  }
+
+  const rollbackMessage = restorePrevious(spawn, expected, rollback);
+  throw new Error(
+    `${mutationError("link the current package", linked, adopted.problem).message} ${rollbackMessage}`,
+  );
+}
+
+/** Compatibility alias for callers that used the original setup API. */
+export function setupHerdrPlugin(packageRoot: string, spawn: Spawn = runCommand): HerdrSetupResult {
+  return syncHerdrPlugin(packageRoot, spawn);
+}
+
+function preflightPackage(packageRoot: string): PluginPackage {
+  const requestedRoot = path.resolve(packageRoot);
+  let root: string;
+  try {
+    root = fs.realpathSync(requestedRoot);
+  } catch (error) {
+    throw new Error(`Pi Workflows package root is missing: ${requestedRoot}`, { cause: error });
+  }
+  if (!fs.statSync(root).isDirectory()) {
+    throw new Error(`Pi Workflows package root is not a directory: ${requestedRoot}`);
+  }
+  const packagePath = checkedRegularFile(root, "package.json");
+  const manifestPath = checkedRegularFile(root, MANIFEST_NAME);
+  const packageJson = parseJsonObject(fs.readFileSync(packagePath, "utf8"), "package.json");
+  if (packageJson["name"] !== PACKAGE_NAME) {
+    throw new Error(`Unexpected Pi Workflows package name in ${packagePath}.`);
+  }
+  const packageVersion = packageJson["version"];
+  if (typeof packageVersion !== "string" || packageVersion.length === 0) {
+    throw new Error(`Pi Workflows package version is missing in ${packagePath}.`);
+  }
+
+  const manifest = fs.readFileSync(manifestPath, "utf8");
+  const topLevelManifest = manifest.split(/^\s*\[\[/mu, 1)[0] ?? "";
+  const pluginId = tomlString(topLevelManifest, "id", manifestPath);
+  const pluginVersion = tomlString(topLevelManifest, "version", manifestPath);
+  tomlString(topLevelManifest, "min_herdr_version", manifestPath);
+  const platforms = tomlStringArray(topLevelManifest, "platforms", manifestPath);
+  const command = tomlStringArray(manifest, "command", manifestPath);
+  if (pluginId !== HERDR_PLUGIN_ID) {
+    throw new Error(`Unexpected Herdr plugin ID in ${manifestPath}.`);
+  }
+  if (pluginVersion !== packageVersion) {
+    throw new Error(`Herdr plugin version does not match package version ${packageVersion}.`);
+  }
+  const platform = process.platform === "darwin" ? "macos" : process.platform;
+  if (!platforms.includes(platform)) {
+    throw new Error(`Herdr plugin does not support platform ${platform}.`);
+  }
+  if (command.length !== 2 || command[0] !== "node" || command[1] !== VIEWER_PATH) {
+    throw new Error(`Unexpected Herdr plugin viewer command in ${manifestPath}.`);
+  }
+  checkedRegularFile(root, VIEWER_PATH);
+  return { root, manifestPath, version: packageVersion };
+}
+
+function checkedRegularFile(root: string, relativePath: string): string {
+  const target = path.resolve(root, relativePath);
+  if (!isWithin(root, target)) {
+    throw new Error(`Package file escapes the package root: ${relativePath}`);
+  }
+  const stat = statOrThrow(target, `Package file ${relativePath}`);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`Package file is not a regular file: ${relativePath}`);
+  }
+  const real = fs.realpathSync(target);
+  if (!isWithin(root, real)) {
+    throw new Error(`Package file resolves outside the package root: ${relativePath}`);
+  }
+  return real;
+}
+
+function isWithin(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
+function statOrThrow(target: string, label: string): fs.Stats {
+  try {
+    return fs.lstatSync(target);
+  } catch (error) {
+    throw new Error(`${label} is missing: ${target}`, { cause: error });
+  }
+}
+
+function parseJsonObject(text: string, label: string): Record<string, unknown> {
+  let value: unknown;
+  try {
+    value = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON.`, { cause: error });
+  }
+  if (!isRecord(value)) throw new Error(`${label} must contain a JSON object.`);
+  return value;
+}
+
+function tomlString(text: string, key: string, manifestPath: string): string {
+  const expressions = matches(
+    text,
+    new RegExp(String.raw`^\s*${escapeRegExp(key)}\s*=\s*("(?:[^"\\]|\\.)*")\s*(?:#.*)?$`, "gmu"),
+  );
+  if (expressions.length !== 1) {
+    throw new Error(`Herdr manifest must contain one ${key} string: ${manifestPath}`);
+  }
+  try {
+    const value: unknown = JSON.parse(expressions[0] as string);
+    if (typeof value !== "string" || value.length === 0) throw new Error("empty string");
+    return value;
+  } catch (error) {
+    throw new Error(`Herdr manifest has an invalid ${key} string: ${manifestPath}`, {
+      cause: error,
+    });
+  }
+}
+
+function tomlStringArray(text: string, key: string, manifestPath: string): string[] {
+  const expressions = matches(
+    text,
+    new RegExp(
+      String.raw`^\s*${escapeRegExp(key)}\s*=\s*(\[(?:[^\]"\\]|"(?:[^"\\]|\\.)*")*\])\s*(?:#.*)?$`,
+      "gmu",
+    ),
+  );
+  if (expressions.length !== 1) {
+    throw new Error(`Herdr manifest must contain one ${key} string array: ${manifestPath}`);
+  }
+  try {
+    const value: unknown = JSON.parse(expressions[0] as string);
+    if (
+      !Array.isArray(value) ||
+      value.length === 0 ||
+      value.some((item) => typeof item !== "string")
+    ) {
+      throw new Error("invalid string array");
+    }
+    return value as string[];
+  } catch (error) {
+    throw new Error(`Herdr manifest has an invalid ${key} string array: ${manifestPath}`, {
+      cause: error,
+    });
+  }
+}
+
+function matches(text: string, expression: RegExp): string[] {
+  const values: string[] = [];
+  for (const match of text.matchAll(expression)) {
+    const value = match[1];
+    if (value !== undefined) values.push(value);
+  }
+  return values;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function inspectHerdr(spawn: Spawn, allowUnavailable: boolean): Inspection {
   const listed = spawn("herdr", ["plugin", "list", "--plugin", HERDR_PLUGIN_ID, "--json"]);
-  if (listed.error) throw new Error(`Could not run Herdr: ${listed.error.message}`);
+  if (listed.error !== undefined) {
+    if (allowUnavailable && errorCode(listed.error) === "ENOENT") return { available: false };
+    throw new Error(`Could not run Herdr: ${listed.error.message}`);
+  }
   if (listed.status !== 0) {
     throw new Error(`Could not inspect Herdr plugins: ${bounded(listed.stderr || listed.stdout)}`);
   }
-  const installed = installedPlugin(listed.stdout);
-  if (installed !== undefined) {
-    if (path.resolve(installed.root) !== root) {
-      throw new Error(
-        `Herdr plugin ${HERDR_PLUGIN_ID} is already registered from ${installed.root}. Unlink it before linking ${root}.`,
-      );
-    }
-    if (installed.enabled) {
-      return { changed: false, message: `Herdr plugin ${HERDR_PLUGIN_ID} is already linked.` };
-    }
-    const enabled = spawn("herdr", ["plugin", "enable", HERDR_PLUGIN_ID]);
-    if (enabled.error) throw new Error(`Could not run Herdr: ${enabled.error.message}`);
-    if (enabled.status !== 0) {
-      throw new Error(
-        `Could not enable the Herdr plugin: ${bounded(enabled.stderr || enabled.stdout)}`,
-      );
-    }
-    return { changed: true, message: `Enabled Herdr plugin ${HERDR_PLUGIN_ID}.` };
-  }
-
-  const linked = spawn("herdr", ["plugin", "link", root]);
-  if (linked.error) throw new Error(`Could not run Herdr: ${linked.error.message}`);
-  if (linked.status !== 0) {
-    throw new Error(`Could not link the Herdr plugin: ${bounded(linked.stderr || linked.stdout)}`);
-  }
-  return { changed: true, message: `Linked Herdr plugin ${HERDR_PLUGIN_ID} from ${root}.` };
+  return { available: true, plugin: installedPlugin(listed.stdout) };
 }
 
-function installedPlugin(stdout: string): { root: string; enabled: boolean } | undefined {
+function installedPlugin(stdout: string): InstalledPlugin | undefined {
   let value: unknown;
   try {
     value = JSON.parse(stdout) as unknown;
   } catch {
     throw new Error("Herdr returned invalid plugin JSON.");
   }
-  if (!isRecord(value) || !isRecord(value.result) || !Array.isArray(value.result.plugins)) {
+  if (
+    !isRecord(value) ||
+    !isRecord(value["result"]) ||
+    !Array.isArray(value["result"]["plugins"])
+  ) {
     throw new Error("Herdr returned an invalid plugin list.");
   }
-  for (const plugin of value.result.plugins) {
-    if (
-      isRecord(plugin) &&
-      plugin.plugin_id === HERDR_PLUGIN_ID &&
-      typeof plugin.plugin_root === "string" &&
-      typeof plugin.enabled === "boolean"
-    ) {
-      return { root: plugin.plugin_root, enabled: plugin.enabled };
-    }
+  const candidates = value["result"]["plugins"].filter(
+    (plugin) => isRecord(plugin) && plugin["plugin_id"] === HERDR_PLUGIN_ID,
+  );
+  if (candidates.length > 1) {
+    throw new Error(`Herdr returned duplicate records for ${HERDR_PLUGIN_ID}.`);
   }
-  return undefined;
+  const candidate = candidates[0];
+  if (candidate === undefined) return undefined;
+  if (
+    !isRecord(candidate) ||
+    typeof candidate["plugin_root"] !== "string" ||
+    typeof candidate["manifest_path"] !== "string" ||
+    typeof candidate["version"] !== "string" ||
+    typeof candidate["enabled"] !== "boolean"
+  ) {
+    throw new Error(`Herdr returned an incomplete record for ${HERDR_PLUGIN_ID}.`);
+  }
+  return {
+    root: normalizedPath(candidate["plugin_root"]),
+    manifestPath: normalizedPath(candidate["manifest_path"]),
+    version: candidate["version"],
+    enabled: candidate["enabled"],
+    warnings: pluginWarnings(candidate),
+  };
+}
+
+function pluginWarnings(plugin: Record<string, unknown>): string[] {
+  const warnings: string[] = [];
+  for (const key of ["warning", "manifest_warning"] as const) {
+    const value = plugin[key];
+    if (typeof value === "string" && value.trim().length > 0) warnings.push(value.trim());
+  }
+  const many = plugin["warnings"];
+  if (many !== undefined) {
+    if (!Array.isArray(many) || many.some((item) => typeof item !== "string")) {
+      throw new Error(`Herdr returned invalid warnings for ${HERDR_PLUGIN_ID}.`);
+    }
+    warnings.push(...many.filter((item) => item.trim().length > 0).map((item) => item.trim()));
+  }
+  return warnings;
+}
+
+function matchesExpected(
+  installed: InstalledPlugin,
+  expected: PluginPackage,
+  requireEnabled: boolean,
+): boolean {
+  return (
+    installed.root === normalizedPath(expected.root) &&
+    installed.manifestPath === normalizedPath(expected.manifestPath) &&
+    installed.version === expected.version &&
+    (!requireEnabled || installed.enabled) &&
+    installed.warnings.length === 0
+  );
+}
+
+function rollbackTarget(installed: InstalledPlugin): RollbackTarget | undefined {
+  try {
+    const previous = preflightPackage(installed.root);
+    return matchesExpected(installed, previous, installed.enabled)
+      ? { package: previous, enabled: installed.enabled }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function restorePrevious(
+  spawn: Spawn,
+  expected: PluginPackage,
+  previous: RollbackTarget | undefined,
+): string {
+  if (previous === undefined) return "The previous registration could not be restored.";
+  try {
+    const current = inspectHerdr(spawn, false);
+    if (!current.available)
+      return "Herdr became unavailable; the previous registration was not restored.";
+    if (current.plugin !== undefined) {
+      if (!matchesExpected(current.plugin, expected, current.plugin.enabled)) {
+        return "A different registration appeared; the previous registration was not restored.";
+      }
+      const removed = mutate(spawn, "unlink", [HERDR_PLUGIN_ID]);
+      if (!removed.ok) return `The previous registration was not restored: ${removed.error}`;
+    }
+    const args = previous.enabled ? [previous.package.root] : [previous.package.root, "--disabled"];
+    const restored = mutate(spawn, "link", args);
+    if (!restored.ok) return `The previous registration was not restored: ${restored.error}`;
+    const verified = inspectHerdr(spawn, false);
+    if (
+      verified.available &&
+      verified.plugin !== undefined &&
+      matchesExpected(verified.plugin, previous.package, previous.enabled) &&
+      verified.plugin.enabled === previous.enabled
+    ) {
+      return "The previous registration was restored.";
+    }
+    return "Herdr did not verify the restored registration.";
+  } catch (error) {
+    return `The previous registration was not restored: ${bounded(errorMessage(error))}`;
+  }
+}
+
+function verifyOrExplain(
+  spawn: Spawn,
+  expected: PluginPackage,
+): { plugin?: InstalledPlugin; problem: string } {
+  try {
+    const inspected = inspectHerdr(spawn, false);
+    if (!inspected.available) return { problem: "Herdr became unavailable." };
+    if (inspected.plugin === undefined) return { problem: "Herdr reports no plugin registration." };
+    if (matchesExpected(inspected.plugin, expected, true)) {
+      return { plugin: inspected.plugin, problem: "" };
+    }
+    return {
+      plugin: inspected.plugin,
+      problem: "Herdr did not report the expected healthy registration.",
+    };
+  } catch (error) {
+    return { problem: errorMessage(error) };
+  }
+}
+
+function mutate(spawn: Spawn, action: string, args: readonly string[]): MutationResult {
+  const changed = spawn("herdr", ["plugin", action, ...args]);
+  if (changed.error !== undefined) return { ok: false, error: changed.error.message };
+  if (changed.status !== 0) {
+    return { ok: false, error: bounded(changed.stderr || changed.stdout) };
+  }
+  return { ok: true };
+}
+
+function mutationError(action: string, mutation: MutationResult, verification: string): Error {
+  const command = mutation.ok ? "The command completed" : `The command failed: ${mutation.error}`;
+  return new Error(`Could not ${action} the Herdr plugin. ${command}. ${verification}`);
+}
+
+function result(
+  status: HerdrSyncStatus,
+  changed: boolean,
+  expectedVersion: string,
+  effective: InstalledPlugin | undefined,
+): HerdrSyncResult {
+  const messages: Record<HerdrSyncStatus, string> = {
+    linked: `Linked Herdr plugin ${HERDR_PLUGIN_ID}.`,
+    relinked: `Repaired Herdr plugin ${HERDR_PLUGIN_ID}.`,
+    enabled: `Enabled Herdr plugin ${HERDR_PLUGIN_ID}.`,
+    unchanged: `Herdr plugin ${HERDR_PLUGIN_ID} is current.`,
+    unavailable: "Herdr is not installed; plugin synchronization was skipped.",
+  };
+  return {
+    schema: RESULT_SCHEMA,
+    status,
+    changed,
+    pluginId: HERDR_PLUGIN_ID,
+    expectedVersion,
+    effectiveVersion: effective?.version ?? null,
+    enabled: effective?.enabled ?? null,
+    runningPiProcessesNeedReload: true,
+    message: messages[status],
+  };
 }
 
 function runCommand(command: string, args: readonly string[]): SpawnSyncReturns<string> {
   return spawnSync(command, [...args], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: MAX_COMMAND_OUTPUT_BYTES,
+    shell: false,
   });
+}
+
+function errorCode(error: Error): string | undefined {
+  const value = error as Error & { code?: unknown };
+  return typeof value.code === "string" ? value.code : undefined;
+}
+
+function normalizedPath(value: string): string {
+  const resolved = path.resolve(value);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
 }
 
 function bounded(value: string): string {
@@ -86,6 +472,10 @@ function bounded(value: string): string {
     .replace(/ +/gu, " ")
     .trim();
   return compact.length <= 300 ? compact : `${compact.slice(0, 299)}…`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { SqliteControllerStore } from "../controllers/sqlite.js";
 import { projectControllerStoreBaseDir } from "../controllers/store.js";
-import { setupHerdrPlugin } from "../herdr/setup.js";
+import { syncHerdrPlugin } from "../herdr/setup.js";
 import { sanitizeText } from "../render/ansi.js";
 import { listRunBundles, readRunBundle, workflowRunsBaseDir } from "../workflows/store.js";
 import {
@@ -24,7 +24,8 @@ Usage:
   pi-workflows controllers [--controller-dir <dir>]
   pi-workflows controller <controller> <key> [--controller-dir <dir>]
   pi-workflows host [--project <dir>] [-- <extra pi args>]
-  pi-workflows herdr setup
+  pi-workflows herdr sync [--json]
+  pi-workflows herdr setup [--json]
 
 Commands:
   view          Open the live workflow TUI. With --once, print a snapshot.
@@ -32,13 +33,14 @@ Commands:
   controllers   List durable controller resources.
   controller    Show one resource, its effects, child workflows, and events.
   host          Run the always-on workflow host in the foreground.
-  herdr         Set up the bundled Herdr plugin.
+  herdr         Synchronize the bundled Herdr plugin. setup is an alias for sync.
 
 Options:
   --dir <runsDir>          Runs directory (default: ~/.pi/agent/workflows/runs)
   --controller-dir <dir>  Controller directory (default: project-scoped local store)
   --once                   Render once without the interactive TUI
   --project <dir>          Project directory for the host (default: cwd)
+  --json                   Print a versioned JSON result for herdr sync
 `;
 
 export type CliArgs = {
@@ -50,6 +52,7 @@ export type CliArgs = {
   dir: string;
   controllerDir: string;
   once: boolean;
+  json: boolean;
   project?: string | undefined;
   piArgs?: string[] | undefined;
 };
@@ -60,6 +63,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
   let dir = workflowRunsBaseDir();
   let controllerDir = projectControllerStoreBaseDir(process.cwd());
   let once = false;
+  let json = false;
   const positionals: string[] = [];
   let project: string | undefined;
   const piArgs: string[] = [];
@@ -74,8 +78,10 @@ export function parseCliArgs(argv: string[]): CliArgs {
       project = requiredValue(args, "--project");
     } else if (arg === "--once") {
       once = true;
+    } else if (arg === "--json") {
+      json = true;
     } else if (arg === "--help" || arg === "-h") {
-      return { command: "help", dir, controllerDir, once };
+      return { command: "help", dir, controllerDir, once, json };
     } else if (arg === "--") {
       piArgs.push(...args.splice(0));
     } else if (arg.startsWith("-")) {
@@ -85,8 +91,12 @@ export function parseCliArgs(argv: string[]): CliArgs {
     }
   }
 
+  if (command !== "herdr" && json) {
+    throw new Error("--json is available only for herdr sync");
+  }
+
   if (command === "host") {
-    return { command, dir, controllerDir, once, project, piArgs };
+    return { command, dir, controllerDir, once, json, project, piArgs };
   }
 
   if (command === "controller") {
@@ -100,13 +110,14 @@ export function parseCliArgs(argv: string[]): CliArgs {
       dir,
       controllerDir,
       once,
+      json,
     };
   }
   if (command === "herdr") {
-    if (positionals.length !== 1 || positionals[0] !== "setup") {
-      throw new Error("herdr requires the setup action");
+    if (positionals.length !== 1 || (positionals[0] !== "sync" && positionals[0] !== "setup")) {
+      throw new Error("herdr requires the sync action");
     }
-    return { command, herdrAction: positionals[0], dir, controllerDir, once };
+    return { command, herdrAction: positionals[0], dir, controllerDir, once, json };
   }
   if (positionals.length > 1) {
     throw new Error(`Unexpected argument: ${positionals[1]}`);
@@ -117,6 +128,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
     dir,
     controllerDir,
     once,
+    json,
   };
 }
 
@@ -240,8 +252,8 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
       return await runHost(args.project ?? process.cwd(), args.piArgs);
     }
     if (args.command === "herdr") {
-      const result = setupHerdrPlugin(packageRoot());
-      process.stdout.write(`${result.message}\n`);
+      const result = syncHerdrPlugin(packageRoot());
+      process.stdout.write(args.json ? `${JSON.stringify(result)}\n` : `${result.message}\n`);
       return 0;
     }
     if (args.command === "view") {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SqliteControllerStore } from "../src/controllers/sqlite.js";
@@ -36,6 +37,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("parseCliArgs", () => {
@@ -73,9 +75,15 @@ describe("parseCliArgs", () => {
       controllerDir: "/tmp/controllers",
     });
     expect(parseCliArgs(["--help"]).command).toBe("help");
+    expect(parseCliArgs(["herdr", "sync", "--json"])).toMatchObject({
+      command: "herdr",
+      herdrAction: "sync",
+      json: true,
+    });
     expect(parseCliArgs(["herdr", "setup"])).toMatchObject({
       command: "herdr",
       herdrAction: "setup",
+      json: false,
     });
   });
 
@@ -182,6 +190,31 @@ describe("pi-workflows CLI", () => {
     expect(stdout).toContain('"type": "created"');
   });
 
+  it("prints the versioned Herdr sync result as JSON", async () => {
+    const temp = await makeTempDir("pi-workflows-cli-herdr");
+    const bin = path.join(temp, "bin");
+    await fs.mkdir(bin);
+    const root = path.resolve(import.meta.dirname, "..");
+    const herdr = path.join(bin, "herdr");
+    await fs.writeFile(
+      herdr,
+      `#!/usr/bin/env node\nconst path = require("node:path");\nconst root = process.env.TEST_HERDR_ROOT;\nprocess.stdout.write(JSON.stringify({ result: { plugins: [{ plugin_id: "osolmaz.pi-workflows", plugin_root: root, manifest_path: path.join(root, "herdr-plugin.toml"), version: "0.11.0", enabled: true }] } }));\n`,
+    );
+    await fs.chmod(herdr, 0o755);
+    vi.stubEnv("TEST_HERDR_ROOT", root);
+    vi.stubEnv("PATH", `${bin}:${process.env["PATH"] ?? ""}`);
+
+    expect(await main(["herdr", "sync", "--json"])).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      schema: "pi-workflows.herdr-sync.v1",
+      status: "unchanged",
+      changed: false,
+      expectedVersion: "0.11.0",
+      effectiveVersion: "0.11.0",
+      enabled: true,
+    });
+  });
+
   it("reports missing and empty controller stores", async () => {
     const controllerDir = await makeTempDir("pi-workflows-cli-controllers");
     expect(await main(["controllers", "--controller-dir", controllerDir])).toBe(0);
@@ -210,7 +243,11 @@ describe("pi-workflows CLI", () => {
 
     stderr = "";
     expect(await main(["herdr", "wrong"])).toBe(2);
-    expect(stderr).toContain("herdr requires the setup action");
+    expect(stderr).toContain("herdr requires the sync action");
+
+    stderr = "";
+    expect(await main(["runs", "--json"])).toBe(2);
+    expect(stderr).toContain("--json is available only for herdr sync");
 
     stderr = "";
     expect(await main(["frobnicate"])).toBe(2);

--- a/test/e2e/herdr-package.e2e.test.ts
+++ b/test/e2e/herdr-package.e2e.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeTempDir } from "../helpers.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+describe("packed Herdr plugin synchronization", () => {
+  it("runs from packed hoisted and nested package layouts with spaces", async () => {
+    const temp = await makeTempDir("pi-workflows-packed-herdr");
+    const packs = path.join(temp, "packs");
+    const bin = path.join(temp, "fake bin");
+    await fs.mkdir(packs);
+    await fs.mkdir(bin);
+
+    const sourceManifest = JSON.parse(
+      await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),
+    ) as { version: string };
+    const archiveName = execFileSync("npm", ["pack", "--silent", "--pack-destination", packs], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+    const archive = path.join(packs, archiveName.split("\n").at(-1) as string);
+    const herdr = path.join(bin, "herdr");
+    await fs.writeFile(
+      herdr,
+      `#!/usr/bin/env node\nconst path = require("node:path");\nconst root = process.env.TEST_PLUGIN_ROOT;\nconst pkg = require(path.join(root, "package.json"));\nprocess.stdout.write(JSON.stringify({ result: { plugins: [{ plugin_id: "osolmaz.pi-workflows", plugin_root: root, manifest_path: path.join(root, "herdr-plugin.toml"), version: pkg.version, enabled: true }] } }));\n`,
+    );
+    await fs.chmod(herdr, 0o755);
+
+    const packageRoots = [
+      path.join(temp, "hoisted install with spaces", "node_modules", "@osolmaz", "pi-workflows"),
+      path.join(
+        temp,
+        "workspace with spaces",
+        "packages",
+        "wrapper",
+        "node_modules",
+        "@osolmaz",
+        "pi-workflows",
+      ),
+    ];
+
+    for (const [index, packageRoot] of packageRoots.entries()) {
+      const extract = path.join(temp, `extract-${index}`);
+      await fs.mkdir(extract);
+      execFileSync("tar", ["-xzf", archive, "-C", extract]);
+      await fs.mkdir(path.dirname(packageRoot), { recursive: true });
+      await fs.rename(path.join(extract, "package"), packageRoot);
+      await fs.symlink(path.join(repoRoot, "node_modules"), path.join(packageRoot, "node_modules"));
+
+      const result = spawnSync(
+        process.execPath,
+        [path.join(packageRoot, "dist", "viewer", "cli.js"), "herdr", "sync", "--json"],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${bin}:${process.env["PATH"] ?? ""}`,
+            TEST_PLUGIN_ROOT: packageRoot,
+          },
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        schema: "pi-workflows.herdr-sync.v1",
+        status: "unchanged",
+        changed: false,
+        expectedVersion: sourceManifest.version,
+        effectiveVersion: sourceManifest.version,
+        enabled: true,
+      });
+      await expect(fs.stat(path.join(packageRoot, "herdr-plugin.toml"))).resolves.toBeDefined();
+      await expect(
+        fs.stat(path.join(packageRoot, "plugins", "herdr", "viewer.mjs")),
+      ).resolves.toBeDefined();
+    }
+  });
+});

--- a/test/herdr-setup.test.ts
+++ b/test/herdr-setup.test.ts
@@ -1,9 +1,10 @@
 import type { SpawnSyncReturns } from "node:child_process";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { HERDR_PLUGIN_ID } from "../src/herdr/constants.js";
-import { setupHerdrPlugin } from "../src/herdr/setup.js";
+import { setupHerdrPlugin, syncHerdrPlugin } from "../src/herdr/setup.js";
 import { makeTempDir } from "./helpers.js";
 
 function reply(
@@ -21,202 +22,317 @@ function reply(
   };
 }
 
-describe("setupHerdrPlugin", () => {
-  it("links the current package root when the plugin is absent", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
-    const calls: { command: string; args: readonly string[] }[] = [];
-    const result = setupHerdrPlugin(root, (command, args) => {
-      calls.push({ command, args });
-      return args.includes("list") ? reply(JSON.stringify({ result: { plugins: [] } })) : reply();
-    });
+type PluginRecord = {
+  plugin_id: string;
+  plugin_root: string;
+  manifest_path: string;
+  version: string;
+  enabled: boolean;
+  warnings?: string[];
+};
 
-    expect(result).toEqual({
+async function makePackage(label = "pi-workflows-herdr-sync", version = "0.11.0"): Promise<string> {
+  const root = await makeTempDir(label);
+  await fs.mkdir(path.join(root, "plugins", "herdr"), { recursive: true });
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify({ name: "@osolmaz/pi-workflows", version }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(root, "herdr-plugin.toml"),
+    [
+      `id = "${HERDR_PLUGIN_ID}"`,
+      'name = "Pi Workflows"',
+      `version = "${version}"`,
+      'min_herdr_version = "0.7.0"',
+      'platforms = ["linux", "macos"]',
+      "",
+      "[[panes]]",
+      'id = "piw"',
+      'command = ["node", "plugins/herdr/viewer.mjs"]',
+      "",
+    ].join("\n"),
+  );
+  await fs.writeFile(path.join(root, "plugins", "herdr", "viewer.mjs"), "export {};\n");
+  return fs.realpath(root);
+}
+
+function record(root: string, enabled = true, overrides: Partial<PluginRecord> = {}): PluginRecord {
+  const manifest = JSON.parse(fsSync.readFileSync(path.join(root, "package.json"), "utf8")) as {
+    version: string;
+  };
+  return {
+    plugin_id: HERDR_PLUGIN_ID,
+    plugin_root: root,
+    manifest_path: path.join(root, "herdr-plugin.toml"),
+    version: manifest.version,
+    enabled,
+    ...overrides,
+  };
+}
+
+class FakeHerdr {
+  plugin: PluginRecord | undefined;
+  readonly calls: { command: string; args: readonly string[] }[] = [];
+  failAction: string | undefined;
+  failLinkRoot: string | undefined;
+  malformedList: string | undefined;
+  listError: Error | undefined;
+
+  constructor(plugin?: PluginRecord) {
+    this.plugin = plugin;
+  }
+
+  readonly spawn = (command: string, args: readonly string[]): SpawnSyncReturns<string> => {
+    this.calls.push({ command, args });
+    if (args[1] === "list") {
+      if (this.listError !== undefined) return reply("", { error: this.listError });
+      if (this.malformedList !== undefined) return reply(this.malformedList);
+      return reply(
+        JSON.stringify({ result: { plugins: this.plugin === undefined ? [] : [this.plugin] } }),
+      );
+    }
+    const action = args[1];
+    if (action === this.failAction) return reply("", { status: 1, stderr: `${action} refused` });
+    if (action === "link") {
+      const root = args[2];
+      if (root === undefined) return reply("", { status: 2, stderr: "missing root" });
+      if (root === this.failLinkRoot) return reply("", { status: 1, stderr: "link refused" });
+      this.plugin = record(root, !args.includes("--disabled"));
+      return reply();
+    }
+    if (action === "unlink") {
+      this.plugin = undefined;
+      return reply();
+    }
+    if (action === "enable") {
+      if (this.plugin !== undefined) this.plugin = { ...this.plugin, enabled: true };
+      return reply();
+    }
+    return reply("", { status: 2, stderr: `unexpected action ${String(action)}` });
+  };
+}
+
+describe("syncHerdrPlugin", () => {
+  it("links an absent plugin and verifies it", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr();
+
+    const result = syncHerdrPlugin(root, herdr.spawn);
+
+    expect(result).toMatchObject({
+      schema: "pi-workflows.herdr-sync.v1",
+      status: "linked",
       changed: true,
-      message: `Linked Herdr plugin ${HERDR_PLUGIN_ID} from ${root}.`,
+      pluginId: HERDR_PLUGIN_ID,
+      expectedVersion: "0.11.0",
+      effectiveVersion: "0.11.0",
+      enabled: true,
+      runningPiProcessesNeedReload: true,
     });
-    expect(calls).toEqual([
-      {
-        command: "herdr",
-        args: ["plugin", "list", "--plugin", HERDR_PLUGIN_ID, "--json"],
-      },
-      { command: "herdr", args: ["plugin", "link", root] },
+    expect(herdr.calls.map((call) => call.args[1])).toEqual(["list", "link", "list"]);
+  });
+
+  it("leaves an exact healthy registration unchanged", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr(record(root));
+
+    expect(syncHerdrPlugin(root, herdr.spawn)).toMatchObject({
+      status: "unchanged",
+      changed: false,
+    });
+    expect(herdr.calls).toHaveLength(1);
+  });
+
+  it("enables and verifies a disabled registration", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr(record(root, false));
+
+    expect(syncHerdrPlugin(root, herdr.spawn)).toMatchObject({ status: "enabled", changed: true });
+    expect(herdr.calls.map((call) => call.args[1])).toEqual(["list", "enable", "list"]);
+  });
+
+  it("repairs a registration after the package moves or changes version", async () => {
+    const oldRoot = await makePackage("pi-workflows-old", "0.10.0");
+    const currentRoot = await makePackage("pi-workflows current path with spaces", "0.11.0");
+    const herdr = new FakeHerdr(record(oldRoot));
+
+    expect(syncHerdrPlugin(currentRoot, herdr.spawn)).toMatchObject({
+      status: "relinked",
+      effectiveVersion: "0.11.0",
+    });
+    expect(herdr.plugin).toEqual(record(currentRoot));
+    expect(herdr.calls.map((call) => call.args[1])).toEqual([
+      "list",
+      "unlink",
+      "list",
+      "link",
+      "list",
     ]);
+    expect(herdr.calls.find((call) => call.args[1] === "link")?.args[2]).toBe(currentRoot);
   });
 
-  it("is idempotent for the same linked package root", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
-    const result = setupHerdrPlugin(root, () =>
-      reply(
-        JSON.stringify({
-          result: {
-            plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: true }],
-          },
-        }),
-      ),
+  it("repairs a link whose old root no longer exists", async () => {
+    const oldRoot = await makePackage("pi-workflows-stale", "0.10.0");
+    const oldRecord = record(oldRoot);
+    await fs.rm(oldRoot, { recursive: true, force: true });
+    const currentRoot = await makePackage("pi-workflows-current", "0.11.0");
+    const herdr = new FakeHerdr(oldRecord);
+
+    expect(syncHerdrPlugin(currentRoot, herdr.spawn).status).toBe("relinked");
+    expect(herdr.plugin).toEqual(record(currentRoot));
+  });
+
+  it("adopts a concurrent process that reached the target state", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr();
+    herdr.failAction = "link";
+    const original = herdr.spawn;
+    let linked = false;
+    const spawn = (command: string, args: readonly string[]): SpawnSyncReturns<string> => {
+      const response = original(command, args);
+      if (args[1] === "link" && !linked) {
+        linked = true;
+        herdr.plugin = record(root);
+      }
+      return response;
+    };
+
+    expect(syncHerdrPlugin(root, spawn)).toMatchObject({ status: "linked", changed: true });
+  });
+
+  it("restores one valid previous registration after replacement fails", async () => {
+    const oldRoot = await makePackage("pi-workflows-old", "0.10.0");
+    const currentRoot = await makePackage("pi-workflows-current", "0.11.0");
+    const herdr = new FakeHerdr(record(oldRoot, false));
+    herdr.failLinkRoot = currentRoot;
+
+    expect(() => syncHerdrPlugin(currentRoot, herdr.spawn)).toThrow(
+      /previous registration was restored/u,
     );
-
-    expect(result.changed).toBe(false);
-    expect(result.message).toContain("already linked");
+    expect(herdr.plugin).toEqual(record(oldRoot, false));
+    const restore = herdr.calls.filter((call) => call.args[1] === "link").at(-1);
+    expect(restore?.args).toEqual(["plugin", "link", oldRoot, "--disabled"]);
   });
 
-  it("enables a disabled plugin from the same package root", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
-    const calls: { command: string; args: readonly string[] }[] = [];
-    const result = setupHerdrPlugin(root, (command, args) => {
-      calls.push({ command, args });
-      return args.includes("list")
-        ? reply(
-            JSON.stringify({
-              result: {
-                plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
-              },
-            }),
-          )
-        : reply();
-    });
+  it("does not claim rollback when the previous package is invalid", async () => {
+    const oldRoot = await makePackage("pi-workflows-old", "0.10.0");
+    const oldRecord = record(oldRoot);
+    await fs.rm(oldRoot, { recursive: true, force: true });
+    const currentRoot = await makePackage("pi-workflows-current", "0.11.0");
+    const herdr = new FakeHerdr(oldRecord);
+    herdr.failLinkRoot = currentRoot;
 
-    expect(result).toEqual({
-      changed: true,
-      message: `Enabled Herdr plugin ${HERDR_PLUGIN_ID}.`,
-    });
-    expect(calls.at(-1)).toEqual({
-      command: "herdr",
-      args: ["plugin", "enable", HERDR_PLUGIN_ID],
-    });
+    expect(() => syncHerdrPlugin(currentRoot, herdr.spawn)).toThrow(
+      /previous registration could not be restored/u,
+    );
+    expect(herdr.plugin).toBeUndefined();
   });
 
-  it("refuses to replace a plugin registered from another root", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+  it("returns unavailable only when the Herdr executable is absent", async () => {
+    const root = await makePackage();
+    const missing = Object.assign(new Error("spawn herdr ENOENT"), { code: "ENOENT" });
+    const result = syncHerdrPlugin(root, () => reply("", { error: missing }));
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      changed: false,
+      effectiveVersion: null,
+      enabled: null,
+    });
+
+    const denied = Object.assign(new Error("spawn herdr EACCES"), { code: "EACCES" });
+    expect(() => syncHerdrPlugin(root, () => reply("", { error: denied }))).toThrow(
+      "Could not run Herdr: spawn herdr EACCES",
+    );
+  });
+
+  it("rejects malformed or ambiguous Herdr records", async () => {
+    const root = await makePackage();
+    const malformed = new FakeHerdr();
+    malformed.malformedList = "{";
+    expect(() => syncHerdrPlugin(root, malformed.spawn)).toThrow("invalid plugin JSON");
+
+    const incomplete = new FakeHerdr({
+      ...record(root),
+      manifest_path: undefined,
+    } as unknown as PluginRecord);
+    expect(() => syncHerdrPlugin(root, incomplete.spawn)).toThrow("incomplete record");
 
     expect(() =>
-      setupHerdrPlugin(root, () =>
+      syncHerdrPlugin(root, () =>
         reply(
           JSON.stringify({
-            result: {
-              plugins: [
-                {
-                  plugin_id: HERDR_PLUGIN_ID,
-                  plugin_root: "/other/pi-workflows",
-                  enabled: true,
-                },
-              ],
-            },
+            result: { plugins: [record(root), record(root)] },
           }),
         ),
       ),
-    ).toThrow("Unlink it before linking");
+    ).toThrow("duplicate records");
   });
 
-  it("reports Herdr inspection and registration failures", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
+  it("rejects warnings and failed final verification", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr(record(root, true, { warnings: ["manifest unavailable"] }));
+    herdr.failAction = "unlink";
 
+    expect(() => syncHerdrPlugin(root, herdr.spawn)).toThrow(/conflicting registration/u);
+  });
+
+  it("bounds command failure output", async () => {
+    const root = await makePackage();
     expect(() =>
-      setupHerdrPlugin(root, () => reply("", { error: new Error("missing Herdr") })),
-    ).toThrow("Could not run Herdr: missing Herdr");
-    expect(() =>
-      setupHerdrPlugin(root, () => reply("", { status: 1, stderr: "socket unavailable" })),
-    ).toThrow("Could not inspect Herdr plugins: socket unavailable");
-    expect(() => setupHerdrPlugin(root, () => reply("not json"))).toThrow("invalid plugin JSON");
-    expect(() => setupHerdrPlugin(root, () => reply(JSON.stringify({ result: {} })))).toThrow(
-      "invalid plugin list",
+      syncHerdrPlugin(root, () => reply("", { status: 1, stderr: "x".repeat(400) })),
+    ).toThrow(/Could not inspect Herdr plugins: x+…/u);
+  });
+
+  it("validates the bundled package before running Herdr", async () => {
+    const root = await makePackage();
+    let calls = 0;
+    await fs.writeFile(
+      path.join(root, "herdr-plugin.toml"),
+      [
+        `id = "${HERDR_PLUGIN_ID}"`,
+        'version = "9.9.9"',
+        'min_herdr_version = "0.7.0"',
+        'platforms = ["linux", "macos"]',
+        'command = ["node", "plugins/herdr/viewer.mjs"]',
+      ].join("\n"),
     );
 
-    const listEmpty = JSON.stringify({ result: { plugins: [] } });
-    let calls = 0;
     expect(() =>
-      setupHerdrPlugin(root, () => {
+      syncHerdrPlugin(root, () => {
         calls += 1;
-        return calls === 1 ? reply(listEmpty) : reply("", { status: 1, stderr: "link refused" });
+        return reply();
       }),
-    ).toThrow("Could not link the Herdr plugin: link refused");
-
-    calls = 0;
-    expect(() =>
-      setupHerdrPlugin(root, () => {
-        calls += 1;
-        return calls === 1
-          ? reply(listEmpty)
-          : reply("", { error: new Error("link executable failed") });
-      }),
-    ).toThrow("Could not run Herdr: link executable failed");
-
-    calls = 0;
-    expect(() =>
-      setupHerdrPlugin(root, () => {
-        calls += 1;
-        return calls === 1 ? reply(listEmpty) : reply("", { status: 1, stderr: "x".repeat(400) });
-      }),
-    ).toThrow(/Could not link the Herdr plugin: x+…/u);
+    ).toThrow("plugin version does not match");
+    expect(calls).toBe(0);
   });
 
-  it("reports failures while enabling a linked plugin", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
-    let calls = 0;
+  it("rejects duplicate manifest fields and viewer symlinks", async () => {
+    const root = await makePackage();
+    const manifestPath = path.join(root, "herdr-plugin.toml");
+    const manifest = await fs.readFile(manifestPath, "utf8");
+    await fs.writeFile(
+      manifestPath,
+      manifest.replace(
+        `id = "${HERDR_PLUGIN_ID}"`,
+        `id = "${HERDR_PLUGIN_ID}"\nid = "${HERDR_PLUGIN_ID}"`,
+      ),
+    );
+    expect(() => syncHerdrPlugin(root, () => reply())).toThrow("must contain one id string");
 
-    expect(() =>
-      setupHerdrPlugin(root, () => {
-        calls += 1;
-        return calls === 1
-          ? reply(
-              JSON.stringify({
-                result: {
-                  plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
-                },
-              }),
-            )
-          : reply("", { status: 1, stderr: "enable refused" });
-      }),
-    ).toThrow("Could not enable the Herdr plugin: enable refused");
-
-    calls = 0;
-    expect(() =>
-      setupHerdrPlugin(root, () => {
-        calls += 1;
-        return calls === 1
-          ? reply(
-              JSON.stringify({
-                result: {
-                  plugins: [{ plugin_id: HERDR_PLUGIN_ID, plugin_root: root, enabled: false }],
-                },
-              }),
-            )
-          : reply("", { error: new Error("enable executable failed") });
-      }),
-    ).toThrow("Could not run Herdr: enable executable failed");
+    const linkedRoot = await makePackage("pi-workflows-viewer-link");
+    const viewer = path.join(linkedRoot, "plugins", "herdr", "viewer.mjs");
+    await fs.rm(viewer);
+    await fs.symlink(path.join(linkedRoot, "package.json"), viewer);
+    expect(() => syncHerdrPlugin(linkedRoot, () => reply())).toThrow(
+      "Package file is not a regular file",
+    );
   });
 
-  it("ignores incomplete plugin records and links the complete package", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    await fs.writeFile(path.join(root, "herdr-plugin.toml"), `id = "${HERDR_PLUGIN_ID}"\n`);
-    let calls = 0;
-    const result = setupHerdrPlugin(root, () => {
-      calls += 1;
-      return calls === 1
-        ? reply(
-            JSON.stringify({
-              result: {
-                plugins: [
-                  null,
-                  { plugin_id: HERDR_PLUGIN_ID, plugin_root: root },
-                  { plugin_id: "other.plugin", plugin_root: root, enabled: true },
-                ],
-              },
-            }),
-          )
-        : reply();
-    });
-
-    expect(result.changed).toBe(true);
-  });
-
-  it("fails before calling Herdr when the package has no manifest", async () => {
-    const root = await makeTempDir("pi-workflows-herdr-setup");
-    expect(() => setupHerdrPlugin(root, () => reply())).toThrow("manifest not found");
+  it("keeps setupHerdrPlugin as the same compatibility behavior", async () => {
+    const root = await makePackage();
+    const herdr = new FakeHerdr(record(root));
+    expect(setupHerdrPlugin(root, herdr.spawn).status).toBe("unchanged");
   });
 });

--- a/test/herdr-setup.test.ts
+++ b/test/herdr-setup.test.ts
@@ -247,11 +247,28 @@ describe("syncHerdrPlugin", () => {
     );
   });
 
+  it("reports link and enable failures when the target state was not reached", async () => {
+    const root = await makePackage();
+    const linkFailure = new FakeHerdr();
+    linkFailure.failAction = "link";
+    expect(() => syncHerdrPlugin(root, linkFailure.spawn)).toThrow("command failed: link refused");
+
+    const enableFailure = new FakeHerdr(record(root, false));
+    enableFailure.failAction = "enable";
+    expect(() => syncHerdrPlugin(root, enableFailure.spawn)).toThrow(
+      "command failed: enable refused",
+    );
+  });
+
   it("rejects malformed or ambiguous Herdr records", async () => {
     const root = await makePackage();
     const malformed = new FakeHerdr();
     malformed.malformedList = "{";
     expect(() => syncHerdrPlugin(root, malformed.spawn)).toThrow("invalid plugin JSON");
+
+    const invalidShape = new FakeHerdr();
+    invalidShape.malformedList = "{}";
+    expect(() => syncHerdrPlugin(root, invalidShape.spawn)).toThrow("invalid plugin list");
 
     const incomplete = new FakeHerdr({
       ...record(root),
@@ -268,6 +285,12 @@ describe("syncHerdrPlugin", () => {
         ),
       ),
     ).toThrow("duplicate records");
+
+    const invalidWarnings = new FakeHerdr({
+      ...record(root),
+      warnings: 1,
+    } as unknown as PluginRecord);
+    expect(() => syncHerdrPlugin(root, invalidWarnings.spawn)).toThrow("invalid warnings");
   });
 
   it("rejects warnings and failed final verification", async () => {
@@ -283,6 +306,90 @@ describe("syncHerdrPlugin", () => {
     expect(() =>
       syncHerdrPlugin(root, () => reply("", { status: 1, stderr: "x".repeat(400) })),
     ).toThrow(/Could not inspect Herdr plugins: x+…/u);
+  });
+
+  it("rejects missing and non-directory package roots", async () => {
+    const temp = await makeTempDir("pi-workflows-invalid-root");
+    expect(() => syncHerdrPlugin(path.join(temp, "missing"), () => reply())).toThrow(
+      "package root is missing",
+    );
+    const file = path.join(temp, "file");
+    await fs.writeFile(file, "not a package\n");
+    expect(() => syncHerdrPlugin(file, () => reply())).toThrow("package root is not a directory");
+  });
+
+  it("rejects malformed package metadata", async () => {
+    const invalidJson = await makePackage("pi-workflows-invalid-json");
+    await fs.writeFile(path.join(invalidJson, "package.json"), "{\n");
+    expect(() => syncHerdrPlugin(invalidJson, () => reply())).toThrow("not valid JSON");
+
+    const invalidShape = await makePackage("pi-workflows-invalid-package-shape");
+    await fs.writeFile(path.join(invalidShape, "package.json"), "[]\n");
+    expect(() => syncHerdrPlugin(invalidShape, () => reply())).toThrow(
+      "must contain a JSON object",
+    );
+  });
+
+  it("rejects invalid package identity and missing versions", async () => {
+    const wrongName = await makePackage("pi-workflows-wrong-name");
+    await fs.writeFile(
+      path.join(wrongName, "package.json"),
+      `${JSON.stringify({ name: "other", version: "0.11.0" })}\n`,
+    );
+    expect(() => syncHerdrPlugin(wrongName, () => reply())).toThrow("Unexpected Pi Workflows");
+
+    const missingVersion = await makePackage("pi-workflows-missing-version");
+    await fs.writeFile(
+      path.join(missingVersion, "package.json"),
+      `${JSON.stringify({ name: "@osolmaz/pi-workflows" })}\n`,
+    );
+    expect(() => syncHerdrPlugin(missingVersion, () => reply())).toThrow(
+      "package version is missing",
+    );
+  });
+
+  it("rejects invalid manifest identity and arrays", async () => {
+    const wrongId = await makePackage("pi-workflows-wrong-plugin-id");
+    const wrongIdPath = path.join(wrongId, "herdr-plugin.toml");
+    const wrongIdManifest = await fs.readFile(wrongIdPath, "utf8");
+    await fs.writeFile(
+      wrongIdPath,
+      wrongIdManifest.replace(`id = "${HERDR_PLUGIN_ID}"`, 'id = "other.plugin"'),
+    );
+    expect(() => syncHerdrPlugin(wrongId, () => reply())).toThrow("Unexpected Herdr plugin ID");
+
+    const badPlatforms = await makePackage("pi-workflows-bad-platforms");
+    const badPlatformsPath = path.join(badPlatforms, "herdr-plugin.toml");
+    const badPlatformsManifest = await fs.readFile(badPlatformsPath, "utf8");
+    await fs.writeFile(
+      badPlatformsPath,
+      badPlatformsManifest.replace('platforms = ["linux", "macos"]', "platforms = []"),
+    );
+    expect(() => syncHerdrPlugin(badPlatforms, () => reply())).toThrow(
+      "invalid platforms string array",
+    );
+  });
+
+  it("rejects an unexpected viewer command and a missing viewer", async () => {
+    const wrongCommand = await makePackage("pi-workflows-wrong-command");
+    const manifestPath = path.join(wrongCommand, "herdr-plugin.toml");
+    const manifest = await fs.readFile(manifestPath, "utf8");
+    await fs.writeFile(
+      manifestPath,
+      manifest.replace(
+        'command = ["node", "plugins/herdr/viewer.mjs"]',
+        'command = ["node", "plugins/herdr/other.mjs"]',
+      ),
+    );
+    expect(() => syncHerdrPlugin(wrongCommand, () => reply())).toThrow(
+      "Unexpected Herdr plugin viewer command",
+    );
+
+    const missingViewer = await makePackage("pi-workflows-missing-viewer");
+    await fs.rm(path.join(missingViewer, "plugins", "herdr", "viewer.mjs"));
+    expect(() => syncHerdrPlugin(missingViewer, () => reply())).toThrow(
+      "Package file plugins/herdr/viewer.mjs is missing",
+    );
   });
 
   it("validates the bundled package before running Herdr", async () => {


### PR DESCRIPTION
## Summary

npm can move Pi Workflows between nested and hoisted installation paths during an update.
Herdr then keeps a link to the removed path, and the `piw` plugin stops working.
This change adds one explicit command that finds the running Pi Workflows package, repairs the link, and verifies the final Herdr state.

## What Changed

Pi Workflows now owns the complete registration and repair process.
Installers do not need to know where npm placed the package.

- Added `pi-workflows herdr sync` with versioned `--json` output.
- Kept `pi-workflows herdr setup` as an alias.
- Added package, manifest, viewer, plugin identity, version, state, and warning checks.
- Added idempotent link, enable, relocation, and stale-link repair paths.
- Added bounded restoration when a valid previous package remains available.
- Added packed-package tests for nested and hoisted paths that contain spaces.
- Documented the update and recovery contract.

## Testing

The full repository checks and real-Pi end-to-end suite pass.
The Herdr command tests use a fake Herdr executable, so they do not change the operator's live plugin registration.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`

SimpleDoc also checked the new dated plan, but its repository-wide command reports pre-existing filename and frontmatter migrations in unrelated documents.

## Risks

Herdr exposes separate unlink and link commands, so replacement cannot be atomic.
The command validates the new package first, verifies every resulting state, and makes one restore attempt only when the old package is still valid.

- Only a missing Herdr executable returns `unavailable`.
- Other Herdr failures remain errors.
- The command does not edit Herdr state files directly.
- Running Pi processes still need reload or restart after a package update.

## Follow-ups

Publishing a release and updating OnurPi's exact dependency pin are separate steps.
