### PR TITLE
refactor: use pi-workflows in cosmetic names and add README cover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Repository rules:
 
 ## Alpha compatibility policy
 
-Pi Workflows is in alpha. Until the repository explicitly leaves alpha:
+pi-workflows is in alpha. Until the repository explicitly leaves alpha:
 
 - Do not preserve backward compatibility unless the user explicitly requires it for a task.
 - Change persisted schemas and public contracts in place. Keep their current version identifiers.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pi-workflows
 
 <p align="center">
-  <img src="assets/cover.svg" alt="pi-workflows: a TypeScript workflow graph goes in, a live multi-step agent run comes out" width="880">
+  <img src="assets/cover.svg" alt="pi-workflows: a representative multi-step workflow graph with plan, implement, verify, review, a fix loop, and a clean finish" width="880">
 </p>
 
 pi-workflows is a workflow extension for the [pi coding agent](https://pi.dev).

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ example set. Copy any of them into `.pi/workflows/` to use them:
   a detailed implementation plan, using the ideal end state as guidance rather
   than an out-of-scope requirement.
 - `autoimplement` finds a clear existing plan, documents it when needed,
-  implements and verifies it, writes and runs the exact Pi Reviewer command,
+  implements and verifies it, writes and runs the exact pi-reviewer command,
   tracks P0 through P2, handles PR comments and CI, and
   finalizes the PR. P0 and P1 fixes require another review. P2-only work is
   verified without another reviewer round. A five-minute CI wait routes to

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pi-workflows
 
+<p align="center">
+  <img src="assets/cover.svg" alt="pi-workflows: a TypeScript workflow graph goes in, a live multi-step agent run comes out" width="880">
+</p>
+
 pi-workflows is a workflow extension for the [pi coding agent](https://pi.dev).
 It lets you define multi-step agent workflows as TypeScript graphs, trigger
 them at any point in a pi conversation with `/workflow`, and watch them run
@@ -76,14 +80,14 @@ or run it in place with `npx tsx src/viewer/cli.ts`.
 
 ## Herdr integration
 
-Pi Workflows also ships as a [Herdr](https://herdr.dev) plugin. After installing
-`piw` and Pi Workflows, synchronize the bundled plugin:
+pi-workflows also ships as a [Herdr](https://herdr.dev) plugin. After installing
+`piw` and pi-workflows, synchronize the bundled plugin:
 
 ```bash
 pi-workflows herdr sync
 ```
 
-Run the same command after a Pi Workflows update. It finds the package that
+Run the same command after a pi-workflows update. It finds the package that
 provides the running CLI and repairs a Herdr link when npm moved that package.
 `pi-workflows herdr setup` remains an alias for existing installations. Use
 `--json` for versioned machine-readable output. The [Herdr plugin sync
@@ -94,7 +98,7 @@ When Pi runs inside Herdr, a workflow widget shows `Ctrl+Shift+R piw`. When the 
 The shortcut opens the exact run bundle and lets you choose a split, tab, or new
 workspace. `/piw` opens the same menu, and `/piw right`, `/piw below`, `/piw
 left`, `/piw above`, `/piw tab`, or `/piw workspace` selects a placement
-directly. If a viewer for that run already exists, Pi Workflows focuses it
+directly. If a viewer for that run already exists, pi-workflows focuses it
 instead of opening a duplicate.
 
 The plugin uses Herdr's public pane APIs and runs no service or polling loop. It
@@ -130,7 +134,7 @@ Then, from any pi conversation:
 ```
 
 A model-started workflow is saved before the tool reports it as queued. The returned run ID works
-with `workflow status` and `workflow cancel` before execution starts. Pi Workflows waits for the
+with `workflow status` and `workflow cancel` before execution starts. pi-workflows waits for the
 current agent turn to settle before activation. If activation fails, it saves the failure and sends
 one follow-up turn so the model can correct the cause and start a new run.
 
@@ -191,7 +195,7 @@ The model can use the same `workflow` tool to list, start, inspect, pause,
 resume, cancel, and answer workflows. Step contracts use the tool's `submit`
 action. Slash commands and model actions share one lifecycle implementation.
 
-Pi Workflows includes a `monitor` workflow for plain-language requests such as:
+pi-workflows includes a `monitor` workflow for plain-language requests such as:
 
 > Monitor PR 123 every 30 minutes. Report failed checks. Stop when it is merged or closed.
 

--- a/assets/cover.svg
+++ b/assets/cover.svg
@@ -1,11 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" role="img" aria-label="pi-workflows: a TypeScript workflow graph goes in, a live multi-step agent run comes out">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" role="img" aria-label="pi-workflows: multi-step agent workflows with plan, implement, verify, review, a fix loop, and a clean finish">
   <defs>
     <style>
       .mono { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; }
       .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+      .node { fill: #161b22; stroke: #58a6ff; stroke-width: 2; }
+      .nodelabel { fill: #e6edf3; font-size: 12px; font-weight: 700; text-anchor: middle; }
+      .edge { stroke: #8b949e; stroke-width: 2; fill: none; }
     </style>
-    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
       <path d="M0,0 L7,4 L0,8 Z" fill="#8b949e"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L7,4 L0,8 Z" fill="#3fb950"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L7,4 L0,8 Z" fill="#d29922"/>
     </marker>
   </defs>
 
@@ -25,53 +34,38 @@
     </text>
   </g>
 
-  <!-- Middle: workflow graph card -->
-  <g transform="translate(528,58)">
-    <rect width="160" height="204" rx="10" fill="#161b22" stroke="#30363d"/>
-    <circle cx="18" cy="18" r="4" fill="#f85149"/>
-    <circle cx="32" cy="18" r="4" fill="#d29922"/>
-    <circle cx="46" cy="18" r="4" fill="#3fb950"/>
-    <text x="146" y="22" class="mono" font-size="12" fill="#8b949e" text-anchor="end">graph</text>
-    <line x1="0" y1="34" x2="160" y2="34" stroke="#30363d"/>
+  <!-- Right: representative workflow graph -->
+  <g>
+    <!-- main flow: plan -> implement -> verify -->
+    <line class="edge" x1="584" y1="90" x2="651" y2="90" marker-end="url(#arrow)"/>
+    <line class="edge" x1="749" y1="90" x2="810" y2="90" marker-end="url(#arrow)"/>
+    <!-- verify -> review -->
+    <line class="edge" x1="852" y1="104" x2="852" y2="172" marker-end="url(#arrow)"/>
+    <!-- review -> fix -->
+    <line class="edge" x1="818" y1="190" x2="736" y2="190" marker-end="url(#arrow)"/>
+    <!-- fix -> verify (retry loop) -->
+    <path d="M 718,176 Q 776,134 820,109" fill="none" stroke="#d29922" stroke-width="2" stroke-dasharray="5 4" marker-end="url(#arrow-orange)"/>
+    <!-- review -> done (clean path under fix) -->
+    <path d="M 852,204 C 828,250 600,254 558,212" fill="none" stroke="#3fb950" stroke-width="2" marker-end="url(#arrow-green)"/>
+    <text x="707" y="230" class="mono" font-size="11" fill="#3fb950" text-anchor="middle">clean</text>
 
-    <line x1="80" y1="72" x2="46" y2="119" stroke="#30363d" stroke-width="2"/>
-    <line x1="80" y1="72" x2="114" y2="119" stroke="#30363d" stroke-width="2"/>
-    <line x1="46" y1="119" x2="80" y2="166" stroke="#30363d" stroke-width="2"/>
-    <line x1="114" y1="119" x2="80" y2="166" stroke="#30363d" stroke-width="2"/>
+    <!-- nodes -->
+    <rect class="node" x="528" y="76" width="56" height="28" rx="7"/>
+    <text class="mono nodelabel" x="556" y="94">plan</text>
 
-    <circle cx="80" cy="72" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
-    <circle cx="46" cy="119" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
-    <circle cx="114" cy="119" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
-    <circle cx="80" cy="166" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
-  </g>
+    <rect class="node" x="659" y="76" width="90" height="28" rx="7"/>
+    <text class="mono nodelabel" x="704" y="94">implement</text>
 
-  <!-- Arrow (centered in the 56px gap between the cards) -->
-  <line x1="698" y1="160" x2="728" y2="160" stroke="#8b949e" stroke-width="2.5" marker-end="url(#arrowhead)"/>
+    <rect class="node" x="818" y="76" width="68" height="28" rx="7"/>
+    <text class="mono nodelabel" x="852" y="94">verify</text>
 
-  <!-- Right: live run card -->
-  <g transform="translate(744,58)">
-    <rect width="160" height="204" rx="10" fill="#161b22" stroke="#30363d"/>
-    <circle cx="18" cy="18" r="4" fill="#f85149"/>
-    <circle cx="32" cy="18" r="4" fill="#d29922"/>
-    <circle cx="46" cy="18" r="4" fill="#3fb950"/>
-    <text x="146" y="22" class="mono" font-size="12" fill="#8b949e" text-anchor="end">run</text>
-    <line x1="0" y1="34" x2="160" y2="34" stroke="#30363d"/>
+    <rect class="node" x="818" y="176" width="68" height="28" rx="7"/>
+    <text class="mono nodelabel" x="852" y="194">review</text>
 
-    <g class="mono" font-size="13" font-weight="700">
-      <circle cx="24" cy="62" r="10" fill="#238636"/>
-      <text x="24" y="66.5" fill="#0d1117" text-anchor="middle">&#10003;</text>
-      <rect x="44" y="58" width="88" height="8" rx="4" fill="#30363d"/>
+    <rect x="680" y="176" width="48" height="28" rx="7" fill="#161b22" stroke="#d29922" stroke-width="2"/>
+    <text class="mono nodelabel" x="704" y="194">fix</text>
 
-      <circle cx="24" cy="100" r="10" fill="#238636"/>
-      <text x="24" y="104.5" fill="#0d1117" text-anchor="middle">&#10003;</text>
-      <rect x="44" y="96" width="72" height="8" rx="4" fill="#30363d"/>
-
-      <circle cx="24" cy="138" r="10" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
-      <text x="25.5" y="142.5" font-size="10" fill="#79c0ff" text-anchor="middle">&#9654;</text>
-      <rect x="44" y="134" width="80" height="8" rx="4" fill="#30363d"/>
-
-      <circle cx="24" cy="176" r="10" fill="none" stroke="#30363d" stroke-width="2"/>
-      <rect x="44" y="172" width="60" height="8" rx="4" fill="#30363d"/>
-    </g>
+    <rect x="522" y="176" width="68" height="28" rx="7" fill="#161b22" stroke="#3fb950" stroke-width="2"/>
+    <text class="mono nodelabel" x="556" y="194" fill="#3fb950">&#10003; done</text>
   </g>
 </svg>

--- a/assets/cover.svg
+++ b/assets/cover.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 320" role="img" aria-label="pi-workflows: a TypeScript workflow graph goes in, a live multi-step agent run comes out">
+  <defs>
+    <style>
+      .mono { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; }
+      .sans { font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; }
+    </style>
+    <marker id="arrowhead" markerWidth="8" markerHeight="8" refX="6" refY="4" orient="auto">
+      <path d="M0,0 L7,4 L0,8 Z" fill="#8b949e"/>
+    </marker>
+  </defs>
+
+  <rect x="1" y="1" width="958" height="318" rx="16" fill="#0d1117" stroke="#30363d" stroke-width="2"/>
+
+  <!-- Left: name, tagline, command line (content spans y 76-244, centered on 160) -->
+  <g>
+    <text x="56" y="110" class="mono" font-size="46" font-weight="700">
+      <tspan fill="#58a6ff">pi</tspan><tspan fill="#e6edf3">-workflows</tspan>
+    </text>
+    <text x="56" y="148" class="sans" font-size="17" fill="#8b949e">Multi-step agent workflows for the pi coding agent.</text>
+    <text x="56" y="174" class="sans" font-size="17" fill="#8b949e">Define TypeScript graphs, run and watch them live.</text>
+
+    <rect x="56" y="200" width="392" height="44" rx="8" fill="#161b22" stroke="#30363d"/>
+    <text x="74" y="228" class="mono" font-size="15">
+      <tspan fill="#3fb950">$</tspan><tspan fill="#e6edf3" dx="8">pi install npm:@osolmaz/pi-workflows</tspan>
+    </text>
+  </g>
+
+  <!-- Middle: workflow graph card -->
+  <g transform="translate(528,58)">
+    <rect width="160" height="204" rx="10" fill="#161b22" stroke="#30363d"/>
+    <circle cx="18" cy="18" r="4" fill="#f85149"/>
+    <circle cx="32" cy="18" r="4" fill="#d29922"/>
+    <circle cx="46" cy="18" r="4" fill="#3fb950"/>
+    <text x="146" y="22" class="mono" font-size="12" fill="#8b949e" text-anchor="end">graph</text>
+    <line x1="0" y1="34" x2="160" y2="34" stroke="#30363d"/>
+
+    <line x1="80" y1="72" x2="46" y2="119" stroke="#30363d" stroke-width="2"/>
+    <line x1="80" y1="72" x2="114" y2="119" stroke="#30363d" stroke-width="2"/>
+    <line x1="46" y1="119" x2="80" y2="166" stroke="#30363d" stroke-width="2"/>
+    <line x1="114" y1="119" x2="80" y2="166" stroke="#30363d" stroke-width="2"/>
+
+    <circle cx="80" cy="72" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
+    <circle cx="46" cy="119" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
+    <circle cx="114" cy="119" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
+    <circle cx="80" cy="166" r="11" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
+  </g>
+
+  <!-- Arrow (centered in the 56px gap between the cards) -->
+  <line x1="698" y1="160" x2="728" y2="160" stroke="#8b949e" stroke-width="2.5" marker-end="url(#arrowhead)"/>
+
+  <!-- Right: live run card -->
+  <g transform="translate(744,58)">
+    <rect width="160" height="204" rx="10" fill="#161b22" stroke="#30363d"/>
+    <circle cx="18" cy="18" r="4" fill="#f85149"/>
+    <circle cx="32" cy="18" r="4" fill="#d29922"/>
+    <circle cx="46" cy="18" r="4" fill="#3fb950"/>
+    <text x="146" y="22" class="mono" font-size="12" fill="#8b949e" text-anchor="end">run</text>
+    <line x1="0" y1="34" x2="160" y2="34" stroke="#30363d"/>
+
+    <g class="mono" font-size="13" font-weight="700">
+      <circle cx="24" cy="62" r="10" fill="#238636"/>
+      <text x="24" y="66.5" fill="#0d1117" text-anchor="middle">&#10003;</text>
+      <rect x="44" y="58" width="88" height="8" rx="4" fill="#30363d"/>
+
+      <circle cx="24" cy="100" r="10" fill="#238636"/>
+      <text x="24" y="104.5" fill="#0d1117" text-anchor="middle">&#10003;</text>
+      <rect x="44" y="96" width="72" height="8" rx="4" fill="#30363d"/>
+
+      <circle cx="24" cy="138" r="10" fill="#0d419d" stroke="#58a6ff" stroke-width="2"/>
+      <text x="25.5" y="142.5" font-size="10" fill="#79c0ff" text-anchor="middle">&#9654;</text>
+      <rect x="44" y="134" width="80" height="8" rx="4" fill="#30363d"/>
+
+      <circle cx="24" cy="176" r="10" fill="none" stroke="#30363d" stroke-width="2"/>
+      <rect x="44" y="172" width="60" height="8" rx="4" fill="#30363d"/>
+    </g>
+  </g>
+</svg>

--- a/docs/2026-08-18-herdr-piw-plan.md
+++ b/docs/2026-08-18-herdr-piw-plan.md
@@ -8,7 +8,7 @@ date: 2026-08-18
 
 ## Purpose
 
-When Pi Workflows runs inside Herdr, show a shortcut that opens the current run in `piw`. The integration must belong to Pi Workflows and ship as one package, repository, version, and release. The same repository must also qualify for Herdr's public plugin marketplace.
+When pi-workflows runs inside Herdr, show a shortcut that opens the current run in `piw`. The integration must belong to pi-workflows and ship as one package, repository, version, and release. The same repository must also qualify for Herdr's public plugin marketplace.
 
 ## Requirements
 

--- a/docs/2026-08-20-durable-workflow-launch-plan.md
+++ b/docs/2026-08-20-durable-workflow-launch-plan.md
@@ -9,14 +9,14 @@ date: 2026-08-20
 ## Goal
 
 A successful `workflow start` call must create a real queued workflow before it returns. The model
-must receive the final run ID, and Pi Workflows must start that run only after the current agent turn
+must receive the final run ID, and pi-workflows must start that run only after the current agent turn
 settles.
 
-If startup then fails, Pi Workflows must save the failure and start one new model turn with an
+If startup then fails, pi-workflows must save the failure and start one new model turn with an
 actionable error. The model can correct the request and call `workflow start` again. A failed launch
 must release the session reservation so the corrected run can start.
 
-This change stays inside Pi Workflows. It uses the existing project-scoped SQLite controller store
+This change stays inside pi-workflows. It uses the existing project-scoped SQLite controller store
 and documented Pi extension APIs. It does not change Pi, add a service, or add another database.
 
 ## Current failure
@@ -39,7 +39,7 @@ the workflow had started.
 
 Use a durable prepared run and one model-visible failure follow-up.
 
-During the `workflow start` tool call, Pi Workflows will:
+During the `workflow start` tool call, pi-workflows will:
 
 1. Resolve and validate the workflow and all available start conditions.
 2. Allocate the final run ID.
@@ -47,7 +47,7 @@ During the `workflow start` tool call, Pi Workflows will:
 4. Reserve the initiating Pi session.
 5. Return the run ID and say that the workflow is queued.
 
-After the current agent turn settles, Pi Workflows will:
+After the current agent turn settles, pi-workflows will:
 
 1. Claim the queued record.
 2. Change it to `starting`.
@@ -55,7 +55,7 @@ After the current agent turn settles, Pi Workflows will:
 4. Change the record to `running`.
 5. Release the engine to run the first node.
 
-If startup fails, Pi Workflows will:
+If startup fails, pi-workflows will:
 
 1. Change the record to `failed`.
 2. Save a bounded safe error.
@@ -66,11 +66,11 @@ If startup fails, Pi Workflows will:
 
 The new model turn will contain the failed run ID and an actionable error. The model can fix the
 workflow reference, input, source, or local condition and call `workflow start` again. Each retry is
-an explicit model action with a new run ID. Pi Workflows does not perform a blind automatic retry.
+an explicit model action with a new run ID. pi-workflows does not perform a blind automatic retry.
 
 ## Alpha compatibility contract
 
-Pi Workflows is in alpha. Change the current storage and tool contracts in place.
+pi-workflows is in alpha. Change the current storage and tool contracts in place.
 
 - Keep `pi-workflows.controller-store.v1`.
 - Keep existing run-bundle schema identifiers.
@@ -80,7 +80,7 @@ Pi Workflows is in alpha. Change the current storage and tool contracts in place
 - Change the SQLite table definitions and TypeScript types directly.
 - Remove the superseded status values and launch path in the same change.
 
-An existing controller store with the old alpha table layout is incompatible. On open, Pi Workflows
+An existing controller store with the old alpha table layout is incompatible. On open, pi-workflows
 must verify the required table columns and status contract. If the layout is old, it must stop with a
 clear instruction to preserve any needed run evidence and reset the project-scoped controller store.
 It must not silently reinterpret or delete old state.
@@ -150,7 +150,7 @@ Inspect the error and call workflow start again only after you correct the cause
 The message does not contain raw workflow input, prompt text, credentials, request headers, or a
 stack trace.
 
-The failure notification has a deterministic ID derived from the run ID. Pi Workflows records its
+The failure notification has a deterministic ID derived from the run ID. pi-workflows records its
 delivery in the existing notification outbox. Before a delivery retry, it checks the native Pi
 session for that notification ID. This prevents a duplicate after a crash between session append and
 outbox acknowledgement.

--- a/docs/2026-08-20-durable-workflow-launch-plan.md
+++ b/docs/2026-08-20-durable-workflow-launch-plan.md
@@ -433,7 +433,7 @@ npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
 git diff --check
 ```
 
-Run Pi Reviewer against the base branch and fix all valid P0 and P1 findings before release work.
+Run pi-reviewer against the base branch and fix all valid P0 and P1 findings before release work.
 
 Package publication and OnurPi adoption are separate tasks. Do not edit an installed `node_modules`
 copy as the implementation source.

--- a/docs/CONTROLLERS.md
+++ b/docs/CONTROLLERS.md
@@ -1,10 +1,10 @@
 # Controller runtime specification
 
-Pi Workflows runs finite TypeScript graphs. A graph starts with an input, follows explicit edges, and ends with a result or checkpoint. This works well for one bounded task.
+pi-workflows runs finite TypeScript graphs. A graph starts with an input, follows explicit edges, and ends with a result or checkpoint. This works well for one bounded task.
 
 Long-running automation has a different job. It must keep comparing a requested state with the current state of another system. Events can arrive more than once, processes can stop between an external request and its local receipt, and the external state can change while work is running.
 
-This specification adds a Kubernetes-style controller runtime to Pi Workflows. The controller runtime sits beside the graph engine. Controllers manage durable resources, while workflows remain finite jobs that a controller can start and observe.
+This specification adds a Kubernetes-style controller runtime to pi-workflows. The controller runtime sits beside the graph engine. Controllers manage durable resources, while workflows remain finite jobs that a controller can start and observe.
 
 The design follows the Kubernetes [controller pattern](https://kubernetes.io/docs/concepts/architecture/controller/), its [`spec` and `status` split](https://kubernetes.io/docs/concepts/overview/working-with-objects/), and the [idempotent reconciliation guidance](https://book.kubebuilder.io/reference/good-practices).
 

--- a/docs/DESIGN_PHILOSOPHY.md
+++ b/docs/DESIGN_PHILOSOPHY.md
@@ -1,6 +1,6 @@
 # Design philosophy
 
-Pi Workflows should stay small and easy to combine. A small set of clear, general parts should support many kinds of work.
+pi-workflows should stay small and easy to combine. A small set of clear, general parts should support many kinds of work.
 
 ## Primary rule
 

--- a/docs/HUMAN_DECISIONS.md
+++ b/docs/HUMAN_DECISIONS.md
@@ -1,6 +1,6 @@
 # Human decisions
 
-Pi Workflows needs a reusable way to stop at a proposal and wait for a person. The same decision must appear in Pi and Telegram, and either channel must be able to continue the run. Workflows must be able to offer plain choices, choices that collect text, and choices that route back to planning.
+pi-workflows needs a reusable way to stop at a proposal and wait for a person. The same decision must appear in Pi and Telegram, and either channel must be able to continue the run. Workflows must be able to offer plain choices, choices that collect text, and choices that route back to planning.
 
 This document defines that behavior. The implementation is tracked in the [human decision gates plan](plans/2026-08-19-human-decision-gates-plan.md).
 
@@ -197,7 +197,7 @@ Private configuration maps the audience to channels:
 
 The workflow never receives a bot token, user ID, chat ID, Telegram message ID, or Pi session detail. Channel profiles are private host configuration and are excluded from run presentation.
 
-Pi Workflows keeps credential references in a separate private file. A Telegram credential points to an existing absolute mode-`0600` token file:
+pi-workflows keeps credential references in a separate private file. A Telegram credential points to an existing absolute mode-`0600` token file:
 
 ```json
 {
@@ -254,11 +254,11 @@ The adapter does not infer a choice from ordinary chat text. Callback payloads c
 
 Telegram permits one long-polling consumer for a bot profile. Active Pi processes use a shared lease so one process owns polling and the others use the same private channel state. The lease owner can accept a verified reply, but only the Pi session that owns the waiting run creates its continuation. Active sessions inspect the durable accepted-answer fence and recover their own continuation. If no Pi process is running, Telegram delivery and reply collection resume when Pi starts again. Running an always-on service is outside this design.
 
-The Bot API does not provide an idempotency key for `sendMessage`. Pi Workflows therefore writes a delivery intent before sending and never blindly retries an ambiguous send. A timed-out send is recorded as `unknown`; Pi remains available and an operator can request another delivery. This avoids automatic duplicate messages while keeping decision acceptance exactly once.
+The Bot API does not provide an idempotency key for `sendMessage`. pi-workflows therefore writes a delivery intent before sending and never blindly retries an ambiguous send. A timed-out send is recorded as `unknown`; Pi remains available and an operator can request another delivery. This avoids automatic duplicate messages while keeping decision acceptance exactly once.
 
 ## Durable decision records
 
-Decision records live next to workflow run bundles under the Pi Workflows state root. They are additive and linked by run ID. A decision directory contains immutable records for:
+Decision records live next to workflow run bundles under the pi-workflows state root. They are additive and linked by run ID. A decision directory contains immutable records for:
 
 - the request;
 - channel delivery intents and results;
@@ -276,7 +276,7 @@ SQLite may index pending decisions and channel leases, but immutable decision fi
 
 ## Planning workflow composition
 
-Pi Workflows keeps solution choice, documentation, and implementation in separate built-ins:
+pi-workflows keeps solution choice, documentation, and implementation in separate built-ins:
 
 - `autoplan` chooses a solution or revises one after new evidence.
 - `autodoc` records an already selected solution in the canonical specification and implementation plan. It does not choose a solution or implement it.
@@ -290,7 +290,7 @@ If later implementation, verification, review, comments, or CI evidence invalida
 
 ## Reusable plan approval workflow
 
-Pi Workflows ships a typed `plan-approval` workflow built on `humanDecision()`. Its input contains the documented plan, plan digest, audience, and display summary. It has three named exits:
+pi-workflows ships a typed `plan-approval` workflow built on `humanDecision()`. Its input contains the documented plan, plan digest, audience, and display summary. It has three named exits:
 
 - `continue`, with the approval receipt;
 - `stop`, with the stop receipt; and
@@ -345,7 +345,7 @@ The engine remains independent from Pi and Telegram. Core code owns decision con
 - **Other persistent data:** additive decision records, a rebuildable private channel index, and private channel configuration.
 - **Pi internals:** none.
 - **Public Pi API:** documented extension lifecycle and UI methods only.
-- **Public Pi Workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, and the `plan-approval` workflow.
+- **Public pi-workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, and the `plan-approval` workflow.
 
 ## Verification requirements
 

--- a/docs/HUMAN_DECISION_PRESENTATIONS.md
+++ b/docs/HUMAN_DECISION_PRESENTATIONS.md
@@ -7,7 +7,7 @@ The implementation plan is in
 [the human decision presentations plan](plans/2026-08-19-human-decision-presentations-plan.md).
 
 A human decision contains machine data and a separate message for the operator.
-Pi Workflows stores and validates the machine data. Pi and Telegram render only
+pi-workflows stores and validates the machine data. Pi and Telegram render only
 the operator message, and future channels follow the same rule.
 
 ## Minimal example
@@ -229,7 +229,7 @@ text prompt. It wraps and scrolls while responding to resize, theme, cancellatio
 and `AbortSignal` events.
 
 When Telegram or another channel accepts the decision, the signal closes the Pi
-dialog. Pi Workflows does not modify Pi core or use undocumented TUI state.
+dialog. pi-workflows does not modify Pi core or use undocumented TUI state.
 
 ### Other channels
 
@@ -239,7 +239,7 @@ for display.
 
 ## Plan presentation
 
-Pi Workflows provides a reusable plan presenter for built-in workflows. It
+pi-workflows provides a reusable plan presenter for built-in workflows. It
 derives a presentation from the same typed plan stored as the subject.
 
 The presenter uses these sections when data exists:

--- a/docs/MONITOR.md
+++ b/docs/MONITOR.md
@@ -148,9 +148,9 @@ A check may use available tools to read current state. It must use the target's 
 
 ## Progress ownership boundary
 
-The regular Pi model running the check is the observation adapter. It uses the target-specific tools authorized by the task, converts observed facts into `pi-workflows.progress.v1` tracks, and publishes them through the existing `workflow` tool. Pi Workflows validates, stores, estimates, and displays those tracks.
+The regular Pi model running the check is the observation adapter. It uses the target-specific tools authorized by the task, converts observed facts into `pi-workflows.progress.v1` tracks, and publishes them through the existing `workflow` tool. pi-workflows validates, stores, estimates, and displays those tracks.
 
-The monitored target stays independent of Pi Workflows. A monitor must not require a target Job or application to import Pi Workflows, emit a Pi schema, write a Pi progress file, expose a Pi endpoint, create a progress store, or add a progress reader command solely for monitoring. Provider-specific clients and credentials do not belong in Pi Workflows.
+The monitored target stays independent of pi-workflows. A monitor must not require a target Job or application to import pi-workflows, emit a Pi schema, write a Pi progress file, expose a Pi endpoint, create a progress store, or add a progress reader command solely for monitoring. Provider-specific clients and credentials do not belong in pi-workflows.
 
 When a target does not expose a factual count, total, or source estimate, the check reports that ETA is unavailable. Better application telemetry is separate work. It should expose normal operational facts for all operators, not a Pi-specific reporting protocol.
 

--- a/docs/WORKFLOW_COMPOSITION.md
+++ b/docs/WORKFLOW_COMPOSITION.md
@@ -1,6 +1,6 @@
 # Workflow composition
 
-Pi Workflows can include one workflow inside another without copying nodes, prompts, or routing logic. The included workflow still runs on its own. The parent supplies input and connects the included workflow's named exits to later parent steps.
+pi-workflows can include one workflow inside another without copying nodes, prompts, or routing logic. The included workflow still runs on its own. The parent supplies input and connects the included workflow's named exits to later parent steps.
 
 Composition keeps one run, trace, pause state, cancellation state, and final presentation. Controllers remain the correct tool for independent or indefinitely reconciled child runs.
 
@@ -306,7 +306,7 @@ This is a compatible public API addition under the project's pre-1.0 policy. It 
 - **Other persistent data:** additive source and mount data, definition digests, and include events in existing run bundles.
 - **Pi internals:** none.
 - **Public Pi API:** existing extension APIs only.
-- **Public Pi Workflows API:** typed workflow inputs and exits, `includeWorkflow()`, direct imports, dynamic references, and `defineWorkflowRegistry()`.
+- **Public pi-workflows API:** typed workflow inputs and exits, `includeWorkflow()`, direct imports, dynamic references, and `defineWorkflowRegistry()`.
 
 ## Required tests
 

--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -1,6 +1,6 @@
 # Workflow step messages
 
-This specification defines how Pi Workflows shows agent-step instructions in an interactive Pi session. The model receives the complete step prompt, while the user sees a small workflow card that can be expanded.
+This specification defines how pi-workflows shows agent-step instructions in an interactive Pi session. The model receives the complete step prompt, while the user sees a small workflow card that can be expanded.
 
 This contract is implemented for the release after `0.5.3`.
 
@@ -8,7 +8,7 @@ This contract is implemented for the release after `0.5.3`.
 
 Agent-step prompts contain the task, workflow identity, attempt identity, output shape, and submission rules. This information is required by the model, but showing it as a large user message makes the conversation hard to read.
 
-Pi Workflows will send the same prompt as a custom Pi message. A custom renderer will show a compact summary by default and the full content when expanded.
+pi-workflows will send the same prompt as a custom Pi message. A custom renderer will show a compact summary by default and the full content when expanded.
 
 This is a presentation change. It does not add a workflow primitive, change graph execution, or change the step completion contract.
 
@@ -85,7 +85,7 @@ The expanded card shows:
 - expected output
 - full model prompt
 
-Expansion uses Pi's existing custom-message expansion state and keys. Pi Workflows does not add another toggle or store separate expansion state.
+Expansion uses Pi's existing custom-message expansion state and keys. pi-workflows does not add another toggle or store separate expansion state.
 
 ## Reminders and resumes
 
@@ -105,9 +105,9 @@ The two message types must not share delivery code that can accidentally change 
 
 New interactive step deliveries replace `sendUserMessage` with `sendMessage`. Existing session entries remain readable and are not rewritten.
 
-The custom message is a normal documented Pi session message. Pi Workflows adds no Pi session schema, private entry type, or separate persistent store. Run bundles keep the existing full prompt and structured step contract, so this change does not alter the run-bundle schema.
+The custom message is a normal documented Pi session message. pi-workflows adds no Pi session schema, private entry type, or separate persistent store. Run bundles keep the existing full prompt and structured step contract, so this change does not alter the run-bundle schema.
 
-If the renderer is unavailable, Pi still retains the custom message content. Pi Workflows does not add a fallback path that sends a duplicate user message.
+If the renderer is unavailable, Pi still retains the custom message content. pi-workflows does not add a fallback path that sends a duplicate user message.
 
 ## Public API boundary
 

--- a/docs/WORKFLOW_UPDATES.md
+++ b/docs/WORKFLOW_UPDATES.md
@@ -1,6 +1,6 @@
 # Workflow updates
 
-This specification defines durable, non-terminal updates from running Pi Workflows nodes. An update reports current state without finishing a node or choosing a graph route.
+This specification defines durable, non-terminal updates from running pi-workflows nodes. An update reports current state without finishing a node or choosing a graph route.
 
 ## Minimal examples
 
@@ -54,7 +54,7 @@ The `update` tool action does not complete the agent step. The agent still calls
 
 ## Place in the workflow model
 
-Pi Workflows keeps its current node primitives:
+pi-workflows keeps its current node primitives:
 
 - `agent` for model judgment and language work
 - `compute` for pure local calculation
@@ -80,7 +80,7 @@ A node's final result remains the only value that completes the node and control
 
 For monitoring, the regular Pi model running the workflow step observes the external target and publishes progress with the existing `workflow` tool. This is the intended adapter boundary. Deterministic runtime code validates, persists, estimates, and renders the submitted data.
 
-External Jobs and applications do not need a Pi Workflows dependency or reporting protocol. Provider-specific observation stays in the agent task and its authorized tools. If the target does not expose enough facts, the model publishes only what is known and leaves ETA unavailable.
+External Jobs and applications do not need a pi-workflows dependency or reporting protocol. Provider-specific observation stays in the agent task and its authorized tools. If the target does not expose enough facts, the model publishes only what is known and leaves ETA unavailable.
 
 Do not add a transport, endpoint, store, schema, or provider integration when the regular Pi model can observe the target and use `workflow update` or `submit`.
 
@@ -333,7 +333,7 @@ Fields:
 
 A progress object is a full snapshot for its key. Omitted optional fields clear their previous values. Publishers mark finished tracks with a terminal status instead of deleting them.
 
-The reserved key `overall` represents an explicit aggregate supplied by the workflow. Pi Workflows never combines unrelated tracks automatically. Without `overall`, displays list independent tracks.
+The reserved key `overall` represents an explicit aggregate supplied by the workflow. pi-workflows never combines unrelated tracks automatically. Without `overall`, displays list independent tracks.
 
 Unknown fields in `pi-workflows.progress.v1` are validation errors.
 
@@ -355,7 +355,7 @@ A measured ETA requires a known total and at least two usable samples in the cur
 
 The median interval rate is the central estimate. The 25th and 75th percentile rates form the ETA range. The faster rate gives the lower remaining-time bound and the slower rate gives the upper bound. One usable interval has low confidence. With two through four intervals, a ratio of interquartile range to median no greater than 0.5 gives medium confidence; a wider spread gives low confidence. With five or more intervals, a ratio no greater than 0.25 gives high confidence, a ratio through 0.5 gives medium confidence, and a wider spread gives low confidence. A non-positive median makes ETA unavailable. A non-positive lower rate removes the upper time bound, so the formatter shows the central ETA with low confidence instead of a closed range.
 
-A fresh `sourceEstimatedFinishAt` takes priority over a measured ETA and is labelled as a source estimate. It is fresh when it comes from the latest track update, is later than the matching `sourceUpdatedAt` or runtime receipt time, and has not passed. When `sourceUpdatedAt` is absent, the runtime receipt time is the source time. A passed source estimate is expired and does not override a measured estimate. Pi Workflows does not ask a model to invent an ETA. When the target supplies no usable estimate and the samples cannot support one, the formatter says `ETA unavailable` and states the reason.
+A fresh `sourceEstimatedFinishAt` takes priority over a measured ETA and is labelled as a source estimate. It is fresh when it comes from the latest track update, is later than the matching `sourceUpdatedAt` or runtime receipt time, and has not passed. When `sourceUpdatedAt` is absent, the runtime receipt time is the source time. A passed source estimate is expired and does not override a measured estimate. pi-workflows does not ask a model to invent an ETA. When the target supplies no usable estimate and the samples cannot support one, the formatter says `ETA unavailable` and states the reason.
 
 For `waiting` or `blocked` tracks, measured ETA is paused and the display reports the current state. A source estimate may still be shown when the target reports one. For terminal tracks, remaining work and ETA are omitted.
 

--- a/docs/plans/2026-08-04-controller-runtime-plan.md
+++ b/docs/plans/2026-08-04-controller-runtime-plan.md
@@ -8,7 +8,7 @@ status: implemented
 
 # Controller runtime plan
 
-Pi Workflows needs a controller mode for automation that spans repeated events, external state changes, and process restarts. The design in [CONTROLLERS.md](../CONTROLLERS.md) follows the Kubernetes controller pattern. Durable resources hold desired and observed state, events enqueue resource keys, and each reconciliation reads current facts before acting.
+pi-workflows needs a controller mode for automation that spans repeated events, external state changes, and process restarts. The design in [CONTROLLERS.md](../CONTROLLERS.md) follows the Kubernetes controller pattern. Durable resources hold desired and observed state, events enqueue resource keys, and each reconciliation reads current facts before acting.
 
 The implementation keeps the graph engine focused on finite jobs. Controllers start and observe workflows through a child-run interface. Workflow graphs keep their finite execution model.
 

--- a/docs/plans/2026-08-05-always-on-workflows-plan.md
+++ b/docs/plans/2026-08-05-always-on-workflows-plan.md
@@ -8,7 +8,7 @@ status: implemented
 
 # Always-on workflows plan
 
-Pi Workflows should feel the same whether the user watches a run or walks away from it. In the user's words: "I might start a workflow locally in Pi then I wait for it to complete. All the while I am looking at the screen and I'm not closing the Pi window. When the workflow ends I just want to be able to continue the same Pi session like normal with a session up to date with what happened in the workflow." And: "I just want to interact by starting a workflow, closing it, and then coming back and then still being able to continue it when I open it up. It's syncing continuously or something."
+pi-workflows should feel the same whether the user watches a run or walks away from it. In the user's words: "I might start a workflow locally in Pi then I wait for it to complete. All the while I am looking at the screen and I'm not closing the Pi window. When the workflow ends I just want to be able to continue the same Pi session like normal with a session up to date with what happened in the workflow." And: "I just want to interact by starting a workflow, closing it, and then coming back and then still being able to continue it when I open it up. It's syncing continuously or something."
 
 These are not two modes. The user asked for "both in a single unified system." This plan makes the Pi window irrelevant to execution: closing or opening the window is a change in observation, not in the run. The work stays on one machine, uses the merged controller runtime as its foundation, and does not modify Pi core.
 

--- a/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
+++ b/docs/plans/2026-08-10-agent-managed-monitor-workflows-plan.md
@@ -10,7 +10,7 @@ status: implemented
 
 The user should be able to tell an agent, "Monitor this every 30 minutes," and have the agent start the right workflow. The user must not write controller records or JSON. The existing `workflow` model tool should manage workflows instead of serving only as a step-submission tool.
 
-A monitor is one Pi Workflows graph. It checks the target, reports a meaningful change, sleeps for the requested interval with the existing shell node, and loops. This plan does not use controllers, Unified Exec, a new wait node, or a second scheduler.
+A monitor is one pi-workflows graph. It checks the target, reports a meaningful change, sleeps for the requested interval with the existing shell node, and loops. This plan does not use controllers, Unified Exec, a new wait node, or a second scheduler.
 
 ## Shipped design
 
@@ -84,11 +84,11 @@ The `list` result identifies `monitor` as a built-in workflow and gives a short 
 
 ## Built-in monitor workflow
 
-Ship `monitor` as a built-in workflow in the Pi Workflows package. Built-ins have the lowest discovery precedence:
+Ship `monitor` as a built-in workflow in the pi-workflows package. Built-ins have the lowest discovery precedence:
 
 1. Project workflows under `.pi/workflows/`
 2. Global workflows under `~/.pi/agent/workflows/`
-3. Workflows bundled with Pi Workflows
+3. Workflows bundled with pi-workflows
 
 A project or global `monitor.workflow.ts` can therefore replace the default. The built-in remains a real workflow file so run bundles can record its path and source hash with the existing rules.
 
@@ -112,13 +112,13 @@ prepare -> guard -> check
                     | stop and report -> report-final -> finish
 ```
 
-`prepare` validates and normalizes the input. `guard` enforces `maxChecks`. `check` is an agent node that performs one observation and returns a validated route, a bounded observation, and an optional report. The next `check` can read the previous accepted `check` output, which Pi Workflows already keeps for looped nodes.
+`prepare` validates and normalizes the input. `guard` enforces `maxChecks`. `check` is an agent node that performs one observation and returns a validated route, a bounded observation, and an optional report. The next `check` can read the previous accepted `check` output, which pi-workflows already keeps for looped nodes.
 
 The report nodes write a normal assistant message and then submit an acknowledgement. Keeping reporting after accepted check output prevents the agent from showing a report before the structured result passes validation. The final presentation reports why the monitor stopped without repeating a report that the user already saw.
 
-The sleep node uses the existing Pi Workflows shell action to launch the current Node executable with a timer. Set the node timeout above the largest supported interval because the engine default is 15 minutes. Set the shell execution timeout above the requested wait by a small fixed margin. Cancellation aborts the timer process immediately.
+The sleep node uses the existing pi-workflows shell action to launch the current Node executable with a timer. Set the node timeout above the largest supported interval because the engine default is 15 minutes. Set the shell execution timeout above the requested wait by a small fixed margin. Cancellation aborts the timer process immediately.
 
-If the Pi TUI or standalone workflow host stops during sleep, Pi Workflows parks the run and kills the shell child. Resuming the run starts that sleep node again from the beginning. This is existing workflow behavior and is acceptable for this feature. No special timer persistence is added.
+If the Pi TUI or standalone workflow host stops during sleep, pi-workflows parks the run and kills the shell child. Resuming the run starts that sleep node again from the beginning. This is existing workflow behavior and is acceptable for this feature. No special timer persistence is added.
 
 The workflow uses a high but finite `maxSteps` value as a second safety guard. Check and report values have explicit size limits so a long run cannot grow its bundle without bound.
 
@@ -133,7 +133,7 @@ Make the feature in `osolmaz/pi-workflows`:
 - Add the built-in monitor workflow and focused tests.
 - Update `README.md` and `docs/workflows.md`.
 
-After the upstream change is complete, update the pinned Pi Workflows commit in OnurPi's thin `packages/workflows` wrapper. Do not add a new OnurPi extension or copy a monitor file into live global state.
+After the upstream change is complete, update the pinned pi-workflows commit in OnurPi's thin `packages/workflows` wrapper. Do not add a new OnurPi extension or copy a monitor file into live global state.
 
 ## State and API impact
 
@@ -141,7 +141,7 @@ After the upstream change is complete, update the pinned Pi Workflows commit in 
 - **Other persistent data:** No new data model. The feature uses existing run bundles and the existing workflow run queue.
 - **Pi internals:** None.
 - **Pi public API:** `registerTool`, `registerCommand`, `sendUserMessage`, and documented agent and session lifecycle events.
-- **Pi Workflows API:** The workflow definition and run-state models do not change. The model-facing `workflow` tool contract changes, and discovery gains a lowest-priority built-in source.
+- **pi-workflows API:** The workflow definition and run-state models do not change. The model-facing `workflow` tool contract changes, and discovery gains a lowest-priority built-in source.
 
 ## Non-goals
 
@@ -179,6 +179,6 @@ npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
 npx -y @simpledoc/simpledoc check
 ```
 
-Test the extension from the Pi Workflows checkout with `pi -e src/extension/index.ts`. Use a short test interval in a controlled fixture, then perform one manual 30-minute monitor run to confirm that the configured node timeout does not stop it. Test plain-language startup with the normal model, then test list, status, pause, resume, cancel, and checkpoint answer actions.
+Test the extension from the pi-workflows checkout with `pi -e src/extension/index.ts`. Use a short test interval in a controlled fixture, then perform one manual 30-minute monitor run to confirm that the configured node timeout does not stop it. Test plain-language startup with the normal model, then test list, status, pause, resume, cancel, and checkpoint answer actions.
 
 After updating OnurPi, run its full checks and start Pi with the installed OnurPi package. Confirm that the model sees one `workflow` tool, discovers `monitor`, and can start it from a plain-language request.

--- a/docs/plans/2026-08-13-built-in-workflow-catalog-plan.md
+++ b/docs/plans/2026-08-13-built-in-workflow-catalog-plan.md
@@ -66,7 +66,7 @@ If identity or revision cannot be proved, leave the run unchanged and report a c
 
 ## Scope and non-goals
 
-This changes Pi Workflows only. It uses no Pi internals and changes no Pi session entry. It updates Pi Workflows run bundles and controller queue records as described above.
+This changes pi-workflows only. It uses no Pi internals and changes no Pi session entry. It updates pi-workflows run bundles and controller queue records as described above.
 
 It does not add runtime compatibility readers, aliases, dual-write fields, or a permanent migration service. It does not hot-reload package-provided built-ins. A package update takes effect after Pi reload or restart.
 

--- a/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
+++ b/docs/plans/2026-08-13-session-addressed-workflow-notifications-plan.md
@@ -6,7 +6,7 @@ date: 2026-08-13
 
 # Route workflow reports to their starting session
 
-Pi Workflows must not send one workflow's report into an unrelated conversation. A workflow started in one Pi session must report only to that session, even when another session or the standalone host executes part of the run.
+pi-workflows must not send one workflow's report into an unrelated conversation. A workflow started in one Pi session must report only to that session, even when another session or the standalone host executes part of the run.
 
 ## Requirements
 

--- a/docs/plans/2026-08-16-workflow-updates-plan.md
+++ b/docs/plans/2026-08-16-workflow-updates-plan.md
@@ -10,7 +10,7 @@ This plan implements the contracts in [WORKFLOW_UPDATES.md](../WORKFLOW_UPDATES.
 
 ## Outcome
 
-Pi Workflows will let a running agent, function action, shell action, or claimed runner publish durable structured updates without completing a node. Progress will be one optional update type with shared estimation and presentation helpers.
+pi-workflows will let a running agent, function action, shell action, or claimed runner publish durable structured updates without completing a node. Progress will be one optional update type with shared estimation and presentation helpers.
 
 The built-in monitor will report every accepted check, support optional progress tracks, show live timing in the widget, and deliver notifications without starting an assistant turn.
 
@@ -18,7 +18,7 @@ Interactive agent steps will keep their full model prompts while appearing as co
 
 ## Scope
 
-### Pi Workflows engine
+### pi-workflows engine
 
 - Add public update types and the action context that publishes them.
 - Add fenced update publication to the engine and run store.
@@ -456,7 +456,7 @@ Run package and real-Pi checks again after updating OnurPi. Run the tools skill 
 - The built-in monitor reports every accepted check and has no quiet path.
 - The monitor discloses its finite safety ceiling.
 - TypeScript and Rust viewers agree on replayed progress.
-- All required checks pass in Pi Workflows and OnurPi.
+- All required checks pass in pi-workflows and OnurPi.
 - The published package, OnurPi pin, monitor skill source, and installed Pi copy agree.
 
 ## Risks and controls

--- a/docs/plans/2026-08-17-bundled-skills-plan.md
+++ b/docs/plans/2026-08-17-bundled-skills-plan.md
@@ -61,7 +61,7 @@ The `workflow` tool description remains the small always-available call contract
 4. Add tests that validate declared paths, required frontmatter, unique skill names, and packed files.
 5. Update README installation and configuration examples, including independent resource filtering.
 6. Pack the package and start the real Pi runtime from that artifact. Verify that `/skill:pi-workflows` and `/skill:monitor` are discovered with the extension, then verify that package filtering can hide the monitor skill without hiding the extension.
-7. Run all repository checks and Pi Reviewer, merge, release `0.7.0`, and verify npm contents.
+7. Run all repository checks and pi-reviewer, merge, release `0.7.0`, and verify npm contents.
 8. Pin `0.7.0` in OnurPi, forward the dependency's skills, and run OnurPi checks.
 9. Remove `agents/skills/monitor` from Tools, run the sync script, and verify that the installed skill now comes from the pi-workflows package only.
 
@@ -73,7 +73,7 @@ The `workflow` tool description remains the small always-available call contract
 - The model can use the `workflow` tool from the new skill without larger workflow step messages.
 - npm contains the two `SKILL.md` files and their referenced documentation.
 - Tools contains no monitor skill source or synced duplicate.
-- Local checks, real-Pi end-to-end tests, Pi Reviewer, and CI pass.
+- Local checks, real-Pi end-to-end tests, pi-reviewer, and CI pass.
 
 ## Verification
 

--- a/docs/plans/2026-08-17-bundled-skills-plan.md
+++ b/docs/plans/2026-08-17-bundled-skills-plan.md
@@ -1,12 +1,12 @@
 ---
-title: Bundle Pi Workflows skills with the extension
+title: Bundle pi-workflows skills with the extension
 author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
 date: 2026-08-17
 ---
 
-# Bundle Pi Workflows skills with the extension
+# Bundle pi-workflows skills with the extension
 
-Pi Workflows should be the single source of truth for instructions that teach an agent how to use its extension and built-in workflows. Installing the Pi package should discover those skills with the extension, while Pi's normal package filters let users disable either resource type or an individual skill.
+pi-workflows should be the single source of truth for instructions that teach an agent how to use its extension and built-in workflows. Installing the Pi package should discover those skills with the extension, while Pi's normal package filters let users disable either resource type or an individual skill.
 
 ## Outcome
 
@@ -63,7 +63,7 @@ The `workflow` tool description remains the small always-available call contract
 6. Pack the package and start the real Pi runtime from that artifact. Verify that `/skill:pi-workflows` and `/skill:monitor` are discovered with the extension, then verify that package filtering can hide the monitor skill without hiding the extension.
 7. Run all repository checks and Pi Reviewer, merge, release `0.7.0`, and verify npm contents.
 8. Pin `0.7.0` in OnurPi, forward the dependency's skills, and run OnurPi checks.
-9. Remove `agents/skills/monitor` from Tools, run the sync script, and verify that the installed skill now comes from the Pi Workflows package only.
+9. Remove `agents/skills/monitor` from Tools, run the sync script, and verify that the installed skill now comes from the pi-workflows package only.
 
 ## Acceptance criteria
 

--- a/docs/plans/2026-08-19-human-decision-gates-plan.md
+++ b/docs/plans/2026-08-19-human-decision-gates-plan.md
@@ -6,9 +6,9 @@ date: 2026-08-19
 
 # Add reusable human decision gates
 
-Pi Workflows must let any workflow stop after a proposal, ask the operator in Pi and Telegram, and continue from a verified human choice. A `replan` choice must collect the operator's exact alternative text, send it back to planning, and present the revised plan for another decision.
+pi-workflows must let any workflow stop after a proposal, ask the operator in Pi and Telegram, and continue from a verified human choice. A `replan` choice must collect the operator's exact alternative text, send it back to planning, and present the revised plan for another decision.
 
-The canonical behavior and public contracts are in [Human decisions](../HUMAN_DECISIONS.md). This plan covers the practical implementation in Pi Workflows without changing Pi core or adding a persistent operating-system service.
+The canonical behavior and public contracts are in [Human decisions](../HUMAN_DECISIONS.md). This plan covers the practical implementation in pi-workflows without changing Pi core or adding a persistent operating-system service.
 
 ## Outcome
 
@@ -62,7 +62,7 @@ Pi and Telegram implement one channel interface. Workflows address a named audie
 - Add a Telegram channel using the Bot API and private profiles.
 - Add named audience resolution and private channel configuration.
 - Add a setup command that writes private configuration with mode `600`, references an existing mode-`0600` token file, and verifies the Telegram bot without reading the token into a prompt or printing it.
-- Keep Telegram optional. Pi Workflows must start and run normal workflows without Telegram configuration.
+- Keep Telegram optional. pi-workflows must start and run normal workflows without Telegram configuration.
 - Use one leased long-poll owner per Telegram profile across active Pi processes.
 
 ### Documentation and display
@@ -293,4 +293,4 @@ This work adds compatible public APIs and additive persisted records. Release it
 - **Other persistent data:** additive decision records, a rebuildable private channel index, and private channel configuration.
 - **Pi internals:** none.
 - **Public Pi API:** documented extension lifecycle plus command and UI methods only.
-- **Public Pi Workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, and the `plan-approval` workflow.
+- **Public pi-workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, and the `plan-approval` workflow.

--- a/docs/plans/2026-08-19-human-decision-gates-plan.md
+++ b/docs/plans/2026-08-19-human-decision-gates-plan.md
@@ -281,7 +281,7 @@ npx -y @simpledoc/simpledoc check
 git diff --check
 ```
 
-Run Pi Reviewer against the pushed branch. Fix every P0 and P1 finding and rerun it. Address valid P2 findings, but do not rerun review solely because of a P2-only change. Open or update a pull request and leave it unmerged unless merge is separately authorized.
+Run pi-reviewer against the pushed branch. Fix every P0 and P1 finding and rerun it. Address valid P2 findings, but do not rerun review solely because of a P2-only change. Open or update a pull request and leave it unmerged unless merge is separately authorized.
 
 ## Release
 

--- a/docs/plans/2026-08-19-human-decision-presentations-plan.md
+++ b/docs/plans/2026-08-19-human-decision-presentations-plan.md
@@ -6,7 +6,7 @@ date: 2026-08-19
 
 # Add readable human decision presentations
 
-Pi Workflows currently sends a structured human decision body to Telegram with
+pi-workflows currently sends a structured human decision body to Telegram with
 `JSON.stringify()`. A plan approval therefore reaches the operator as machine
 JSON. Pi also shows only the decision title in its basic selection prompt.
 

--- a/docs/plans/2026-08-19-provider-compatible-workflow-tool-schema-plan.md
+++ b/docs/plans/2026-08-19-provider-compatible-workflow-tool-schema-plan.md
@@ -41,5 +41,5 @@ Fix the workflow tool schema so strict OpenAI-compatible providers accept it wit
 - The strict local endpoint accepts both workflow tool schemas.
 - Runtime parsing rejects malformed calls before execution.
 - `npm run check`, `npm run test:e2e`, Rust tests, Slophammer checks, and `git diff --check` pass.
-- Pi Reviewer reports no P0 or P1 findings.
+- pi-reviewer reports no P0 or P1 findings.
 - PR #33 CI passes before merge.

--- a/docs/plans/2026-08-19-workflow-composition-plan.md
+++ b/docs/plans/2026-08-19-workflow-composition-plan.md
@@ -6,7 +6,7 @@ date: 2026-08-19
 
 # Add typed workflow composition and automatic repair
 
-Pi Workflows needs reusable nested workflows with normal TypeScript imports. Monitor must be able to devise and implement a repair when mutation is authorized. Autoimplement must move back to solution design when new evidence invalidates its plan, correct failed reviewer commands, track P0, P1, and P2 findings, and use long CI waits for additional local testing.
+pi-workflows needs reusable nested workflows with normal TypeScript imports. Monitor must be able to devise and implement a repair when mutation is authorized. Autoimplement must move back to solution design when new evidence invalidates its plan, correct failed reviewer commands, track P0, P1, and P2 findings, and use long CI waits for additional local testing.
 
 The canonical behavior is in [Workflow composition](../WORKFLOW_COMPOSITION.md).
 
@@ -305,4 +305,4 @@ The package and Rust viewer version is `0.10.0`.
 - **Other persistent data:** additive mount, source, digest, review, and CI evidence in existing run bundles.
 - **Pi internals:** none.
 - **Public Pi API:** existing documented extension APIs only.
-- **Public Pi Workflows API:** generic input and exits, direct and dynamic `includeWorkflow()`, and `defineWorkflowRegistry()`.
+- **Public pi-workflows API:** generic input and exits, direct and dynamic `includeWorkflow()`, and `defineWorkflowRegistry()`.

--- a/docs/plans/2026-08-19-workflow-composition-plan.md
+++ b/docs/plans/2026-08-19-workflow-composition-plan.md
@@ -56,7 +56,7 @@ The package will ship `autoplan`, `autoimplement`, and `monitor` as compatible b
 - Track P0, P1, and P2 review findings by round.
 - Rerun review only after P0 or P1 work.
 - Permit P2 work without another reviewer round.
-- Generate, validate, execute, and correct exact Pi Reviewer commands.
+- Generate, validate, execute, and correct exact pi-reviewer commands.
 - Track PR comments, CI, merge, and final PR reporting.
 - Bound one CI watch to five minutes.
 - Route a long CI wait to useful local testing before checking CI again.
@@ -71,7 +71,7 @@ The package will ship `autoplan`, `autoimplement`, and `monitor` as compatible b
 - Do not permit recursive include graphs.
 - Do not add unrestricted model-selected node names.
 - Do not let monitor mutate a target without explicit authorization.
-- Do not replace Pi Reviewer with another reviewer after an invocation failure.
+- Do not replace pi-reviewer with another reviewer after an invocation failure.
 - Do not merge before required gates pass or an allowed unrelated failure is recorded.
 - Do not rewrite existing terminal run bundles.
 
@@ -214,7 +214,7 @@ CI
 
 The structured plan input is optional because the plan can already exist in conversation context or canonical documentation. Its absence never authorizes initial autoplan. Autoimplement blocks when no clear plan exists, skips autodoc for current documentation, and records every evidence-driven revision through autodoc before continuing.
 
-The workflow will collect all review rounds in its final output. It will never rerun Pi Reviewer solely because P2 work changed files.
+The workflow will collect all review rounds in its final output. It will never rerun pi-reviewer solely because P2 work changed files.
 
 ### 8. Monitor repair
 
@@ -278,7 +278,7 @@ npx -y @simpledoc/simpledoc check
 git diff --check
 ```
 
-Run Pi Reviewer against the pushed branch. Fix every P0 and P1 finding and rerun it. P2-only changes do not require another reviewer run unless they expose a new P0 or P1 concern. Check PR comments and CI after review passes.
+Run pi-reviewer against the pushed branch. Fix every P0 and P1 finding and rerun it. P2-only changes do not require another reviewer run unless they expose a new P0 or P1 concern. Check PR comments and CI after review passes.
 
 ## Release
 

--- a/docs/plans/2026-08-20-autoimplement-blocker-challenge-plan.md
+++ b/docs/plans/2026-08-20-autoimplement-blocker-challenge-plan.md
@@ -12,7 +12,7 @@ The canonical workflow behavior is in [Workflow authoring reference](../workflow
 
 ## Outcome
 
-Add one independent `challengeBlocker` agent node to the built-in autoimplement workflow. Use only existing public Pi Workflows primitives. Keep the graph explicit and reuse the existing redesign include and terminal blocked result.
+Add one independent `challengeBlocker` agent node to the built-in autoimplement workflow. Use only existing public pi-workflows primitives. Keep the graph explicit and reuse the existing redesign include and terminal blocked result.
 
 The challenge asks these questions in plain terms:
 
@@ -120,7 +120,7 @@ Review the final diff for missing blocker routes, accidental unbounded loops, an
 ## Boundaries
 
 - Preserve current run-bundle schemas unless a schema change is required. Do not add a persistence layer.
-- Use existing public Pi Workflows primitives only. Do not change Pi core.
+- Use existing public pi-workflows primitives only. Do not change Pi core.
 - Keep explicit human and protected authorization boundaries intact.
 - Use a hard cutover. Do not retain a legacy blocker route.
 - Preserve unrelated work and do not modify other repositories.
@@ -135,4 +135,4 @@ Review the final diff for missing blocker routes, accidental unbounded loops, an
 - **Other persistent data:** none beyond the existing run bundle records for normal node outputs.
 - **Pi internals:** none.
 - **Public Pi API:** existing documented extension APIs only.
-- **Public Pi Workflows API:** existing agent, compute, edge, and included-workflow primitives only.
+- **Public pi-workflows API:** existing agent, compute, edge, and included-workflow primitives only.

--- a/docs/plans/2026-08-20-herdr-plugin-sync-plan.md
+++ b/docs/plans/2026-08-20-herdr-plugin-sync-plan.md
@@ -6,9 +6,9 @@ date: 2026-08-20
 
 # Keep the Herdr plugin linked after package updates
 
-Pi Workflows ships its Herdr plugin inside the npm package. Herdr records the package's absolute path. npm can move an installed package between nested and hoisted `node_modules` directories during an update, which leaves Herdr linked to a path that no longer exists.
+pi-workflows ships its Herdr plugin inside the npm package. Herdr records the package's absolute path. npm can move an installed package between nested and hoisted `node_modules` directories during an update, which leaves Herdr linked to a path that no longer exists.
 
-Pi Workflows will own one explicit command that finds its own package and repairs this link. OnurPi will call that command after it installs an exact reviewed Pi Workflows release. OnurPi will not contain Herdr paths, manifests, or link-repair rules.
+pi-workflows will own one explicit command that finds its own package and repairs this link. OnurPi will call that command after it installs an exact reviewed pi-workflows release. OnurPi will not contain Herdr paths, manifests, or link-repair rules.
 
 ## Outcome
 
@@ -24,7 +24,7 @@ The command validates the bundled package before it changes Herdr. It then creat
 
 ## Scope
 
-### Pi Workflows
+### pi-workflows
 
 - Resolve the installed package root from the running CLI.
 - Validate `package.json`, `herdr-plugin.toml`, and the bundled viewer before changing Herdr.
@@ -37,9 +37,9 @@ The command validates the bundled package before it changes Herdr. It then creat
 
 ### OnurPi
 
-- Keep the Pi Workflows dependency pinned to an exact reviewed release.
+- Keep the pi-workflows dependency pinned to an exact reviewed release.
 - Invoke the local `pi-workflows herdr sync --json` command from an explicit TypeScript sync script after dependency installation.
-- Accept the versioned result and keep Herdr-specific behavior in Pi Workflows.
+- Accept the versioned result and keep Herdr-specific behavior in pi-workflows.
 - Keep package installation free of `postinstall` side effects.
 
 ## Non-goals
@@ -66,19 +66,19 @@ The JSON result uses schema `pi-workflows.herdr-sync.v1` and contains:
 
 A missing Herdr executable returns `unavailable` with exit code zero because Herdr is an optional integration. Every other failure returns a nonzero exit code and does not claim success.
 
-The command preflights the new package before unlinking an old registration. Herdr currently exposes separate unlink and link commands, so replacement cannot be atomic. If replacement fails, Pi Workflows makes one restore attempt only when the previous package root still passes the same validation. It then reports the state found by a fresh Herdr query.
+The command preflights the new package before unlinking an old registration. Herdr currently exposes separate unlink and link commands, so replacement cannot be atomic. If replacement fails, pi-workflows makes one restore attempt only when the previous package root still passes the same validation. It then reports the state found by a fresh Herdr query.
 
 Concurrent sync commands converge on the same target. After a failed or ambiguous mutation, the command queries Herdr and adopts the result only when another process already reached the exact expected state. It does not repeat the same mutation blindly.
 
 ## Compatibility
 
-Existing `herdr setup` callers use the same implementation. Other Pi Workflows CLI commands do not change. The npm package remains the only source of the plugin manifest and viewer.
+Existing `herdr setup` callers use the same implementation. Other pi-workflows CLI commands do not change. The npm package remains the only source of the plugin manifest and viewer.
 
 OnurPi adds only invocation timing and result handling. It does not parse the Herdr manifest or issue link commands.
 
 ## Verification
 
-### Pi Workflows
+### pi-workflows
 
 - Test first link, unchanged link, disabled link, moved package path, stale path, and version update.
 - Test missing Herdr, malformed manifests, malformed plugin records, command failures, post-action mismatches, and bounded restore behavior.
@@ -95,7 +95,7 @@ OnurPi adds only invocation timing and result handling. It does not parse the He
 
 ### Adoption
 
-After a separately approved Pi Workflows release, update OnurPi to that exact version and run:
+After a separately approved pi-workflows release, update OnurPi to that exact version and run:
 
 ```bash
 npm run workflows:sync

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -13,9 +13,9 @@ Files are discovered by suffix (`.workflow.ts`, `.workflow.js`, `.workflow.mts`,
 
 1. `.pi/workflows/` in the project (highest precedence on name collisions)
 2. `~/.pi/agent/workflows/` globally
-3. Workflows built into Pi Workflows
+3. Workflows built into pi-workflows
 
-Pi Workflows includes built-in `autoplan`, `autodoc`, `autoimplement`,
+pi-workflows includes built-in `autoplan`, `autodoc`, `autoimplement`,
 `plan-approval`, and `monitor` workflows. `autoplan` is the current name for the
 planning workflow that was first released as `autodevise`; the old command and
 export are not retained. A project or global file named `monitor.workflow.ts`
@@ -445,9 +445,9 @@ The first check runs immediately. Omit `repair` for observation-only monitoring.
 runtime queues that report as a workflow notification with `triggerTurn:
 false`, so it does not cause an assistant reply. A check can also provide
 independent progress tracks. The regular Pi model running the check observes
-the target and submits those facts. Pi Workflows validates the counts and
+the target and submits those facts. pi-workflows validates the counts and
 calculates rates, confidence, and ETA deterministically. The target does not
-need a Pi Workflows dependency or reporting protocol.
+need a pi-workflows dependency or reporting protocol.
 
 Intervals must be whole minutes from 1 through 1,440. When `stopWhen` is
 omitted, the monitor stops only after an explicit user request. `maxChecks`
@@ -562,7 +562,7 @@ possible. Defaults worth knowing:
   exists.
 - If deferred activation fails, the queue stores a bounded safe error, releases the session
   reservation, and sends one follow-up turn to the initiating model. The model can correct the
-  cause and make a new explicit start call. Pi Workflows does not retry blindly.
+  cause and make a new explicit start call. pi-workflows does not retry blindly.
 - `/workflow cancel` aborts the current node and marks the run `cancelled`.
   When no run is live but the widget still shows a parked or finished run,
   the same command clears the widget.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -417,7 +417,7 @@ The built-in `autoplan` workflow selects a practical in-scope solution and write
 
 The built-in `plan-approval` workflow offers verified human `continue`, `stop`, and exact-text `replan` exits. It is optional. A replan exit returns the unchanged text to autoplan, documents the revised plan, and asks again through a new plan digest.
 
-Autoimplement writes and runs the exact Pi Reviewer command. It records P0 through P2 by review round. P0 or P1 work requires another review. P2-only work can be addressed and verified without another reviewer run. CI tracking commands are also explicit. One CI watch lasts at most five minutes, after which the model runs more useful local tests before checking CI again.
+Autoimplement writes and runs the exact pi-reviewer command. It records P0 through P2 by review round. P0 or P1 work requires another review. P2-only work can be addressed and verified without another reviewer run. CI tracking commands are also explicit. One CI watch lasts at most five minutes, after which the model runs more useful local tests before checking CI again.
 
 A model-generated blocker from implementation or a safe later stage does not end autoimplement by itself. A separate blocker-challenge agent checks the task, approved plan, current result, evidence, scope, authority, earlier attempts, and practical alternatives. It confirms a blocker only when the blocker exists now, is outside the granted authority, has no safe path forward, has an empty next action, and includes concrete evidence and checked alternatives. A rejected blocker must name the next practical action and routes through the existing redesign workflow before implementation and verification continue.
 

--- a/fixtures/layout/example-autoimplement.json
+++ b/fixtures/layout/example-autoimplement.json
@@ -76,7 +76,7 @@
       "runReview": {
         "nodeType": "action",
         "timeoutMs": 610000,
-        "statusDetail": "running Pi Reviewer",
+        "statusDetail": "running pi-reviewer",
         "actionExecution": "shell"
       },
       "repairReviewCommand": {
@@ -9396,7 +9396,7 @@
         "                                                                              │      │      │      │      │      │      │      │ ◇ failed                             │      │      │      │      │      │      │                                                                                │ │ │",
         "                                                                              │      │      │      │      │      │      │      │ ◇ timed_out                          │      │      │      │      │      │      │                                                                                │ │ │",
         "                                                                              │      │      │      │      │      │      │      │                                      │      │      │      │      │      │      │                                                                                │ │ │",
-        "                                                                              │      │      │      │      │      │      │      │ … running Pi Reviewer                │      │      │      │      │      │      │                                                                                │ │ │",
+        "                                                                              │      │      │      │      │      │      │      │ … running pi-reviewer                │      │      │      │      │      │      │                                                                                │ │ │",
         "                                                                              │      │      │      │      │      │      │      └──────────────────────────────────────┘      │      │      │      │      │      │                                                                                │ │ │",
         "                                                                       ┌──────┘      ├──────┘      ├──────┘      ├──────┘      ┌─── timed_out ─┼─┘ └──── ok ─────┐           │      └──────┤      └──────┤      └──────┐                                                                         │ │ │",
         "                                                                       │      ┌──────┤      ┌──────┤      ┌──────┤      ┌──────┼───────────────┘ failed          │           │             ├──────┐      ├──────┐      │                                                                         │ │ │",

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,8 +1,8 @@
 id = "osolmaz.pi-workflows"
-name = "Pi Workflows"
+name = "pi-workflows"
 version = "0.11.2"
 min_herdr_version = "0.7.0"
-description = "Open the active Pi Workflows run in piw from a managed Herdr pane."
+description = "Open the active pi-workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]
 
 [[panes]]

--- a/schemas/decision-presentation-v1.schema.json
+++ b/schemas/decision-presentation-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/decision-presentation-v1.schema.json",
-  "title": "Pi Workflows decision presentation v1",
+  "title": "pi-workflows decision presentation v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema", "summary", "blocks"],

--- a/schemas/human-decision-accepted-v1.schema.json
+++ b/schemas/human-decision-accepted-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-accepted-v1.schema.json",
-  "title": "Pi Workflows accepted human decision v1",
+  "title": "pi-workflows accepted human decision v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-accepted-v2.schema.json
+++ b/schemas/human-decision-accepted-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-accepted-v2.schema.json",
-  "title": "Pi Workflows accepted human decision v2",
+  "title": "pi-workflows accepted human decision v2",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-answer-attempt-v1.schema.json
+++ b/schemas/human-decision-answer-attempt-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-answer-attempt-v1.schema.json",
-  "title": "Pi Workflows human decision answer attempt v1",
+  "title": "pi-workflows human decision answer attempt v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-cancellation-v1.schema.json
+++ b/schemas/human-decision-cancellation-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-cancellation-v1.schema.json",
-  "title": "Pi Workflows human decision cancellation v1",
+  "title": "pi-workflows human decision cancellation v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema", "decisionId", "requestDigest", "cancelledAt", "reason"],

--- a/schemas/human-decision-continuation-v1.schema.json
+++ b/schemas/human-decision-continuation-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-continuation-v1.schema.json",
-  "title": "Pi Workflows human decision continuation v1",
+  "title": "pi-workflows human decision continuation v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema", "decisionId", "requestDigest", "parentRunId", "runId", "createdAt"],

--- a/schemas/human-decision-delivery-v1.schema.json
+++ b/schemas/human-decision-delivery-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-delivery-v1.schema.json",
-  "title": "Pi Workflows human decision delivery v1",
+  "title": "pi-workflows human decision delivery v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-delivery-v2.schema.json
+++ b/schemas/human-decision-delivery-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-delivery-v2.schema.json",
-  "title": "Pi Workflows human decision delivery v2",
+  "title": "pi-workflows human decision delivery v2",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-receipt-v1.schema.json
+++ b/schemas/human-decision-receipt-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-receipt-v1.schema.json",
-  "title": "Pi Workflows redacted human decision receipt v1",
+  "title": "pi-workflows redacted human decision receipt v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-receipt-v2.schema.json
+++ b/schemas/human-decision-receipt-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-receipt-v2.schema.json",
-  "title": "Pi Workflows redacted human decision receipt v2",
+  "title": "pi-workflows redacted human decision receipt v2",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-request-v1.schema.json
+++ b/schemas/human-decision-request-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-request-v1.schema.json",
-  "title": "Pi Workflows human decision request v1",
+  "title": "pi-workflows human decision request v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-request-v2.schema.json
+++ b/schemas/human-decision-request-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-request-v2.schema.json",
-  "title": "Pi Workflows human decision request v2",
+  "title": "pi-workflows human decision request v2",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/schemas/human-decision-resolution-v1.schema.json
+++ b/schemas/human-decision-resolution-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-resolution-v1.schema.json",
-  "title": "Pi Workflows human decision resolution v1",
+  "title": "pi-workflows human decision resolution v1",
   "oneOf": [
     {
       "type": "object",

--- a/schemas/human-decision-resolution-v2.schema.json
+++ b/schemas/human-decision-resolution-v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-resolution-v2.schema.json",
-  "title": "Pi Workflows human decision resolution v2",
+  "title": "pi-workflows human decision resolution v2",
   "oneOf": [
     {
       "type": "object",

--- a/schemas/human-decision-settlement-v1.schema.json
+++ b/schemas/human-decision-settlement-v1.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/osolmaz/pi-workflows/schemas/human-decision-settlement-v1.schema.json",
-  "title": "Pi Workflows human decision settlement v1",
+  "title": "pi-workflows human decision settlement v1",
   "type": "object",
   "additionalProperties": false,
   "required": [

--- a/skills/autodoc/SKILL.md
+++ b/skills/autodoc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autodoc
 description: Use when an existing selected solution or clear implementation plan must be recorded or updated in canonical documentation before implementation, including choosing the right repository and applying SimpleDoc conventions.
-compatibility: Requires Pi Workflows and the built-in autodoc workflow.
+compatibility: Requires pi-workflows and the built-in autodoc workflow.
 ---
 
 # Autodoc

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoimplement
-description: Use when the user asks to implement a plan end-to-end, test it, run Pi Reviewer against the base branch in a loop until no P0/P1 issues remain, and make sure CI/CD is green before finishing.
+description: Use when the user asks to implement a plan end-to-end, test it, run pi-reviewer against the base branch in a loop until no P0/P1 issues remain, and make sure CI/CD is green before finishing.
 compatibility: Requires pi-workflows and the built-in autoimplement workflow.
 ---
 
@@ -26,16 +26,16 @@ Outside Pi, or when the workflow is unavailable, do the following in the order t
    - Do not put mutation testing on the critical path unless repository policy explicitly requires it; keep the mutation test scripts available.
 
 3. Push your latest commits before running review so the review is always against the current PR head.
-   - Run Pi Reviewer with its configured defaults against the base branch: `pi-reviewer --base <branch_name>`. The model and thinking level come from the reviewer's own config, not from this skill.
-   - Use a 10 minute timeout on the tool call available to the model, not the shell `timeout` program. If Pi Reviewer takes more than 10 minutes, kill it.
-   - Do not silently fall back to `codex review` when Pi Reviewer is unavailable; stop and report the missing command or configuration.
+   - Run pi-reviewer with its configured defaults against the base branch: `pi-reviewer --base <branch_name>`. The model and thinking level come from the reviewer's own config, not from this skill.
+   - Use a 10 minute timeout on the tool call available to the model, not the shell `timeout` program. If pi-reviewer takes more than 10 minutes, kill it.
+   - Do not silently fall back to `codex review` when pi-reviewer is unavailable; stop and report the missing command or configuration.
    - Record every review round with separate P0, P1, P2, and lower findings.
-   - Run Pi Reviewer in a loop and address any P0 or P1 issues until there are none left.
-   - If a round reports only P2 or lower findings, address valid proportionate P2 findings, verify and push them, then move to the next stage without running Pi Reviewer again solely because of that P2 work.
+   - Run pi-reviewer in a loop and address any P0 or P1 issues until there are none left.
+   - If a round reports only P2 or lower findings, address valid proportionate P2 findings, verify and push them, then move to the next stage without running pi-reviewer again solely because of that P2 work.
    - Ignore issues about supporting legacy behavior unless the plan requires compatibility.
-   - Look at CI only after Pi Reviewer passes, meaning the last completed run found no issues or only P2 or lower issues.
+   - Look at CI only after pi-reviewer passes, meaning the last completed run found no issues or only P2 or lower issues.
 
-4. Pi Reviewer reports findings locally and does not post them to the pull request.
+4. pi-reviewer reports findings locally and does not post them to the pull request.
    - Separately check existing inline review comments and PR issue comments, and address valid comments.
    - Ignore irrelevant comments and stale comments from before the latest commit unless they still apply.
    - Reply to and resolve each comment either way.

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoimplement
 description: Use when the user asks to implement a plan end-to-end, test it, run Pi Reviewer against the base branch in a loop until no P0/P1 issues remain, and make sure CI/CD is green before finishing.
-compatibility: Requires Pi Workflows and the built-in autoimplement workflow.
+compatibility: Requires pi-workflows and the built-in autoimplement workflow.
 ---
 
 Use the built-in `autoimplement` Pi Workflow when it is available. At top level, list workflows, then start `autoimplement` once with the task, existing plan, repository, scope, constraints, base branch, and merge policy from the conversation. Set `merge: true` only when the user explicitly requested merge or an applicable standing instruction authorizes it. Otherwise set it to false. Do not manually duplicate stages already owned by the workflow.

--- a/skills/autoplan/SKILL.md
+++ b/skills/autoplan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: autoplan
 description: Use when the user asks to devise, choose, or plan the most elegant long-term production-ready solution, compare it with the ideal end state, and produce the best practical in-scope implementation plan without asking the user to resolve the gap.
-compatibility: Requires Pi Workflows and the built-in autoplan workflow.
+compatibility: Requires pi-workflows and the built-in autoplan workflow.
 ---
 
 # Autoplan

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: monitor
 description: Use when the user asks to monitor, watch, track, or periodically check a running command, remote Job, CI run, deployment, publication, or other long-running objective. Starts the built-in Pi monitor workflow immediately in the current session and drives the objective autonomously, including routine recovery, until verified completion or a material blocker.
-compatibility: Requires Pi Workflows and the built-in monitor workflow.
+compatibility: Requires pi-workflows and the built-in monitor workflow.
 ---
 
 # Monitor
@@ -115,7 +115,7 @@ Submit observed facts. The workflow computes rates, confidence, remaining work, 
 
 For several concurrent processes, publish one stable track per process. The Pi widget and viewers show them separately and keep each ETA independent.
 
-Keep the monitored target independent of Pi Workflows. Do not require a target Job or application to import Pi Workflows, emit a Pi schema, write a Pi progress file, expose a Pi endpoint, create a progress store, or add a progress reader command solely for monitoring. Do not add provider-specific clients or credentials to Pi Workflows. Target-specific observation belongs in the check task and is performed by the regular Pi model with already authorized tools.
+Keep the monitored target independent of pi-workflows. Do not require a target Job or application to import pi-workflows, emit a Pi schema, write a Pi progress file, expose a Pi endpoint, create a progress store, or add a progress reader command solely for monitoring. Do not add provider-specific clients or credentials to pi-workflows. Target-specific observation belongs in the check task and is performed by the regular Pi model with already authorized tools.
 
 Before proposing a new progress API, transport, schema, or persistence layer, prove that the model cannot observe the needed facts and publish them through the existing `workflow update` and `submit` path. If the target does not expose enough facts for ETA, report `ETA unavailable`. Application telemetry changes require separate scope and should expose normal operational facts rather than a Pi-specific protocol.
 

--- a/skills/pi-workflows/SKILL.md
+++ b/skills/pi-workflows/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pi-workflows
-description: Use when creating, reviewing, debugging, starting, inspecting, or controlling Pi Workflows; authoring .workflow.ts files; using the workflow tool; handling workflow step contracts, checkpoints, updates, or progress; or deciding how a task should compose workflow primitives.
-compatibility: Requires the Pi Workflows extension.
+description: Use when creating, reviewing, debugging, starting, inspecting, or controlling pi-workflows; authoring .workflow.ts files; using the workflow tool; handling workflow step contracts, checkpoints, updates, or progress; or deciding how a task should compose workflow primitives.
+compatibility: Requires the pi-workflows extension.
 ---
 
-# Pi Workflows
+# pi-workflows
 
-Use Pi Workflows for durable multi-step work that needs explicit routing, retries, checkpoints, scheduled waits, or progress. Keep simple one-turn work outside a workflow.
+Use pi-workflows for durable multi-step work that needs explicit routing, retries, checkpoints, scheduled waits, or progress. Keep simple one-turn work outside a workflow.
 
 The `workflow` tool schema is the authority for call shapes. A workflow step message is the authority for its current step id, attempt id, and expected output. Do not guess these values from an earlier attempt.
 

--- a/src/builtins/autoimplement.workflow.ts
+++ b/src/builtins/autoimplement.workflow.ts
@@ -872,7 +872,7 @@ export const autoimplementWorkflow = defineWorkflow({
         const published = outputs.publish as Record<string, unknown>;
         const request = input as AutoimplementInput;
         return [
-          "Write the exact Pi Reviewer command for the pushed branch.",
+          "Write the exact pi-reviewer command for the pushed branch.",
           "The executable must be pi-reviewer. Use its configured model and thinking settings.",
           "Use the repository base branch and an absolute repository working directory.",
           "Set timeoutMs to at most 600000.",
@@ -884,7 +884,7 @@ export const autoimplementWorkflow = defineWorkflow({
       validate: parseReviewerCommand,
     }),
     runReview: shell({
-      statusDetail: "running Pi Reviewer",
+      statusDetail: "running pi-reviewer",
       timeoutMs: TEN_MINUTES_MS + 10_000,
       exec: (context) =>
         commandExecution(
@@ -896,9 +896,9 @@ export const autoimplementWorkflow = defineWorkflow({
       prompt: (context) => {
         const failed = context.results.runReview;
         return [
-          "The Pi Reviewer invocation failed. Diagnose the exact command, arguments, base branch, working directory, and error.",
+          "The pi-reviewer invocation failed. Diagnose the exact command, arguments, base branch, working directory, and error.",
           "Write a corrected pi-reviewer command. Do not substitute codex review or another reviewer.",
-          "If Pi Reviewer or its configuration is missing, report that through the same command shape only when another valid invocation exists; otherwise the next assessment must block.",
+          "If pi-reviewer or its configuration is missing, report that through the same command shape only when another valid invocation exists; otherwise the next assessment must block.",
           `Failed result: ${JSON.stringify(failed)}`,
         ].join("\n");
       },
@@ -925,7 +925,7 @@ export const autoimplementWorkflow = defineWorkflow({
       prompt: (context) => {
         const result = latestOutput<ShellActionResult>(context, ["runReview"]);
         return [
-          "Assess the completed Pi Reviewer invocation.",
+          "Assess the completed pi-reviewer invocation.",
           "Set invocationSucceeded false only when the reviewer did not produce a valid review.",
           "Record each finding under P0, P1, P2, or lower. Mark each finding as design or implementation.",
           "Do not promote P2 findings to P1 merely to force another review round.",
@@ -952,7 +952,7 @@ export const autoimplementWorkflow = defineWorkflow({
       prompt: ({ outputs }) =>
         [
           "Address valid P2 findings from the last review when the improvement is proportionate and in scope.",
-          "Do not rerun Pi Reviewer solely because P2 work changes files. Verification will run once, then the workflow continues.",
+          "Do not rerun pi-reviewer solely because P2 work changes files. Verification will run once, then the workflow continues.",
           `Review: ${JSON.stringify(outputs.assessReview)}`,
         ].join("\n"),
       expectedOutput: `{ "addressed": ["P2 change"], "skipped": [{ "finding": "finding", "reason": "why" }] }`,
@@ -964,7 +964,7 @@ export const autoimplementWorkflow = defineWorkflow({
       prompt: () =>
         [
           "Run focused verification for the P2 changes and push the verified result.",
-          "Do not run Pi Reviewer again because the previous round had no P0 or P1 findings.",
+          "Do not run pi-reviewer again because the previous round had no P0 or P1 findings.",
           "Report exact commands and outcomes.",
         ].join("\n"),
       expectedOutput: `{ "passed": true | false, "commands": [{ "command": "command", "outcome": "result" }], "pushed": true }`,

--- a/src/extension/decision-channels.ts
+++ b/src/extension/decision-channels.ts
@@ -105,13 +105,13 @@ export async function loadDecisionChannelConfig(
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
   }
-  await requirePrivateFile(channelPath, "Pi Workflows channel profile");
+  await requirePrivateFile(channelPath, "pi-workflows channel profile");
   const channels = parseChannelConfig(channelsRaw);
   const profileNames = Object.keys(channels.telegramProfiles ?? {});
   if (profileNames.length === 0) return { channels, credentials: {}, configDir };
 
   const credentialPath = path.join(configDir, "credentials.json");
-  await requirePrivateFile(credentialPath, "Pi Workflows credential profile");
+  await requirePrivateFile(credentialPath, "pi-workflows credential profile");
   const credentialConfig = parseCredentialConfig(
     JSON.parse(await fsp.readFile(credentialPath, "utf8")),
   );
@@ -1163,9 +1163,9 @@ export async function writeDecisionChannelProfile(options: {
 }
 
 function parseChannelConfig(value: unknown): DecisionChannelConfig {
-  const config = record(value, "Pi Workflows channel config");
+  const config = record(value, "pi-workflows channel config");
   if (config.schema !== "pi-workflows.channels.v1") {
-    throw new Error("Pi Workflows channel config schema is invalid");
+    throw new Error("pi-workflows channel config schema is invalid");
   }
   const telegramProfiles: NonNullable<DecisionChannelConfig["telegramProfiles"]> = {};
   if (config.telegramProfiles !== undefined) {
@@ -1191,7 +1191,7 @@ function parseChannelConfig(value: unknown): DecisionChannelConfig {
       };
     }
   }
-  const audiencesRaw = record(config.audiences, "Pi Workflows audiences");
+  const audiencesRaw = record(config.audiences, "pi-workflows audiences");
   const audiences: DecisionChannelConfig["audiences"] = {};
   for (const [name, raw] of Object.entries(audiencesRaw)) {
     requireSimpleId(name, "Decision audience");
@@ -1219,9 +1219,9 @@ function parseChannelConfig(value: unknown): DecisionChannelConfig {
 }
 
 function parseCredentialConfig(value: unknown): DecisionCredentialConfig {
-  const config = record(value, "Pi Workflows credential config");
+  const config = record(value, "pi-workflows credential config");
   if (config.schema !== "pi-workflows.credentials.v1") {
-    throw new Error("Pi Workflows credential config schema is invalid");
+    throw new Error("pi-workflows credential config schema is invalid");
   }
   const telegram: DecisionCredentialConfig["telegram"] = {};
   for (const [name, raw] of Object.entries(record(config.telegram, "Telegram credentials"))) {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -2428,7 +2428,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     name: "workflow",
     label: "Workflow",
     description: [
-      "List, start, inspect, pause, resume, cancel, answer, update, or complete Pi Workflows runs.",
+      "List, start, inspect, pause, resume, cancel, answer, update, or complete pi-workflows runs.",
       "When the user asks to monitor, watch, poll, or check something repeatedly, start the built-in monitor workflow with input keys task, everyMinutes, stopWhen, and optional maxChecks.",
       "Use update or submit only when a workflow step contract asks for it, and pass the exact step and attempt ids.",
       "Do not start repeated work without the user's request, and keep monitoring observation-only unless the user authorizes mutations.",

--- a/src/herdr/setup.ts
+++ b/src/herdr/setup.ts
@@ -115,20 +115,20 @@ function preflightPackage(packageRoot: string): PluginPackage {
   try {
     root = fs.realpathSync(requestedRoot);
   } catch (error) {
-    throw new Error(`Pi Workflows package root is missing: ${requestedRoot}`, { cause: error });
+    throw new Error(`pi-workflows package root is missing: ${requestedRoot}`, { cause: error });
   }
   if (!fs.statSync(root).isDirectory()) {
-    throw new Error(`Pi Workflows package root is not a directory: ${requestedRoot}`);
+    throw new Error(`pi-workflows package root is not a directory: ${requestedRoot}`);
   }
   const packagePath = checkedRegularFile(root, "package.json");
   const manifestPath = checkedRegularFile(root, MANIFEST_NAME);
   const packageJson = parseJsonObject(fs.readFileSync(packagePath, "utf8"), "package.json");
   if (packageJson["name"] !== PACKAGE_NAME) {
-    throw new Error(`Unexpected Pi Workflows package name in ${packagePath}.`);
+    throw new Error(`Unexpected pi-workflows package name in ${packagePath}.`);
   }
   const packageVersion = packageJson["version"];
   if (typeof packageVersion !== "string" || packageVersion.length === 0) {
-    throw new Error(`Pi Workflows package version is missing in ${packagePath}.`);
+    throw new Error(`pi-workflows package version is missing in ${packagePath}.`);
   }
 
   const manifest = fs.readFileSync(manifestPath, "utf8");

--- a/test/herdr-setup.test.ts
+++ b/test/herdr-setup.test.ts
@@ -42,7 +42,7 @@ async function makePackage(label = "pi-workflows-herdr-sync", version = "0.11.0"
     path.join(root, "herdr-plugin.toml"),
     [
       `id = "${HERDR_PLUGIN_ID}"`,
-      'name = "Pi Workflows"',
+      'name = "pi-workflows"',
       `version = "${version}"`,
       'min_herdr_version = "0.7.0"',
       'platforms = ["linux", "macos"]',
@@ -336,7 +336,7 @@ describe("syncHerdrPlugin", () => {
       path.join(wrongName, "package.json"),
       `${JSON.stringify({ name: "other", version: "0.11.0" })}\n`,
     );
-    expect(() => syncHerdrPlugin(wrongName, () => reply())).toThrow("Unexpected Pi Workflows");
+    expect(() => syncHerdrPlugin(wrongName, () => reply())).toThrow("Unexpected pi-workflows");
 
     const missingVersion = await makePackage("pi-workflows-missing-version");
     await fs.writeFile(


### PR DESCRIPTION
## Summary

The project name appeared as "Pi Workflows" in error messages, tool descriptions, docs, and the Herdr plugin manifest, while the command and package are `pi-workflows`.
This change uses `pi-workflows` everywhere the name is cosmetic, so the display name matches the package.
It also adds an SVG cover to the README that shows what the extension does: a representative multi-step workflow graph with a fix loop and a clean finish.

## What Changed

All display-only uses of the name now say `pi-workflows`.
No identifier, path, schema id, or command changed, because those already used `pi-workflows`.

- Replaced "Pi Workflows" with "pi-workflows" in the README, docs, plans, schema descriptions, error messages, tool descriptions, test descriptions, and the `herdr-plugin.toml` display name.
- Added `assets/cover.svg`, a self-contained dark banner with the project name, a one-line description, the install command, and a representative workflow graph in the shape of the autoimplement loop: plan, implement, verify, review, a fix retry loop, and a clean finish.
- Embedded the cover at the top of the README.
- Lowercased cross-references to sibling projects: "Pi Reviewer", "Pi Factory", and "Pi Must Win" become `pi-reviewer`, `pi-factory`, and `pi-must-win` in docs, skills, prompts, and the layout fixture.

## Testing

The full project check passed after the rename, including format, lint, typecheck, build, and tests with coverage.
The cover was rendered to PNG with Inkscape and inspected visually.

- `npm run check`

## Risks

Risk is low because the change touches only display strings and the README.

- The `name` field in `herdr-plugin.toml` changed; this is a display name, and the plugin id stays the same.
- Tests that named "pi-workflows" in descriptions were renamed, not changed in behavior.
