### PR TITLE
fix: make deferred workflow launches durable

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ Then, from any pi conversation:
 /workflow echo summarize this repository
 ```
 
+A model-started workflow is saved before the tool reports it as queued. The returned run ID works
+with `workflow status` and `workflow cancel` before execution starts. Pi Workflows waits for the
+current agent turn to settle before activation. If activation fails, it saves the failure and sends
+one follow-up turn so the model can correct the cause and start a new run.
+
 `/workflow` with no arguments lists discovered workflows. `/workflow pause`
 lets the current step finish and then holds the run before the next node. This
 is useful when you want to interject in the conversation mid-workflow.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -556,6 +556,13 @@ possible. Defaults worth knowing:
   held without nudges and the engine pauses at the next boundary. Node
   timeouts keep ticking while held, so a long-abandoned step still times out.
   `/workflow resume` re-delivers the pending step prompt.
+- A model-started workflow is persisted as `queued` with its final run ID before the start tool
+  returns. Activation waits for the initiating agent turn to settle, then moves through `starting`
+  and `running`. `workflow status` and `workflow cancel` accept the run ID before a run bundle
+  exists.
+- If deferred activation fails, the queue stores a bounded safe error, releases the session
+  reservation, and sends one follow-up turn to the initiating model. The model can correct the
+  cause and make a new explicit start call. Pi Workflows does not retry blindly.
 - `/workflow cancel` aborts the current node and marks the run `cancelled`.
   When no run is live but the widget still shows a parked or finished run,
   the same command clears the widget.

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -83,20 +83,36 @@ type WorkflowRow = {
   error: string | null;
 };
 
+export type WorkflowRunLaunchStatus =
+  | "queued"
+  | "starting"
+  | "running"
+  | "parked"
+  | "done"
+  | "failed"
+  | "cancelled";
+
 type WorkflowRunQueueRow = {
   run_id: string;
   workflow_ref: string;
   workflow_path: string;
+  workflow_source_json: string;
+  definition_digest: string;
   input_json: string;
-  status: "claimed" | "parked" | "done";
+  launch_options_json: string;
+  status: WorkflowRunLaunchStatus;
   runner_id: string | null;
   claim_token: string | null;
   claim_expires_at: number | null;
   affinity_runner_id: string | null;
   origin_session_id: string | null;
   parent_run_id: string | null;
+  error_code: string | null;
+  error_message: string | null;
   created_at: string;
   updated_at: string;
+  started_at: string | null;
+  finished_at: string | null;
 };
 
 /** A user-started workflow run tracked by the durable run queue. */
@@ -106,8 +122,11 @@ export type WorkflowRunQueueRecord = {
   workflowName: string;
   /** Canonical source reference used to reopen the run. */
   workflowSourceRef: string;
+  workflowSource: unknown;
+  definitionDigest: string;
   input: unknown;
-  status: "claimed" | "parked" | "done";
+  launchOptions: unknown;
+  status: WorkflowRunLaunchStatus;
   runnerId: string | null;
   claimToken: string | null;
   claimExpiresAt: string | null;
@@ -115,8 +134,12 @@ export type WorkflowRunQueueRecord = {
   /** Pi session that owns delivery and interactive execution, or null for detached runs. */
   originSessionId: string | null;
   parentRunId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
   createdAt: string;
   updatedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
 };
 
 type WorkflowNotificationRow = {
@@ -126,7 +149,7 @@ type WorkflowNotificationRow = {
   attempt_id: string;
   notification_index: number;
   target_session_id: string;
-  kind: "progress" | "final";
+  kind: "progress" | "final" | "launch_failure";
   content: string;
   created_at: string;
   delivery_claim_token: string | null;
@@ -141,7 +164,7 @@ export type WorkflowNotificationRecord = {
   attemptId: string;
   notificationIndex: number;
   targetSessionId: string;
-  kind: "progress" | "final";
+  kind: "progress" | "final" | "launch_failure";
   content: string;
   createdAt: string;
   deliveryClaimExpiresAt: string | null;
@@ -799,21 +822,57 @@ export class SqliteControllerStore implements ControllerStore {
       if (row === undefined) {
         throw new Error("Controller store has no schema identifier");
       }
-      return;
+    } else {
+      const existingQueue = this.database
+        .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workflow_run_queue'")
+        .get();
+      if (existingQueue !== undefined) this.assertAlphaSchemaLayout();
+      this.transaction(() => {
+        this.database
+          .prepare("INSERT OR IGNORE INTO schema_info (singleton, schema_id) VALUES (1, ?)")
+          .run(CONTROLLER_STORE_SCHEMA);
+        this.database.exec(SCHEMA_SQL);
+      });
     }
-    this.transaction(() => {
-      this.database
-        .prepare("INSERT OR IGNORE INTO schema_info (singleton, schema_id) VALUES (1, ?)")
-        .run(CONTROLLER_STORE_SCHEMA);
-      this.database.exec(SCHEMA_SQL);
-      const queueColumns = this.database.pragma("table_info(workflow_run_queue)") as {
-        name: string;
-      }[];
-      if (!queueColumns.some((column) => column.name === "origin_session_id")) {
-        this.database.exec("ALTER TABLE workflow_run_queue ADD COLUMN origin_session_id TEXT");
-      }
-      this.database.exec("DROP TABLE IF EXISTS session_watermarks");
-    });
+    this.assertAlphaSchemaLayout();
+  }
+
+  private assertAlphaSchemaLayout(): void {
+    const requiredQueueColumns = new Set([
+      "run_id",
+      "workflow_ref",
+      "workflow_path",
+      "workflow_source_json",
+      "definition_digest",
+      "input_json",
+      "launch_options_json",
+      "status",
+      "runner_id",
+      "claim_token",
+      "claim_expires_at",
+      "affinity_runner_id",
+      "origin_session_id",
+      "parent_run_id",
+      "error_code",
+      "error_message",
+      "created_at",
+      "updated_at",
+      "started_at",
+      "finished_at",
+    ]);
+    const actual = new Set(
+      (
+        this.database.pragma("table_info(workflow_run_queue)") as {
+          name: string;
+        }[]
+      ).map((column) => column.name),
+    );
+    const missing = [...requiredQueueColumns].filter((column) => !actual.has(column));
+    if (missing.length > 0) {
+      throw new Error(
+        "Controller store uses an incompatible alpha layout. Preserve needed run bundles, then reset the project controller store.",
+      );
+    }
   }
 
   private transaction<T>(task: () => T): T {
@@ -901,15 +960,68 @@ export class SqliteControllerStore implements ControllerStore {
     return workflow;
   }
 
-  /**
-   * Insert a user-started run and claim it in one statement, so the
-   * originating runner owns the run from birth (origin affinity).
-   */
+  /** Reserve a user-started run before the initiating agent turn settles. */
+  reserveWorkflowRun(options: {
+    runId: string;
+    workflowName: string;
+    workflowSourceRef: string;
+    workflowSource: unknown;
+    definitionDigest: string;
+    input: unknown;
+    launchOptions?: unknown;
+    runnerId: string;
+    originSessionId: string;
+    parentRunId?: string;
+    now?: string;
+  }): WorkflowRunQueueRecord {
+    validateRunId(options.runId);
+    validateKey(options.workflowName, "workflow name");
+    validateKey(options.workflowSourceRef, "workflow source ref");
+    validateKey(options.definitionDigest, "workflow definition digest");
+    validateKey(options.runnerId, "runner id");
+    validateKey(options.originSessionId, "origin session id");
+    const inputJson = canonicalJson(options.input ?? null, "workflow run input");
+    const sourceJson = canonicalJson(options.workflowSource, "workflow run source");
+    const launchJson = canonicalJson(options.launchOptions ?? {}, "workflow launch options");
+    validateJsonSize(inputJson, "Workflow run input", MAX_RESOURCE_VALUE_BYTES);
+    validateJsonSize(sourceJson, "Workflow run source", MAX_EVENT_BYTES);
+    validateJsonSize(launchJson, "Workflow launch options", MAX_EVENT_BYTES);
+    const now = validTimestamp(options.now);
+    this.database
+      .prepare(
+        `INSERT INTO workflow_run_queue (
+          run_id, workflow_ref, workflow_path, workflow_source_json, definition_digest,
+          input_json, launch_options_json, status, runner_id, claim_token, claim_expires_at,
+          affinity_runner_id, origin_session_id, parent_run_id, error_code, error_message,
+          created_at, updated_at, started_at, finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', NULL, NULL, NULL, ?, ?, ?, NULL, NULL, ?, ?, NULL, NULL)`,
+      )
+      .run(
+        options.runId,
+        options.workflowName,
+        options.workflowSourceRef,
+        sourceJson,
+        options.definitionDigest,
+        inputJson,
+        launchJson,
+        options.runnerId,
+        options.originSessionId,
+        options.parentRunId ?? null,
+        now,
+        now,
+      );
+    return this.requireWorkflowRun(options.runId);
+  }
+
+  /** Insert a run that will start immediately outside a live model turn. */
   enqueueWorkflowRun(options: {
     runId: string;
     workflowName: string;
     workflowSourceRef: string;
+    workflowSource?: unknown;
+    definitionDigest?: string;
     input: unknown;
+    launchOptions?: unknown;
     runnerId: string;
     claimToken: string;
     leaseMs: number;
@@ -928,28 +1040,38 @@ export class SqliteControllerStore implements ControllerStore {
       validateKey(options.originSessionId, "origin session id");
     }
     const inputJson = canonicalJson(options.input ?? null, "workflow run input");
+    const sourceJson = canonicalJson(
+      options.workflowSource ?? { ref: options.workflowSourceRef },
+      "workflow run source",
+    );
+    const launchJson = canonicalJson(options.launchOptions ?? {}, "workflow launch options");
     validateJsonSize(inputJson, "Workflow run input", MAX_RESOURCE_VALUE_BYTES);
     const now = validTimestamp(options.now);
     const expiresAt = epoch(now) + options.leaseMs;
     this.database
       .prepare(
         `INSERT INTO workflow_run_queue (
-          run_id, workflow_ref, workflow_path, input_json, status,
-          runner_id, claim_token, claim_expires_at, affinity_runner_id,
-          origin_session_id, parent_run_id, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, 'claimed', ?, ?, ?, ?, ?, ?, ?, ?)`,
+          run_id, workflow_ref, workflow_path, workflow_source_json, definition_digest,
+          input_json, launch_options_json, status, runner_id, claim_token, claim_expires_at,
+          affinity_runner_id, origin_session_id, parent_run_id, error_code, error_message,
+          created_at, updated_at, started_at, finished_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, NULL)`,
       )
       .run(
         options.runId,
         options.workflowName,
         options.workflowSourceRef,
+        sourceJson,
+        options.definitionDigest ?? "unavailable",
         inputJson,
+        launchJson,
         options.runnerId,
         options.claimToken,
         expiresAt,
         options.affinityRunnerId ?? options.runnerId,
         options.originSessionId ?? null,
         options.parentRunId ?? null,
+        now,
         now,
         now,
       );
@@ -976,6 +1098,58 @@ export class SqliteControllerStore implements ControllerStore {
             .prepare("SELECT * FROM workflow_run_queue WHERE status = ? ORDER BY created_at")
             .all(options.status) as WorkflowRunQueueRow[]);
     return rows.map(workflowRunFromRow);
+  }
+
+  findSessionReservation(sessionId: string): WorkflowRunQueueRecord | undefined {
+    validateKey(sessionId, "session id");
+    const row = this.database
+      .prepare(
+        `SELECT * FROM workflow_run_queue
+         WHERE origin_session_id = ? AND status IN ('queued', 'starting', 'running')
+         ORDER BY created_at LIMIT 1`,
+      )
+      .get(sessionId) as WorkflowRunQueueRow | undefined;
+    return row === undefined ? undefined : workflowRunFromRow(row);
+  }
+
+  claimWorkflowRun(options: {
+    runId: string;
+    runnerId: string;
+    claimToken: string;
+    leaseMs: number;
+    now?: string;
+  }): WorkflowRunQueueRecord | undefined {
+    validateRunId(options.runId);
+    validateKey(options.runnerId, "runner id");
+    validateKey(options.claimToken, "claim token");
+    validateDuration(options.leaseMs, "leaseMs");
+    const now = validTimestamp(options.now);
+    const nowMs = epoch(now);
+    const expiresAt = nowMs + options.leaseMs;
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_run_queue
+         SET status = 'starting', runner_id = ?, claim_token = ?, claim_expires_at = ?,
+             started_at = COALESCE(started_at, ?), updated_at = ?
+         WHERE run_id = ? AND (
+           status IN ('queued', 'parked')
+           OR (status = 'starting' AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
+         )`,
+      )
+      .run(options.runnerId, options.claimToken, expiresAt, now, now, options.runId, nowMs);
+    return result.changes === 1 ? this.requireWorkflowRun(options.runId) : undefined;
+  }
+
+  markWorkflowRunRunning(options: { runId: string; claimToken: string; now?: string }): boolean {
+    validateRunId(options.runId);
+    const now = validTimestamp(options.now);
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_run_queue SET status = 'running', updated_at = ?
+         WHERE run_id = ? AND claim_token = ? AND status = 'starting'`,
+      )
+      .run(now, options.runId, options.claimToken);
+    return result.changes === 1;
   }
 
   /**
@@ -1008,11 +1182,11 @@ export class SqliteControllerStore implements ControllerStore {
       excluded.length === 0 ? "" : `AND run_id NOT IN (${excluded.map(() => "?").join(", ")})`;
     const sessionFilter =
       options.sessionId === undefined
-        ? ""
+        ? "AND status != 'queued' AND (status != 'starting' OR origin_session_id IS NULL)"
         : "AND (origin_session_id IS NULL OR origin_session_id = ?)";
     const claimable = `(
-      status = 'parked'
-      OR (status = 'claimed' AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
+      status IN ('queued', 'parked')
+      OR (status IN ('starting', 'running') AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
     )`;
     return this.transaction(() => {
       const candidate = this.database
@@ -1036,14 +1210,14 @@ export class SqliteControllerStore implements ControllerStore {
       const result = this.database
         .prepare(
           `UPDATE workflow_run_queue
-           SET status = 'claimed', runner_id = ?, claim_token = ?,
-               claim_expires_at = ?, updated_at = ?
+           SET status = 'starting', runner_id = ?, claim_token = ?,
+               claim_expires_at = ?, started_at = COALESCE(started_at, ?), updated_at = ?
            WHERE run_id = ? AND (
-             status = 'parked'
-             OR (status = 'claimed' AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
+             status IN ('queued', 'parked')
+             OR (status IN ('starting', 'running') AND claim_expires_at IS NOT NULL AND claim_expires_at <= ?)
            )`,
         )
-        .run(options.runnerId, options.claimToken, expiresAt, now, candidate.run_id, nowMs);
+        .run(options.runnerId, options.claimToken, expiresAt, now, now, candidate.run_id, nowMs);
       return result.changes === 1 ? this.requireWorkflowRun(candidate.run_id) : undefined;
     });
   }
@@ -1062,7 +1236,7 @@ export class SqliteControllerStore implements ControllerStore {
     const result = this.database
       .prepare(
         `UPDATE workflow_run_queue SET claim_expires_at = ?
-         WHERE run_id = ? AND claim_token = ? AND status = 'claimed'
+         WHERE run_id = ? AND claim_token = ? AND status IN ('starting', 'running')
            AND claim_expires_at > ?`,
       )
       .run(expiresAt, options.runId, options.claimToken, nowMs);
@@ -1076,7 +1250,7 @@ export class SqliteControllerStore implements ControllerStore {
     const row = this.database
       .prepare(
         `SELECT 1 AS live FROM workflow_run_queue
-         WHERE run_id = ? AND claim_token = ? AND status = 'claimed'
+         WHERE run_id = ? AND claim_token = ? AND status IN ('starting', 'running')
            AND claim_expires_at > ?`,
       )
       .get(options.runId, options.claimToken, nowMs);
@@ -1092,9 +1266,65 @@ export class SqliteControllerStore implements ControllerStore {
         `UPDATE workflow_run_queue
          SET status = 'parked', runner_id = NULL, claim_token = NULL,
              claim_expires_at = NULL, updated_at = ?
-         WHERE run_id = ? AND claim_token = ? AND status = 'claimed'`,
+         WHERE run_id = ? AND claim_token = ? AND status IN ('starting', 'running')`,
       )
       .run(now, options.runId, options.claimToken);
+    return result.changes === 1;
+  }
+
+  failWorkflowRun(options: {
+    runId: string;
+    claimToken?: string;
+    errorCode: string;
+    errorMessage: string;
+    now?: string;
+  }): boolean {
+    validateRunId(options.runId);
+    validateKey(options.errorCode, "workflow launch error code");
+    const message = options.errorMessage.trim();
+    if (message.length === 0 || Buffer.byteLength(message) > 2_048) {
+      throw new Error("Workflow launch error message must be between 1 and 2048 bytes");
+    }
+    const now = validTimestamp(options.now);
+    const claimFilter = options.claimToken === undefined ? "" : "AND claim_token = ?";
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_run_queue
+         SET status = 'failed', runner_id = NULL, claim_token = NULL,
+             claim_expires_at = NULL, parent_run_id = NULL, input_json = 'null',
+             launch_options_json = '{}', error_code = ?, error_message = ?,
+             finished_at = ?, updated_at = ?
+         WHERE run_id = ? AND status IN ('queued', 'starting', 'running') ${claimFilter}`,
+      )
+      .run(
+        options.errorCode,
+        message,
+        now,
+        now,
+        options.runId,
+        ...(options.claimToken === undefined ? [] : [options.claimToken]),
+      );
+    return result.changes === 1;
+  }
+
+  cancelWorkflowRun(options: { runId: string; claimToken?: string; now?: string }): boolean {
+    validateRunId(options.runId);
+    const now = validTimestamp(options.now);
+    const claimFilter = options.claimToken === undefined ? "" : "AND claim_token = ?";
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_run_queue
+         SET status = 'cancelled', runner_id = NULL, claim_token = NULL,
+             claim_expires_at = NULL, input_json = 'null', launch_options_json = '{}',
+             finished_at = ?, updated_at = ?
+         WHERE run_id = ? AND status IN ('queued', 'starting') ${claimFilter}`,
+      )
+      .run(
+        now,
+        now,
+        options.runId,
+        ...(options.claimToken === undefined ? [] : [options.claimToken]),
+      );
     return result.changes === 1;
   }
 
@@ -1119,10 +1349,11 @@ export class SqliteControllerStore implements ControllerStore {
       .prepare(
         `UPDATE workflow_run_queue
          SET status = 'done', runner_id = NULL, claim_token = NULL,
-             claim_expires_at = NULL, updated_at = ?
-         WHERE run_id = ? AND claim_token = ? AND status = 'claimed'`,
+             claim_expires_at = NULL, input_json = 'null', launch_options_json = '{}',
+             finished_at = ?, updated_at = ?
+         WHERE run_id = ? AND claim_token = ? AND status IN ('starting', 'running')`,
       )
-      .run(now, options.runId, options.claimToken);
+      .run(now, now, options.runId, options.claimToken);
     return result.changes === 1;
   }
 
@@ -1149,26 +1380,28 @@ export class SqliteControllerStore implements ControllerStore {
       const row = this.database
         .prepare("SELECT * FROM workflow_run_queue WHERE run_id = ?")
         .get(options.runId) as WorkflowRunQueueRow | undefined;
-      if (row === undefined || row.status === "done") return false;
+      if (row === undefined || ["done", "failed", "cancelled"].includes(row.status)) {
+        return false;
+      }
       if (row.workflow_path === options.workflowSourceRef && row.status === "parked") {
         return "unchanged";
       }
       const claimable =
         row.status === "parked" ||
-        (row.status === "claimed" &&
+        (row.status === "starting" &&
           row.claim_token === options.claimToken &&
           row.claim_expires_at !== null &&
           row.claim_expires_at > nowMs) ||
-        (row.status === "claimed" &&
+        (row.status === "starting" &&
           row.claim_expires_at !== null &&
           row.claim_expires_at <= nowMs);
       if (!claimable) return false;
       const result = this.database
         .prepare(
           `UPDATE workflow_run_queue
-           SET workflow_ref = ?, workflow_path = ?, status = 'claimed', runner_id = ?,
+           SET workflow_ref = ?, workflow_path = ?, status = 'starting', runner_id = ?,
                claim_token = ?, claim_expires_at = ?, updated_at = ?
-           WHERE run_id = ? AND status != 'done'`,
+           WHERE run_id = ? AND status NOT IN ('done', 'failed', 'cancelled')`,
         )
         .run(
           options.workflowName,
@@ -1208,26 +1441,28 @@ export class SqliteControllerStore implements ControllerStore {
       const row = this.database
         .prepare("SELECT * FROM workflow_run_queue WHERE run_id = ?")
         .get(options.runId) as WorkflowRunQueueRow | undefined;
-      if (row === undefined || row.status === "done") return false;
+      if (row === undefined || ["done", "failed", "cancelled"].includes(row.status)) {
+        return false;
+      }
       const sourceMatches =
         row.workflow_path === options.oldWorkflowPath ||
         row.workflow_path === options.workflowSourceRef;
       const claimable =
         row.status === "parked" ||
-        (row.status === "claimed" &&
+        (row.status === "starting" &&
           row.claim_token === options.claimToken &&
           row.claim_expires_at !== null &&
           row.claim_expires_at > nowMs) ||
-        (row.status === "claimed" &&
+        (row.status === "starting" &&
           row.claim_expires_at !== null &&
           row.claim_expires_at <= nowMs);
       if (!sourceMatches || !claimable) return false;
       const result = this.database
         .prepare(
           `UPDATE workflow_run_queue
-           SET workflow_ref = ?, workflow_path = ?, status = 'claimed', runner_id = ?,
+           SET workflow_ref = ?, workflow_path = ?, status = 'starting', runner_id = ?,
                claim_token = ?, claim_expires_at = ?, updated_at = ?
-           WHERE run_id = ? AND status != 'done'`,
+           WHERE run_id = ? AND status NOT IN ('done', 'failed', 'cancelled')`,
         )
         .run(
           options.workflowName,
@@ -1297,7 +1532,7 @@ export class SqliteControllerStore implements ControllerStore {
     attemptId: string;
     notificationIndex: number;
     targetSessionId: string;
-    kind: "progress" | "final";
+    kind: "progress" | "final" | "launch_failure";
     content: string;
     notificationId?: string;
     now?: string;
@@ -1483,19 +1718,31 @@ const SCHEMA_SQL = `
     run_id TEXT PRIMARY KEY,
     workflow_ref TEXT NOT NULL,
     workflow_path TEXT NOT NULL,
+    workflow_source_json TEXT NOT NULL,
+    definition_digest TEXT NOT NULL,
     input_json TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('claimed', 'parked', 'done')),
+    launch_options_json TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (
+      status IN ('queued', 'starting', 'running', 'parked', 'done', 'failed', 'cancelled')
+    ),
     runner_id TEXT,
     claim_token TEXT,
     claim_expires_at INTEGER,
     affinity_runner_id TEXT,
     origin_session_id TEXT,
     parent_run_id TEXT,
+    error_code TEXT,
+    error_message TEXT,
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    started_at TEXT,
+    finished_at TEXT
   );
   CREATE INDEX IF NOT EXISTS workflow_run_queue_claimable
     ON workflow_run_queue(status, claim_expires_at);
+  CREATE UNIQUE INDEX IF NOT EXISTS workflow_run_queue_session_reservation
+    ON workflow_run_queue(origin_session_id)
+    WHERE origin_session_id IS NOT NULL AND status IN ('queued', 'starting', 'running');
   -- A checkpointed parent admits exactly one continuation run, across
   -- sessions and processes.
   CREATE UNIQUE INDEX IF NOT EXISTS workflow_run_queue_parent
@@ -1519,7 +1766,7 @@ const SCHEMA_SQL = `
     attempt_id TEXT NOT NULL,
     notification_index INTEGER NOT NULL CHECK (notification_index > 0),
     target_session_id TEXT NOT NULL,
-    kind TEXT NOT NULL CHECK (kind IN ('progress', 'final')),
+    kind TEXT NOT NULL CHECK (kind IN ('progress', 'final', 'launch_failure')),
     content TEXT NOT NULL,
     created_at TEXT NOT NULL,
     delivery_claim_token TEXT,
@@ -1643,7 +1890,10 @@ function workflowRunFromRow(row: WorkflowRunQueueRow): WorkflowRunQueueRecord {
     runId: row.run_id,
     workflowName: row.workflow_ref,
     workflowSourceRef: row.workflow_path,
+    workflowSource: parseStoredJson(row.workflow_source_json, "workflow run source"),
+    definitionDigest: row.definition_digest,
     input: parseStoredJson(row.input_json, "workflow run input"),
+    launchOptions: parseStoredJson(row.launch_options_json, "workflow launch options"),
     status: row.status,
     runnerId: row.runner_id,
     claimToken: row.claim_token,
@@ -1651,8 +1901,12 @@ function workflowRunFromRow(row: WorkflowRunQueueRow): WorkflowRunQueueRecord {
     affinityRunnerId: row.affinity_runner_id,
     originSessionId: row.origin_session_id,
     parentRunId: row.parent_run_id,
+    errorCode: row.error_code,
+    errorMessage: row.error_message,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
   };
 }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,11 +1,16 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { builtinWorkflowCatalog } from "../builtins/catalog.js";
-import { projectControllerStorePath, SqliteControllerStore } from "../controllers/index.js";
+import {
+  projectControllerStorePath,
+  SqliteControllerStore,
+  type WorkflowRunQueueRecord,
+} from "../controllers/index.js";
 import type { JsonObject } from "../controllers/types.js";
 import type { WorkflowSchedulerResult } from "../controllers/workflows.js";
+import { compositionMetadata } from "../workflows/composition.js";
 import { humanDecisionChannelRequest } from "../workflows/decision-presentation.js";
 import { WorkflowEngine } from "../workflows/engine.js";
 import {
@@ -170,6 +175,12 @@ function humanDecisionRequest(value: unknown): HumanDecisionRequest | null {
   return value as HumanDecisionRequest;
 }
 
+type PreparedLaunchOptions = {
+  presentation?: boolean;
+  parentRunId?: string;
+  humanDecision?: AcceptedHumanDecision;
+};
+
 type StartRunOptions = {
   runId?: string;
   childKey?: string;
@@ -186,6 +197,49 @@ type StartRunOptions = {
   /** An existing queue claim token, when the caller already claimed the run. */
   claimToken?: string;
 };
+
+function definitionDigest(snapshot: WorkflowDefinitionSnapshot): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(snapshot)).digest("hex")}`;
+}
+
+function launchSourceIdentity(workflow: WorkflowDefinition, root: unknown): unknown {
+  return {
+    root,
+    mounted: compositionMetadata(workflow)?.sources ?? [],
+  };
+}
+
+function preparedLaunchOptions(options: StartRunOptions): PreparedLaunchOptions {
+  return {
+    ...(options.presentation !== undefined ? { presentation: options.presentation } : {}),
+    ...(options.parentRunId !== undefined ? { parentRunId: options.parentRunId } : {}),
+    ...(options.humanDecision !== undefined ? { humanDecision: options.humanDecision } : {}),
+  };
+}
+
+function parsePreparedLaunchOptions(value: unknown): PreparedLaunchOptions {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Stored workflow launch options are invalid");
+  }
+  return value as PreparedLaunchOptions;
+}
+
+function safeLaunchError(error: unknown): { code: string; message: string } {
+  const raw = errorMessage(error)
+    .replace(/Bearer\s+\S+/giu, "Bearer [redacted]")
+    .replace(/(token|api[_-]?key|secret|password)(\s*[:=]\s*)\S+/giu, "$1$2[redacted]")
+    .replaceAll("\n", " ")
+    .trim();
+  const code = /not found|cannot find|unknown workflow/iu.test(raw)
+    ? "workflow_not_found"
+    : /source changed|source mismatch/iu.test(raw)
+      ? "source_changed"
+      : /invalid|must be/iu.test(raw)
+        ? "workflow_invalid"
+        : "activation_failed";
+  const message = raw.length <= 500 ? raw : `${raw.slice(0, 480)}… [error truncated]`;
+  return { code, message: message || "The deferred workflow could not start" };
+}
 
 export type ParsedWorkflowArgs =
   | { kind: "list" }
@@ -343,6 +397,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   // Run events remain an audit feed and never enter a conversation.
   let syncArmed = false;
   let runSyncTimer: ReturnType<typeof setInterval> | null = null;
+  let activationRecovery: ((ctx: ExtensionContext) => void) | undefined;
   let decisionRecoveryTimer: ReturnType<typeof setInterval> | null = null;
   let decisionRecoveryActive = false;
 
@@ -377,6 +432,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   const runSyncPass = (ctx: ExtensionContext): void => {
     if (runQueueStore === null || !syncArmed) return;
     try {
+      activationRecovery?.(ctx);
       const sessionId = ctx.sessionManager.getSessionId();
       const alreadyDelivered = deliveredNotificationIds(ctx);
       const claimToken = randomUUID();
@@ -397,7 +453,9 @@ export default function piWorkflows(pi: ExtensionAPI) {
                 kind: notification.kind,
               },
             },
-            { triggerTurn: false },
+            notification.kind === "launch_failure"
+              ? { triggerTurn: true, deliverAs: "followUp" }
+              : { triggerTurn: false },
           );
           alreadyDelivered.add(notification.notificationId);
         }
@@ -425,12 +483,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   let systemTurnAbort: AgentStepContract | null = null;
   let suppressWorkflowAssistantTail = false;
   let lastExpiredAttempt: { contract: AgentStepContract; reason: string } | null = null;
-  let pendingToolLaunch: {
-    ctx: ExtensionContext;
-    ref: string;
-    input: unknown;
-    options?: StartRunOptions;
-  } | null = null;
   // The interactive run currently parked at a checkpoint, if any.
   let lastWaitingRunId: string | null = null;
   let widgetTimer: NodeJS.Timeout | null = null;
@@ -927,7 +979,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
             workflowSource.kind === "builtin"
               ? `builtin:${workflowSource.id}`
               : workflowSource.path,
+          workflowSource: launchSourceIdentity(workflow, workflowSource),
+          definitionDigest: definitionDigest(snapshot),
           input,
+          launchOptions: preparedLaunchOptions(options),
           runnerId,
           claimToken: token,
           leaseMs: RUN_CLAIM_LEASE_MS,
@@ -1063,6 +1118,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
       ...(options.resume === true ? { resume: true } : {}),
       ...(options.parentRunId !== undefined ? { parentRunId: options.parentRunId } : {}),
     };
+    if (
+      queueStore !== null &&
+      claimToken !== undefined &&
+      !queueStore.markWorkflowRunRunning({ runId, claimToken })
+    ) {
+      throw new ClaimLostError(runId);
+    }
     activeRun = run;
     if (queueStore !== null && claimToken !== undefined) {
       const store = queueStore;
@@ -1224,8 +1286,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
           : bundle.state.workflowSource.kind === "builtin"
             ? `builtin:${bundle.state.workflowSource.id}`
             : bundle.state.workflowSource.path;
+      const launchOptions = parsePreparedLaunchOptions(claimed.launchOptions);
       started = await startRun(ctx, sourceRef, claimed.input, {
-        resume: true,
+        ...launchOptions,
+        resume: bundle !== null,
         runId: claimed.runId,
         claimToken,
       });
@@ -1412,8 +1476,11 @@ export default function piWorkflows(pi: ExtensionAPI) {
     return null;
   };
 
-  const cancelWorkflowControl = async (ctx: ExtensionContext): Promise<WorkflowControlResult> => {
-    if (activeRun) {
+  const cancelWorkflowControl = async (
+    ctx: ExtensionContext,
+    requestedRunId?: string,
+  ): Promise<WorkflowControlResult> => {
+    if (activeRun && (requestedRunId === undefined || requestedRunId === activeRun.runId)) {
       const workflowName = activeRun.workflowName;
       const runId = activeRun.runId;
       activeRun.engine.cancel();
@@ -1422,12 +1489,35 @@ export default function piWorkflows(pi: ExtensionAPI) {
         details: { action: "cancel", workflowName, runId },
       };
     }
-    if (pendingToolLaunch !== null) {
-      const ref = pendingToolLaunch.ref;
-      pendingToolLaunch = null;
+    const queue = ensureRunQueueStore(ctx.cwd);
+    const queued =
+      requestedRunId === undefined
+        ? queue.findSessionReservation(ctx.sessionManager.getSessionId())
+        : queue.getWorkflowRun(requestedRunId);
+    if (
+      queued !== undefined &&
+      ["queued", "starting"].includes(queued.status) &&
+      (queued.originSessionId === null ||
+        queued.originSessionId === ctx.sessionManager.getSessionId())
+    ) {
+      if (!queue.cancelWorkflowRun({ runId: queued.runId })) {
+        throw new Error(
+          `Workflow ${queued.runId} could not be cancelled because its state changed.`,
+        );
+      }
+      recordRunEvent({
+        runId: queued.runId,
+        workflowRef: queued.workflowName,
+        type: "cancelled",
+      });
       return {
-        message: `Cancelled the queued workflow launch for ${ref}.`,
-        details: { action: "cancel", workflow: ref, queued: false },
+        message: `Cancelled queued workflow ${queued.workflowName} (run ${queued.runId}).`,
+        details: {
+          action: "cancel",
+          workflow: queued.workflowName,
+          runId: queued.runId,
+          queued: false,
+        },
       };
     }
     if (widgetSource) {
@@ -1538,6 +1628,21 @@ export default function piWorkflows(pi: ExtensionAPI) {
     };
   };
 
+  const workflowLaunchStatus = (record: WorkflowRunQueueRecord): WorkflowControlResult => ({
+    message: `Workflow ${record.workflowName} is ${record.status} (run ${record.runId}).`,
+    details: {
+      action: "status",
+      active: ["starting", "running"].includes(record.status),
+      queued: record.status === "queued",
+      workflowName: record.workflowName,
+      runId: record.runId,
+      status: record.status,
+      ...(record.errorCode === null ? {} : { errorCode: record.errorCode }),
+      ...(record.errorMessage === null ? {} : { error: record.errorMessage }),
+    },
+    ...(["failed", "cancelled"].includes(record.status) ? { level: "warning" as const } : {}),
+  });
+
   const statusWorkflowControl = async (
     ctx: ExtensionContext,
     runId?: string,
@@ -1545,7 +1650,9 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (runId !== undefined) {
       const bundle = await readRunBundle(new WorkflowRunStore().runDirFor(runId));
       if (bundle === null) {
-        throw new Error(`Workflow run not found: ${runId}`);
+        const launch = ensureRunQueueStore(ctx.cwd).getWorkflowRun(runId);
+        if (launch === undefined) throw new Error(`Workflow run not found: ${runId}`);
+        return workflowLaunchStatus(launch);
       }
       const { state } = bundle;
       return {
@@ -1554,11 +1661,11 @@ export default function piWorkflows(pi: ExtensionAPI) {
       };
     }
     const state = activeRun?.lastState ?? widgetSource?.state;
-    if ((state === undefined || state === null) && pendingToolLaunch !== null) {
-      return {
-        message: `Workflow ${pendingToolLaunch.ref} is queued until the current turn finishes.`,
-        details: { active: false, queued: true, workflow: pendingToolLaunch.ref },
-      };
+    if (state === undefined || state === null) {
+      const queued = ensureRunQueueStore(ctx.cwd).findSessionReservation(
+        ctx.sessionManager.getSessionId(),
+      );
+      if (queued !== undefined) return workflowLaunchStatus(queued);
     }
     if (state === undefined || state === null) {
       return {
@@ -1903,8 +2010,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (activeRun !== null) {
       throw new Error(`A workflow is already running: ${activeRun.workflowName}.`);
     }
-    if (pendingToolLaunch !== null) {
-      throw new Error("A workflow launch is already waiting for the current turn to finish.");
+    const reserved = ensureRunQueueStore(ctx.cwd).findSessionReservation(
+      ctx.sessionManager.getSessionId(),
+    );
+    if (reserved !== undefined) {
+      throw new Error(
+        `Workflow ${reserved.workflowName} is already ${reserved.status} (run ${reserved.runId}).`,
+      );
     }
     if (presentationPending !== null) {
       throw new Error("The previous workflow result is still being presented.");
@@ -1930,34 +2042,158 @@ export default function piWorkflows(pi: ExtensionAPI) {
         `A workflow is already running: ${activeRun.workflowName}. Cancel it before starting another.`,
       );
     }
-    if (pendingToolLaunch !== null) {
-      throw new Error("A workflow launch is already waiting for the current turn to finish.");
+    const queue = ensureRunQueueStore(ctx.cwd);
+    const existing = queue.findSessionReservation(ctx.sessionManager.getSessionId());
+    if (existing !== undefined) {
+      throw new Error(
+        `Workflow ${existing.workflowName} is already ${existing.status} (run ${existing.runId}).`,
+      );
     }
     if (presentationPending !== null) {
       throw new Error("The previous workflow result is still being presented.");
     }
-    const reservation = { ctx, ref, input, options };
-    pendingToolLaunch = reservation;
-    try {
-      const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd }, builtinWorkflowCatalog);
-      const workflow = resolved.definition;
-      if (pendingToolLaunch !== reservation) {
-        throw new Error("The queued workflow launch was cancelled before validation finished.");
+    const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd }, builtinWorkflowCatalog);
+    const workflow = resolved.definition;
+    const workflowSource = resolved.source;
+    if (options.parentRunId !== undefined) {
+      const parent = await readRunBundle(new WorkflowRunStore().runDirFor(options.parentRunId));
+      if (parent === null || parent.state.status !== "waiting") {
+        throw new Error(`Workflow run ${options.parentRunId} is not waiting at a checkpoint`);
       }
-      return {
-        message: `Workflow ${workflow.name} will start after this turn finishes.`,
-        details: {
-          action: "start",
-          workflow: workflow.name,
-          source: resolved.source,
-          queued: true,
-        },
-      };
+      if (
+        parent.state.workflowSource !== undefined &&
+        !isDeepStrictEqual(parent.state.workflowSource, workflowSource)
+      ) {
+        throw new Error(
+          `Workflow source changed since run ${options.parentRunId} started; revert the edit to answer its checkpoint`,
+        );
+      }
+    }
+    const snapshot = createDefinitionSnapshot(workflow);
+    const runId = createRunId(workflow.name);
+    try {
+      queue.reserveWorkflowRun({
+        runId,
+        workflowName: workflow.name,
+        workflowSourceRef:
+          workflowSource.kind === "builtin" ? `builtin:${workflowSource.id}` : workflowSource.path,
+        workflowSource: launchSourceIdentity(workflow, workflowSource),
+        definitionDigest: definitionDigest(snapshot),
+        input,
+        launchOptions: preparedLaunchOptions(options),
+        runnerId,
+        originSessionId: ctx.sessionManager.getSessionId(),
+        ...(options.parentRunId !== undefined ? { parentRunId: options.parentRunId } : {}),
+      });
     } catch (error) {
-      if (pendingToolLaunch === reservation) {
-        pendingToolLaunch = null;
+      const reserved = queue.findSessionReservation(ctx.sessionManager.getSessionId());
+      if (reserved !== undefined) {
+        throw new Error(
+          `A workflow launch is already waiting: ${reserved.workflowName} (run ${reserved.runId}).`,
+          { cause: error },
+        );
       }
       throw error;
+    }
+    recordRunEvent({
+      runId,
+      workflowRef: workflow.name,
+      type: "queued",
+      payload: options.parentRunId === undefined ? {} : { parentRunId: options.parentRunId },
+    });
+    syncArmed = true;
+    return {
+      message: `Workflow ${workflow.name} queued (run ${runId}).`,
+      details: {
+        action: "start",
+        workflow: workflow.name,
+        runId,
+        source: workflowSource,
+        queued: true,
+      },
+    };
+  };
+
+  const activatePreparedLaunch = async (
+    ctx: ExtensionContext,
+    prepared: WorkflowRunQueueRecord,
+  ): Promise<boolean> => {
+    const queue = ensureRunQueueStore(ctx.cwd);
+    const claimToken = randomUUID();
+    const claimed = queue.claimWorkflowRun({
+      runId: prepared.runId,
+      runnerId,
+      claimToken,
+      leaseMs: RUN_CLAIM_LEASE_MS,
+    });
+    if (claimed === undefined) return false;
+    try {
+      const resolved = await resolveWorkflowRef(
+        claimed.workflowSourceRef,
+        { cwd: ctx.cwd },
+        builtinWorkflowCatalog,
+      );
+      const snapshot = createDefinitionSnapshot(resolved.definition);
+      if (
+        !isDeepStrictEqual(
+          launchSourceIdentity(resolved.definition, resolved.source),
+          claimed.workflowSource,
+        ) ||
+        definitionDigest(snapshot) !== claimed.definitionDigest
+      ) {
+        throw new Error("Workflow source changed after the launch was queued");
+      }
+      const launchOptions = parsePreparedLaunchOptions(claimed.launchOptions);
+      const started = await startRun(ctx, claimed.workflowSourceRef, claimed.input, {
+        ...launchOptions,
+        runId: claimed.runId,
+        claimToken,
+      });
+      if (started === undefined) throw new Error("The queued workflow could not start");
+      if (launchOptions.parentRunId !== undefined) lastWaitingRunId = null;
+      return true;
+    } catch (error) {
+      const safe = safeLaunchError(error);
+      queue.failWorkflowRun({
+        runId: claimed.runId,
+        claimToken,
+        errorCode: safe.code,
+        errorMessage: safe.message,
+      });
+      recordRunEvent({
+        runId: claimed.runId,
+        workflowRef: claimed.workflowName,
+        type: "launch_failed",
+        payload: { errorCode: safe.code, error: safe.message },
+      });
+      const content = `Workflow ${claimed.workflowName} failed to start (run ${claimed.runId}): ${safe.message}. Inspect the error and call workflow start again only after you correct the cause.`;
+      try {
+        queue.enqueueWorkflowNotification({
+          runId: claimed.runId,
+          nodeId: "$launch",
+          attemptId: claimed.runId,
+          notificationIndex: 1,
+          targetSessionId: claimed.originSessionId ?? ctx.sessionManager.getSessionId(),
+          kind: "launch_failure",
+          content,
+          notificationId: `launch-failure:${claimed.runId}`,
+        });
+      } catch {
+        // A deterministic notification id makes duplicate insertion harmless.
+      }
+      notify(ctx, content, "error");
+      runSyncPass(ctx);
+      return false;
+    }
+  };
+
+  activationRecovery = (ctx) => {
+    if (activeRun !== null) return;
+    const prepared = ensureRunQueueStore(ctx.cwd).findSessionReservation(
+      ctx.sessionManager.getSessionId(),
+    );
+    if (prepared !== undefined && ["queued", "starting"].includes(prepared.status)) {
+      void activatePreparedLaunch(ctx, prepared).catch(() => undefined);
     }
   };
 
@@ -2218,7 +2454,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           control = resumeWorkflowControl(ctx);
           break;
         case "cancel":
-          control = await cancelWorkflowControl(ctx);
+          control = await cancelWorkflowControl(ctx, params.runId);
           break;
         case "answer": {
           const waiting = await resolveWaitingWorkflow(ctx, params.runId);
@@ -2348,7 +2584,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
       notify(ctx, `Could not recover human decisions: ${errorMessage(error)}`, "warning");
     }
     try {
-      await resumeParkedRun(ctx);
+      const prepared = ensureRunQueueStore(ctx.cwd).findSessionReservation(
+        ctx.sessionManager.getSessionId(),
+      );
+      if (prepared !== undefined && ["queued", "starting"].includes(prepared.status)) {
+        await activatePreparedLaunch(ctx, prepared);
+      } else {
+        await resumeParkedRun(ctx);
+      }
     } catch (error) {
       notify(ctx, `Could not resume a parked workflow: ${errorMessage(error)}`, "warning");
     }
@@ -2443,20 +2686,23 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", async (_event, ctx) => {
-    if (activeRun === null && pendingToolLaunch !== null) {
-      const launch = pendingToolLaunch;
-      pendingToolLaunch = null;
+    if (activeRun === null) {
       try {
-        const runId = await startRun(launch.ctx, launch.ref, launch.input, launch.options);
-        if (runId === undefined) {
-          notify(launch.ctx, "The queued workflow could not start.", "error");
-        } else if (launch.options?.parentRunId !== undefined) {
-          lastWaitingRunId = null;
+        const prepared = ensureRunQueueStore(ctx.cwd).findSessionReservation(
+          ctx.sessionManager.getSessionId(),
+        );
+        if (prepared !== undefined && ["queued", "starting"].includes(prepared.status)) {
+          await activatePreparedLaunch(ctx, prepared);
+          return;
         }
       } catch (error) {
-        notify(launch.ctx, `Could not start queued workflow: ${errorMessage(error)}`, "error");
+        notify(
+          ctx,
+          `Could not activate a queued workflow: ${safeLaunchError(error).message}`,
+          "warning",
+        );
+        return;
       }
-      return;
     }
     const run = activeRun;
     if (!run) {
@@ -2486,7 +2732,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
     await run?.recorder?.stop().catch(() => undefined);
     await run?.completion?.catch(() => undefined);
     activeRun = null;
-    pendingToolLaunch = null;
     lastWaitingRunId = null;
     if (runSyncTimer !== null) {
       clearInterval(runSyncTimer);

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -289,6 +289,9 @@ export class WorkflowHost {
         },
       },
     });
+    if (!store.markWorkflowRunRunning({ runId, claimToken })) {
+      throw new ClaimLostError(runId);
+    }
     const parkEngine = () => engine.park();
     this.parkedEngines.push(parkEngine);
 

--- a/src/workflows/migrate-sources.ts
+++ b/src/workflows/migrate-sources.ts
@@ -24,7 +24,11 @@ export type LegacySourceMigrationQueue = {
     leaseMs: number;
   }): boolean;
   parkWorkflowRun(options: { runId: string; claimToken: string }): boolean;
-  getWorkflowRun(runId: string): { status: "claimed" | "parked" | "done" } | undefined;
+  getWorkflowRun(runId: string):
+    | {
+        status: "queued" | "starting" | "running" | "parked" | "done" | "failed" | "cancelled";
+      }
+    | undefined;
   setWorkflowRunOriginSession?(runId: string, originSessionId: string): boolean;
 };
 

--- a/src/workflows/tool-input.ts
+++ b/src/workflows/tool-input.ts
@@ -11,7 +11,7 @@ const inputSchema = Type.Unknown({
   description: "Checkpoint answer for answer; optional structured workflow input for start",
 });
 const runIdSchema = Type.String({
-  description: "Run id; optional for status and answer",
+  description: "Run id; optional for status, cancel, and answer",
 });
 const stepSchema = Type.String({
   description: "Workflow step id; required when action is update or submit",
@@ -50,7 +50,10 @@ export const WorkflowActionSchemas = {
   ),
   pause: Type.Object({ action: Type.Literal("pause") }, noExtraProperties),
   resume: Type.Object({ action: Type.Literal("resume") }, noExtraProperties),
-  cancel: Type.Object({ action: Type.Literal("cancel") }, noExtraProperties),
+  cancel: Type.Object(
+    { action: Type.Literal("cancel"), runId: Type.Optional(runIdSchema) },
+    noExtraProperties,
+  ),
   answer: Type.Object(
     {
       action: Type.Literal("answer"),

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -164,6 +164,16 @@ export default defineWorkflow({
 });
 `;
 
+const DURABLE_LAUNCH_WORKFLOW = `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "durable-launch-e2e",
+  startAt: "finish",
+  nodes: { finish: compute({ run: ({ input }) => ({ input, recovered: true }) }) },
+  edges: [],
+});
+`;
+
 const E2E_WORKFLOW = `import { agent, decision, decisionEdge, defineWorkflow, shell } from "@osolmaz/pi-workflows";
 
 const choices = ["y", "n"] as const;
@@ -290,6 +300,32 @@ async function waitForCondition(
   }
 }
 
+async function waitForQueueRecord(
+  controllerFile: string,
+  predicate: (record: ReturnType<SqliteControllerStore["getWorkflowRun"]>) => boolean,
+  onTimeout: () => string,
+  timeoutMs = 15_000,
+): Promise<NonNullable<ReturnType<SqliteControllerStore["getWorkflowRun"]>>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    try {
+      const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+      try {
+        const record = store
+          .listWorkflowRuns()
+          .find((candidate) => candidate.workflowName === "durable-launch-e2e");
+        if (predicate(record)) return record as NonNullable<typeof record>;
+      } finally {
+        store.close();
+      }
+    } catch {
+      // The queue file may not exist yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`Timed out waiting for workflow queue state.\n${onTimeout()}`);
+}
+
 async function waitForRunState(
   runsDir: string,
   predicate: (state: WorkflowRunState) => boolean,
@@ -335,6 +371,21 @@ describe.sequential("pi-workflows end to end", () => {
       ({ lastUserText, lastRole }) => {
         if (lastUserText.includes("Presentation instructions:")) {
           return { kind: "text", text: "Implemented the boring, proven design." };
+        }
+        if (
+          lastRole === "user" &&
+          (lastUserText === "Start the durable launch fixture now." ||
+            lastUserText === "Start the repaired durable launch fixture now.")
+        ) {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "start",
+              workflow: "durable-launch-e2e",
+              input: { task: lastUserText },
+            },
+          };
         }
         if (lastRole === "user" && lastUserText === "Start the built-in monitor now.") {
           return {
@@ -513,6 +564,11 @@ describe.sequential("pi-workflows end to end", () => {
       "utf8",
     );
     await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "durable-launch-e2e.workflow.ts"),
+      DURABLE_LAUNCH_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "human-decision-e2e.workflow.ts"),
       HUMAN_DECISION_E2E_WORKFLOW,
       "utf8",
@@ -583,6 +639,68 @@ describe.sequential("pi-workflows end to end", () => {
     await pi?.stop();
     await mock?.close();
   });
+
+  it("persists a model-started run, reports deferred failure, and accepts a corrected start", async () => {
+    const workflowFile = path.join(
+      projectDir,
+      ".pi",
+      "workflows",
+      "durable-launch-e2e.workflow.ts",
+    );
+    const requestsBeforeLaunch = mock.requests.length;
+    pi.send({
+      id: "durable-launch-broken",
+      type: "prompt",
+      message: "Start the durable launch fixture now.",
+    });
+
+    const queued = await waitForQueueRecord(
+      controllerFile,
+      (record) => record?.status === "queued",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await fs.unlink(workflowFile);
+    const failed = await waitForQueueRecord(
+      controllerFile,
+      (record) => record?.runId === queued.runId && record.status === "failed",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    expect(failed.errorMessage).toContain("workflow");
+
+    await waitForCondition(
+      () => pi.stdoutLines.some((line) => line.includes("failed to start")),
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () => mock.requests.length >= requestsBeforeLaunch + 3,
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+
+    await fs.writeFile(workflowFile, DURABLE_LAUNCH_WORKFLOW, "utf8");
+    pi.send({
+      id: "durable-launch-repaired",
+      type: "prompt",
+      message: "Start the repaired durable launch fixture now.",
+    });
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "durable-launch-e2e" && candidate.status === "completed",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    expect(state.input).toEqual({ task: "Start the repaired durable launch fixture now." });
+
+    const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+    try {
+      const records = store
+        .listWorkflowRuns()
+        .filter((record) => record.workflowName === "durable-launch-e2e");
+      expect(records.map((record) => record.status).sort()).toEqual(["done", "failed"]);
+      expect(records[0]?.runId).not.toBe(records[1]?.runId);
+    } finally {
+      store.close();
+    }
+  }, 60_000);
 
   it("runs a directly imported child in one real Pi workflow run", async () => {
     pi.send({

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -224,10 +224,7 @@ function makeHarness(options: {
         message,
         ...(messageOptions === undefined ? {} : { options: messageOptions }),
       });
-      if (
-        message.customType === "pi-workflows-agent-step" &&
-        messageOptions?.triggerTurn === true
-      ) {
+      if (messageOptions?.triggerTurn === true) {
         idle = false;
         queueMicrotask(() => options.respond(message.content, tool as RegisteredTool));
       }
@@ -924,7 +921,7 @@ describe("pi-workflows extension", () => {
     }
   });
 
-  it("reserves one model-started workflow while it validates", async () => {
+  it("reserves one model-started workflow after validation", async () => {
     const cwd = await makeTempDir("pi-workflows-tool-start-reservation");
     await writeEchoWorkflow(cwd);
     const harness = makeHarness({ cwd, respond: () => {} });
@@ -951,12 +948,194 @@ describe("pi-workflows extension", () => {
     const cancelled = await harness.tool.execute("cancel-pending", { action: "cancel" });
     expect(cancelled.details).toMatchObject({ action: "cancel", workflow: "mini", queued: false });
 
-    const validating = harness.tool.execute("start-cancelled", {
+    const queuedAgain = await harness.tool.execute("start-cancelled", {
       action: "start",
       workflow: "mini",
     });
-    await harness.tool.execute("cancel-validating", { action: "cancel" });
-    await expect(validating).rejects.toThrow(/cancelled before validation finished/);
+    await expect(
+      harness.tool.execute("cancel-validating", {
+        action: "cancel",
+        runId: queuedAgain.details.runId as string,
+      }),
+    ).resolves.toMatchObject({ details: { queued: false } });
+  });
+
+  it("recovers a prepared run after the initiating Pi session restarts", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-launch-restart");
+    const runsDir = await makeTempDir("pi-workflows-tool-launch-restart-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const first = makeHarness({ cwd, sessionId: "restart-session", respond: () => {} });
+      const queued = await first.tool.execute("start-before-restart", {
+        action: "start",
+        workflow: "mini",
+      });
+      const runId = queued.details.runId;
+      expect(typeof runId).toBe("string");
+      const queueFile = projectControllerStorePath(cwd);
+      const queue = new SqliteControllerStore(queueFile);
+      try {
+        expect(
+          queue.claimWorkflowRun({
+            runId: runId as string,
+            runnerId: "stopped-runner",
+            claimToken: "stopped-claim",
+            leaseMs: 60_000,
+          })?.status,
+        ).toBe("starting");
+      } finally {
+        queue.close();
+      }
+      await first.emitAsync("session_shutdown");
+
+      const second = makeHarness({ cwd, sessionId: "restart-session", respond: () => {} });
+      await second.emitAsync("session_start");
+      const { default: Database } = await import("better-sqlite3");
+      const raw = new Database(queueFile);
+      raw.prepare("UPDATE workflow_run_queue SET claim_expires_at = 1 WHERE run_id = ?").run(runId);
+      raw.close();
+      await waitFor(
+        () =>
+          second.sentMessages.some(
+            (entry) => entry.message.customType === "pi-workflows-agent-step",
+          ),
+        10_000,
+      );
+      const status = await second.tool.execute("status-after-restart", {
+        action: "status",
+        runId: runId as string,
+      });
+      expect(status.details).toMatchObject({ runId, status: "running" });
+      await second.emitAsync("session_shutdown");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("rejects a queued launch when an included workflow source changes", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-launch-include");
+    const workflowDir = path.join(cwd, ".pi", "workflows");
+    await fs.mkdir(workflowDir, { recursive: true });
+    const childPath = path.join(workflowDir, "launch-child.workflow.ts");
+    await fs.writeFile(
+      childPath,
+      `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  source: import.meta.url,
+  name: "launch-child",
+  input: (value) => value,
+  startAt: "work",
+  exits: { ready: { from: "work" } },
+  nodes: { work: compute({ run: () => ({ version: 1 }) }) },
+  edges: [],
+});
+`,
+    );
+    await fs.writeFile(
+      path.join(workflowDir, "launch-parent.workflow.ts"),
+      `import { compute, defineWorkflow, includeWorkflow } from "@osolmaz/pi-workflows";
+import child from "./launch-child.workflow.ts";
+export default defineWorkflow({
+  source: import.meta.url,
+  name: "launch-parent",
+  startAt: "start",
+  includes: { child: includeWorkflow(child, { input: ({ outputs }) => outputs.start }) },
+  nodes: {
+    start: compute({ run: ({ input }) => input }),
+    finish: compute({ run: ({ outputs }) => outputs.child }),
+  },
+  edges: [
+    { from: "start", to: "child" },
+    { from: "child.ready", to: "finish" },
+  ],
+});
+`,
+    );
+    const harness = makeHarness({ cwd, respond: () => {} });
+    await harness.emitAsync("session_start");
+    const queued = await harness.tool.execute("start-included", {
+      action: "start",
+      workflow: "launch-parent",
+    });
+    await fs.writeFile(
+      childPath,
+      (await fs.readFile(childPath, "utf8")).replace("version: 1", "version: 2"),
+    );
+    await harness.emitAsync("agent_settled");
+    const status = await harness.tool.execute("status-included", {
+      action: "status",
+      runId: queued.details.runId as string,
+    });
+    expect(status.details).toMatchObject({ status: "failed", errorCode: "source_changed" });
+  });
+
+  it("reports a deferred launch failure and lets the model start a corrected run", async () => {
+    const cwd = await makeTempDir("pi-workflows-tool-launch-recovery");
+    const runsDir = await makeTempDir("pi-workflows-tool-launch-recovery-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({ cwd, respond: () => {} });
+      await harness.emitAsync("session_start");
+
+      const queued = await harness.tool.execute("start-broken", {
+        action: "start",
+        workflow: "mini",
+        input: { task: "first" },
+      });
+      expect(queued.details).toMatchObject({ action: "start", queued: true });
+      const firstRunId = queued.details.runId;
+      expect(typeof firstRunId).toBe("string");
+      await fs.unlink(path.join(cwd, ".pi", "workflows", "mini.workflow.ts"));
+
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) =>
+            entry.message.customType === "pi-workflows-notification" &&
+            entry.message.details?.kind === "launch_failure",
+        ),
+      );
+      const failureMessages = harness.sentMessages.filter(
+        (entry) => entry.message.details?.kind === "launch_failure",
+      );
+      expect(failureMessages).toHaveLength(1);
+      expect(failureMessages[0]).toMatchObject({
+        options: { triggerTurn: true, deliverAs: "followUp" },
+        message: { content: expect.stringContaining("failed to start") },
+      });
+
+      const failed = await harness.tool.execute("status-failed-launch", {
+        action: "status",
+        runId: firstRunId as string,
+      });
+      expect(failed.details).toMatchObject({
+        runId: firstRunId,
+        status: "failed",
+        errorCode: "activation_failed",
+      });
+
+      await writeEchoWorkflow(cwd);
+      const corrected = await harness.tool.execute("start-corrected", {
+        action: "start",
+        workflow: "mini",
+        input: { task: "second" },
+      });
+      expect(corrected.details.runId).not.toBe(firstRunId);
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-agent-step",
+        ),
+      );
+      await harness.emitAsync("agent_settled");
+      expect(
+        harness.sentMessages.filter((entry) => entry.message.details?.kind === "launch_failure"),
+      ).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("bounds failed-run errors returned by workflow status", async () => {
@@ -1780,12 +1959,12 @@ export default defineWorkflow({
       const command = harness.commands.get("workflow");
       await command?.handler("slow", harness.ctx);
 
-      // Wait for the run to be claimed and the node to be in flight.
+      // Wait for the run to be running and the node to be in flight.
       const queueFile = projectControllerStorePath(cwd);
       await waitFor(() => {
         const reader = new SqliteControllerStore(queueFile, { readOnly: true });
         try {
-          return reader.listWorkflowRuns()[0]?.status === "claimed";
+          return reader.listWorkflowRuns()[0]?.status === "running";
         } finally {
           reader.close();
         }
@@ -1861,7 +2040,7 @@ export default defineWorkflow({
         expect(rows.every((row) => row.status === "done")).toBe(true);
         const [parent, child] = rows;
         expect(child?.parentRunId).toBe(parent?.runId);
-        expect(child?.input).toEqual({ approved: true });
+        expect(child?.input).toBeNull();
       } finally {
         queue.close();
       }
@@ -2277,7 +2456,7 @@ export default defineWorkflow({
       await waitFor(() => {
         const reader = new SqliteControllerStore(queueFile, { readOnly: true });
         try {
-          return reader.listWorkflowRuns()[0]?.status === "claimed";
+          return reader.listWorkflowRuns()[0]?.status === "running";
         } finally {
           reader.close();
         }
@@ -2287,11 +2466,11 @@ export default defineWorkflow({
       const { default: Database } = await import("better-sqlite3");
       const raw = new Database(queueFile);
       raw
-        .prepare("UPDATE workflow_run_queue SET claim_expires_at = 1 WHERE status = 'claimed'")
+        .prepare("UPDATE workflow_run_queue SET claim_expires_at = 1 WHERE status = 'running'")
         .run();
       raw
         .prepare(
-          "UPDATE workflow_run_queue SET runner_id = 'other', claim_token = 'other-token', claim_expires_at = 9999999999999 WHERE status = 'claimed'",
+          "UPDATE workflow_run_queue SET runner_id = 'other', claim_token = 'other-token', claim_expires_at = 9999999999999 WHERE status = 'running'",
         )
         .run();
       raw.close();
@@ -2508,7 +2687,7 @@ export default defineWorkflow({
         // The fallback continued the second (unanswered) parent.
         const parents = rows.filter((row) => row.parentRunId === null);
         expect(continuations[1]?.parentRunId).toBe(parents[1]?.runId);
-        expect(continuations[1]?.input).toEqual({ round: 2 });
+        expect(continuations[1]?.input).toBeNull();
       } finally {
         queue.close();
       }
@@ -2620,7 +2799,7 @@ export default defineWorkflow({
         const raw = new Database(queueFile);
         raw
           .prepare(
-            "UPDATE workflow_run_queue SET status = 'claimed', runner_id = 'dead-runner', claim_token = 'stale-token', claim_expires_at = 1 WHERE run_id = ?",
+            "UPDATE workflow_run_queue SET status = 'running', runner_id = 'dead-runner', claim_token = 'stale-token', claim_expires_at = 1 WHERE run_id = ?",
           )
           .run(runId);
         raw.close();

--- a/test/migrate-sources.test.ts
+++ b/test/migrate-sources.test.ts
@@ -228,7 +228,7 @@ describe("migrateLegacyWorkflowSources", () => {
     const result = await migrateLegacyWorkflowSources({ catalog: catalog(), store, queue });
 
     expect(result.blocked).toEqual([]);
-    expect(queue.getWorkflowRun("live-owner-run")?.status).toBe("claimed");
+    expect(queue.getWorkflowRun("live-owner-run")?.status).toBe("starting");
     queue.close();
   });
 

--- a/test/run-queue.test.ts
+++ b/test/run-queue.test.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { SqliteControllerStore } from "../src/controllers/sqlite.js";
 import { makeTempDir } from "./helpers.js";
@@ -37,6 +39,42 @@ function enqueue(store: SqliteControllerStore, runId = "run-1") {
 }
 
 describe("workflow run queue", () => {
+  it("rejects an incompatible older alpha layout without changing it", async () => {
+    const dir = await makeTempDir("pi-run-queue-old-alpha");
+    const databasePath = path.join(dir, "state", "controller.sqlite");
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const raw = new Database(databasePath);
+    raw.exec(`
+      CREATE TABLE schema_info (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        schema_id TEXT NOT NULL
+      );
+      INSERT INTO schema_info (singleton, schema_id)
+      VALUES (1, 'pi-workflows.controller-store.v1');
+      CREATE TABLE workflow_run_queue (
+        run_id TEXT PRIMARY KEY,
+        workflow_ref TEXT NOT NULL,
+        workflow_path TEXT NOT NULL,
+        input_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    raw.close();
+
+    expect(() => new SqliteControllerStore(databasePath)).toThrow(
+      /incompatible alpha layout.*reset the project controller store/,
+    );
+    const unchanged = new Database(databasePath, { readonly: true });
+    try {
+      const columns = unchanged.pragma("table_info(workflow_run_queue)") as { name: string }[];
+      expect(columns.map((column) => column.name)).not.toContain("workflow_source_json");
+    } finally {
+      unchanged.close();
+    }
+  });
+
   it("inserts and claims a run atomically", async () => {
     const store = await makeStore();
     const record = enqueue(store);
@@ -44,7 +82,7 @@ describe("workflow run queue", () => {
       runId: "run-1",
       workflowName: "summarize",
       input: { task: "hello" },
-      status: "claimed",
+      status: "starting",
       runnerId: "runner-a",
       claimToken: "token-a",
       affinityRunnerId: "runner-a",
@@ -62,6 +100,118 @@ describe("workflow run queue", () => {
         now: T0,
       }),
     ).toBeUndefined();
+  });
+
+  it("persists a prepared run before activation and releases the reservation on failure", async () => {
+    const store = await makeStore();
+    const prepared = store.reserveWorkflowRun({
+      runId: "prepared-1",
+      workflowName: "summarize",
+      workflowSourceRef: "/project/.pi/workflows/summarize.workflow.ts",
+      workflowSource: { kind: "file", path: "/project/summarize.workflow.ts", hash: "abc" },
+      definitionDigest: "sha256:abc",
+      input: { secretMarker: "private-input" },
+      launchOptions: { presentation: false },
+      runnerId: "runner-a",
+      originSessionId: "session-a",
+      now: T0,
+    });
+    expect(prepared).toMatchObject({
+      runId: "prepared-1",
+      status: "queued",
+      originSessionId: "session-a",
+      definitionDigest: "sha256:abc",
+      launchOptions: { presentation: false },
+    });
+    expect(store.findSessionReservation("session-a")?.runId).toBe("prepared-1");
+
+    const claimed = store.claimWorkflowRun({
+      runId: "prepared-1",
+      runnerId: "runner-a",
+      claimToken: "claim-a",
+      leaseMs: 1_000,
+      now: T1,
+    });
+    expect(claimed?.status).toBe("starting");
+    expect(
+      store.failWorkflowRun({
+        runId: "prepared-1",
+        claimToken: "claim-a",
+        errorCode: "workflow_not_found",
+        errorMessage: "Workflow source is missing",
+        now: T2,
+      }),
+    ).toBe(true);
+    expect(store.getWorkflowRun("prepared-1")).toMatchObject({
+      status: "failed",
+      input: null,
+      launchOptions: {},
+      errorCode: "workflow_not_found",
+      errorMessage: "Workflow source is missing",
+      finishedAt: T2,
+    });
+    expect(store.findSessionReservation("session-a")).toBeUndefined();
+  });
+
+  it("keeps an unactivated starting run out of detached host recovery", async () => {
+    const store = await makeStore();
+    store.reserveWorkflowRun({
+      runId: "prepared-1",
+      workflowName: "summarize",
+      workflowSourceRef: "/project/summarize.workflow.ts",
+      workflowSource: { kind: "file", path: "/project/summarize.workflow.ts", hash: "abc" },
+      definitionDigest: "sha256:abc",
+      input: {},
+      runnerId: "runner-a",
+      originSessionId: "session-a",
+      now: T0,
+    });
+    store.claimWorkflowRun({
+      runId: "prepared-1",
+      runnerId: "runner-a",
+      claimToken: "claim-a",
+      leaseMs: 1_000,
+      now: T0,
+    });
+
+    expect(
+      store.claimNextWorkflowRun({
+        runnerId: "detached-host",
+        claimToken: "host-claim",
+        leaseMs: 1_000,
+        now: T2,
+      }),
+    ).toBeUndefined();
+    expect(
+      store.claimNextWorkflowRun({
+        runnerId: "session-runner",
+        claimToken: "session-claim",
+        leaseMs: 1_000,
+        sessionId: "session-a",
+        now: T2,
+      })?.runId,
+    ).toBe("prepared-1");
+  });
+
+  it("cancels a prepared run and permits another session reservation", async () => {
+    const store = await makeStore();
+    const reserve = (runId: string) =>
+      store.reserveWorkflowRun({
+        runId,
+        workflowName: "summarize",
+        workflowSourceRef: "/project/summarize.workflow.ts",
+        workflowSource: { kind: "file", path: "/project/summarize.workflow.ts", hash: "abc" },
+        definitionDigest: "sha256:abc",
+        input: {},
+        runnerId: "runner-a",
+        originSessionId: "session-a",
+        now: T0,
+      });
+    reserve("prepared-1");
+    expect(() => reserve("prepared-2")).toThrow(/UNIQUE constraint/);
+    expect(store.cancelWorkflowRun({ runId: "prepared-1", now: T1 })).toBe(true);
+    expect(store.getWorkflowRun("prepared-1")?.status).toBe("cancelled");
+    expect(reserve("prepared-2").status).toBe("queued");
   });
 
   it("restricts session-bound runs to their origin session", async () => {
@@ -235,7 +385,7 @@ describe("workflow run queue", () => {
     ).toBe(true);
     expect(store.getWorkflowRun(record.runId)).toMatchObject({
       workflowSourceRef: "builtin:summarize",
-      status: "claimed",
+      status: "starting",
       runnerId: "migration",
       claimToken: "migration-token",
     });
@@ -393,7 +543,7 @@ describe("workflow run queue", () => {
     });
     expect(claimed).toMatchObject({
       runId: "run-1",
-      status: "claimed",
+      status: "starting",
       runnerId: "runner-b",
       claimToken: "token-b",
     });

--- a/test/workflow-tool-input.test.ts
+++ b/test/workflow-tool-input.test.ts
@@ -23,6 +23,7 @@ describe("workflow tool input", () => {
     { action: "pause" },
     { action: "resume" },
     { action: "cancel" },
+    { action: "cancel", runId: "run-1" },
     { action: "answer", input: { approved: true } },
     { action: "answer", input: null, runId: "run-1" },
     { action: "update", step: "check", attempt: "try-1", update },


### PR DESCRIPTION
> Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A workflow could report that it was queued and then disappear when deferred startup failed.
This change saves the final run ID before the current agent turn ends, records startup failures, and gives the model one follow-up turn to correct the cause and try again.
It also makes queued runs inspectable and cancellable before a run bundle exists.

## What Changed

Model-started workflows now use the existing SQLite controller store as the source of truth from the first acknowledgement.
Activation waits for `agent_settled`, uses claimed state transitions, and cannot release two executors for one reservation.

- Added explicit `queued`, `starting`, `running`, `failed`, and `cancelled` launch states.
- Persisted the workflow source identity, definition digest, private input, launch options, safe error, and lifecycle times.
- Returned the final run ID in the queued tool result.
- Added status and cancellation by run ID before engine startup.
- Added durable launch-failure notifications through `pi.sendMessage` with one follow-up turn.
- Added restart recovery, lease fencing, and corrected-start behavior.
- Removed the volatile `pendingToolLaunch` path.
- Kept current alpha schema identifiers and reject incompatible older alpha layouts with a reset instruction.

## Testing

The full unit, coverage, build, lint, type, and real Pi E2E gates pass.
The E2E test uses the packaged extension and mock provider to delete a workflow after acknowledgement, observe the model-visible failure, restore the workflow, and start a corrected run.

- `npm run check` — 67 files and 925 tests passed with coverage
- `npm run test:e2e` — 3 files and 15 real Pi E2E tests passed
- `npx slophammer-ts@latest dry .` — passed
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — passed
- `git diff --check` — passed

SimpleDoc still reports existing naming and frontmatter debt in unrelated documents. This change does not modify those files.

## Risks

The project is in alpha and this is a hard storage cutover.
Existing controller stores with the older alpha table layout are rejected instead of migrated or deleted.
Run bundles remain separate and are not removed by a controller-store reset.

The follow-up contains only a bounded safe error and run identity. Raw workflow input, prompts, credentials, request headers, and stack traces are not sent.
