### PR TITLE
chore: release 0.11.1

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "osolmaz.pi-workflows"
 name = "Pi Workflows"
-version = "0.11.0"
+version = "0.11.1"
 min_herdr_version = "0.7.0"
 description = "Open the active Pi Workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -195,10 +195,15 @@ describe("pi-workflows CLI", () => {
     const bin = path.join(temp, "bin");
     await fs.mkdir(bin);
     const root = path.resolve(import.meta.dirname, "..");
+    const packageVersion = JSON.parse(
+      await fs.readFile(path.join(root, "package.json"), "utf8"),
+    ) as {
+      version: string;
+    };
     const herdr = path.join(bin, "herdr");
     await fs.writeFile(
       herdr,
-      `#!/usr/bin/env node\nconst path = require("node:path");\nconst root = process.env.TEST_HERDR_ROOT;\nprocess.stdout.write(JSON.stringify({ result: { plugins: [{ plugin_id: "osolmaz.pi-workflows", plugin_root: root, manifest_path: path.join(root, "herdr-plugin.toml"), version: "0.11.0", enabled: true }] } }));\n`,
+      `#!/usr/bin/env node\nconst path = require("node:path");\nconst root = process.env.TEST_HERDR_ROOT;\nconst pkg = require(path.join(root, "package.json"));\nprocess.stdout.write(JSON.stringify({ result: { plugins: [{ plugin_id: "osolmaz.pi-workflows", plugin_root: root, manifest_path: path.join(root, "herdr-plugin.toml"), version: pkg.version, enabled: true }] } }));\n`,
     );
     await fs.chmod(herdr, 0o755);
     vi.stubEnv("TEST_HERDR_ROOT", root);
@@ -209,8 +214,8 @@ describe("pi-workflows CLI", () => {
       schema: "pi-workflows.herdr-sync.v1",
       status: "unchanged",
       changed: false,
-      expectedVersion: "0.11.0",
-      effectiveVersion: "0.11.0",
+      expectedVersion: packageVersion.version,
+      effectiveVersion: packageVersion.version,
       enabled: true,
     });
   });

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
## Summary

This prepares Pi Workflows `0.11.1` for release.
The patch includes the merged Herdr link repair and autoimplement blocker-check changes.
It also removes a hard-coded version from the Herdr CLI test so later release bumps use package metadata.

## What Changed

All release artifacts now use one version.

- Bumped the npm package and lockfile to `0.11.1`.
- Bumped the Rust `pi-workflows` crate and lockfile to `0.11.1`.
- Bumped the bundled Herdr plugin to `0.11.1`.
- Made the Herdr CLI test read the package version.

## Testing

Both package release paths passed their local checks.

- `npm run check`
- `npm run test:e2e`
- `npm pack --dry-run --json`
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `cargo publish --manifest-path tui/Cargo.toml --dry-run --allow-dirty`
- `git diff --check`

## Risks

The change only updates release metadata and one version-aware test.
Publishing remains controlled by the GitHub Release workflows, which verify the tag, default-branch ancestry, package versions, and registry state before publishing.
