### PR TITLE
feat: guarantee successor turns after workflow interruption

### DIFF
--- a/docs/2026-08-20-durable-workflow-launch-plan.md
+++ b/docs/2026-08-20-durable-workflow-launch-plan.md
@@ -6,6 +6,8 @@ date: 2026-08-20
 
 # Make deferred workflow launches durable
 
+The launch queue and activation contract in this plan remain current. [Deferred workflow turns](DEFERRED_TURNS.md) replaces the launch-specific failure-notification mechanism with the general successor-turn intent contract.
+
 ## Goal
 
 A successful `workflow start` call must create a real queued workflow before it returns. The model
@@ -60,9 +62,8 @@ If startup fails, pi-workflows will:
 1. Change the record to `failed`.
 2. Save a bounded safe error.
 3. Release the session reservation.
-4. Queue one durable failure notification for the owning Pi session.
-5. Send that notification through `pi.sendMessage` with `triggerTurn: true` and
-   `deliverAs: "followUp"`.
+4. Create one eligible deferred-turn intent for the owning Pi session.
+5. Resolve that intent with one factual follow-up after settlement.
 
 The new model turn will contain the failed run ID and an actionable error. The model can fix the
 workflow reference, input, source, or local condition and call `workflow start` again. Each retry is
@@ -150,10 +151,7 @@ Inspect the error and call workflow start again only after you correct the cause
 The message does not contain raw workflow input, prompt text, credentials, request headers, or a
 stack trace.
 
-The failure notification has a deterministic ID derived from the run ID. pi-workflows records its
-delivery in the existing notification outbox. Before a delivery retry, it checks the native Pi
-session for that notification ID. This prevents a duplicate after a crash between session append and
-outbox acknowledgement.
+The turn intent has a deterministic ID derived from the session, run, and launch event. Pi Workflows records it in `workflow_turn_intents`. Before a delivery retry, it checks the Pi session branch for the intent ID. This prevents a duplicate after a crash between session append and intent resolution.
 
 A failed launch releases the one-workflow session reservation before it sends the follow-up. The
 model can therefore call `workflow start` during the new turn. If that launch also fails, the same
@@ -217,9 +215,7 @@ and `running` state its meaning directly.
 Clear private queue input when the launch becomes `running`, `failed`, or `cancelled`. The normal run
 bundle owns input after the engine starts.
 
-Extend the existing `workflow_notifications` table in place so a notification can be run-level.
-Add `launch_failure` to its kind contract and allow node and attempt identity to be absent for a
-run-level notification. Reuse its delivery claim, lease, and delivered timestamp.
+Keep `workflow_notifications` limited to passive `progress` and `final` reports. A launch failure creates an eligible row in `workflow_turn_intents`; it does not add a run-level notification kind.
 
 The project-scoped controller store remains private local state. Tests must verify restrictive file
 and directory permissions.
@@ -384,8 +380,8 @@ Add or update these tests:
 10. Cancellation before claim, during `starting`, and before executor release.
 11. Source change between preparation and activation.
 12. Safe error redaction and byte bounds.
-13. One durable launch-failure notification.
-14. Crash before session append, after append, and before outbox acknowledgement.
+13. One durable launch-failure turn intent.
+14. Crash before session append, after append, and before intent resolution.
 15. Failed reservation release followed by a corrected model start.
 16. Repeated model correction attempts with one active reservation at a time.
 17. Status for every launch and run state.
@@ -411,7 +407,7 @@ or external service.
 - The start tool never reports success without a committed queued record and final run ID.
 - The model can correct synchronous start errors in the same turn.
 - A deferred startup failure always becomes durable before notification.
-- One failure notification starts one new model turn.
+- One launch-failure intent starts one new model turn.
 - The model can correct the cause and start a new run.
 - Failed and cancelled launches release the session reservation.
 - No two runs activate for one reservation.

--- a/docs/DEFERRED_TURNS.md
+++ b/docs/DEFERRED_TURNS.md
@@ -1,0 +1,298 @@
+# Deferred workflow turns
+
+This specification defines how Pi Workflows schedules one successor agent turn after a workflow event stops or strands the current turn. It covers cancellation, timeout, terminal failure, launch failure, controller interruption, and claim loss.
+
+The implementation plan is [Guarantee one successor turn after workflow interruption](plans/2026-08-21-deferred-turn-intents-plan.md).
+
+## Terms
+
+- **Source event:** The workflow event that creates the need for another turn.
+- **Turn intent:** The durable obligation to send one successor turn.
+- **Natural successor:** The next workflow agent prompt or result presentation.
+- **Fallback:** A factual model-facing message sent when no natural successor remains.
+- **Resolution:** The recorded fact that one message path satisfied the intent.
+- **Target session:** The Pi session that owns the successor turn.
+
+## Core rule
+
+Each eligible source event creates at most one turn intent. Exactly one of these message paths can resolve it:
+
+1. a workflow agent prompt;
+2. a completed or waiting result presentation;
+3. a factual fallback.
+
+All three paths claim the same intent before sending. A resolved intent cannot start another turn.
+
+Cancellation and process termination remain immediate. Pi Workflows does not keep the old assistant turn alive and does not wait for the successor before stopping active work.
+
+## Intent lifecycle
+
+An intent has two stored states:
+
+| State    | Condition                                                     | Meaning                                                   |
+| -------- | ------------------------------------------------------------- | --------------------------------------------------------- |
+| Pending  | `resolvedAt` is null                                          | No message path has resolved the intent.                  |
+| Resolved | `resolvedAt`, `resolution`, and `resolutionMessageId` are set | One message path was sent or found in the session branch. |
+
+Pending intents have separate fallback eligibility:
+
+| Eligibility | Condition            | Meaning                                                          |
+| ----------- | -------------------- | ---------------------------------------------------------------- |
+| Ineligible  | `eligibleAt` is null | A natural workflow prompt or presentation can still arrive.      |
+| Eligible    | `eligibleAt` is set  | Durable state shows that no immediate natural successor remains. |
+
+A claim is temporary coordination state. A claim does not resolve an intent. An expired claim can be acquired again.
+
+Valid resolutions are:
+
+```text
+workflowPrompt | presentation | fallback
+```
+
+Resolution records message delivery into the Pi session or the presence of the same message in the session branch. It does not prove that a model turn started or completed.
+
+## Source events
+
+Valid causes are:
+
+```text
+agentCancelled | timedOut | failed | launchFailed | controllerInterrupted | claimLost
+```
+
+The event policy is:
+
+| Event                                                          | Intent                                                 | Fallback rule                                                                          |
+| -------------------------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| Agent calls `workflow cancel` during an active workflow turn   | Create before `ctx.abort()` when storage is available. | Make eligible after durable terminal cancellation.                                     |
+| Agent step times out                                           | Create before `ctx.abort()` when storage is available. | Keep ineligible while a recovery prompt can arrive. Make eligible on terminal timeout. |
+| Active workflow turn ends in terminal failure                  | Create or reuse the abort intent.                      | Make eligible after durable terminal failure.                                          |
+| Workflow reports started, then crashes before its first prompt | Create after durable failure.                          | Create as eligible.                                                                    |
+| Queued launch activation fails                                 | Create after the queue row is durably failed.          | Create as eligible.                                                                    |
+| Controller interrupts an active workflow turn                  | Create before the turn abort when possible.            | Durable terminal or handoff state decides eligibility.                                 |
+| Active workflow turn loses its queue claim                     | Create before the turn abort when possible.            | Keep ineligible while a new owner can continue.                                        |
+| Completed or waiting result has a presentation                 | Do not create a new intent.                            | Resolve an existing intent through presentation.                                       |
+| Direct `/workflow cancel`                                      | Do not create.                                         | No automatic model turn.                                                               |
+| Workflow pause                                                 | Do not create.                                         | No automatic model turn.                                                               |
+| User Escape or held workflow                                   | Do not create.                                         | No automatic model turn.                                                               |
+| Session shutdown                                               | Do not create.                                         | A closing session cannot start another turn.                                           |
+
+A terminal failure after a successful start tool result is eligible even when it did not first call `ctx.abort()`. This rule covers asynchronous runtime validation and startup failures that the user can see in the UI but the model cannot see in its current context.
+
+## Stable identity
+
+`intentId` is a deterministic digest of:
+
+- target session ID;
+- run ID;
+- source event ID;
+- node ID or `$launch`;
+- attempt ID when known;
+- cause.
+
+The same source event must always produce the same ID. Reusing an ID with different immutable facts is an error.
+
+`sourceEventId` identifies the source transition independently of delivery retries. Terminal handling must reuse an earlier abort event instead of creating a second terminal event for the same interruption.
+
+IDs use the existing controller-store key limit of 512 characters. The digest representation must be stable across processes and extension restarts.
+
+## Stored record
+
+`workflow_turn_intents` lives in the existing controller SQLite database.
+
+| Column                      | Null | Meaning                                      |
+| --------------------------- | ---- | -------------------------------------------- |
+| `intent_id`                 | No   | Deterministic primary key.                   |
+| `source_event_id`           | No   | Stable source transition identity.           |
+| `run_id`                    | No   | Related workflow run.                        |
+| `workflow_ref`              | No   | Workflow identity used in messages.          |
+| `target_session_id`         | No   | Session that can receive the successor.      |
+| `cause`                     | No   | Closed cause value.                          |
+| `node_id`                   | Yes  | Source node when known.                      |
+| `attempt_id`                | Yes  | Source attempt when known.                   |
+| `fallback_facts_json`       | No   | Bounded factual payload.                     |
+| `requested_at`              | No   | Absolute ISO 8601 creation time.             |
+| `eligible_at`               | Yes  | Absolute ISO 8601 fallback eligibility time. |
+| `resolved_at`               | Yes  | Absolute ISO 8601 resolution time.           |
+| `resolution`                | Yes  | Closed resolution value.                     |
+| `resolution_message_id`     | Yes  | Stable message identity.                     |
+| `delivery_claim_token`      | Yes  | Current claimant.                            |
+| `delivery_claim_expires_at` | Yes  | Claim expiry as epoch milliseconds.          |
+
+The table requires these indexes:
+
+- unresolved intents by run and target session;
+- unresolved eligible intents by target session, eligibility time, and intent ID.
+
+A resolved row has all three resolution fields. A pending row has none of them. A row cannot change immutable identity or source fields after creation.
+
+## Fallback facts
+
+`fallback_facts_json` uses this versioned camelCase object:
+
+```json
+{
+  "schema": "pi-workflows.deferred-turn-facts.v1",
+  "workflowName": "autoimplement",
+  "runId": "20260821T081731Z-autoimplement-407480dd",
+  "observedState": "failed",
+  "cause": "failed",
+  "nodeId": "$launch",
+  "attemptId": null,
+  "reason": "scope must be a non-empty string",
+  "handoff": false
+}
+```
+
+Rules:
+
+- `schema` is required and has the exact value shown above.
+- `workflowName`, `runId`, `observedState`, and `cause` are required strings.
+- `nodeId`, `attemptId`, and `reason` are strings or null.
+- `handoff` is a required boolean.
+- `reason` is safe diagnostic text with at most 8,192 characters.
+- The serialized object is at most 64 KiB.
+- Unknown fields are rejected during alpha.
+- The object must not contain credentials, raw environment values, or unbounded command output.
+
+`handoff: true` means another runner can continue. A handoff message must not describe the run as terminal unless separate durable state proves it.
+
+## Store operations
+
+The controller store provides these internal operations:
+
+- `ensureWorkflowTurnIntent`
+- `getWorkflowTurnIntent`
+- `claimWorkflowTurnIntentForRun`
+- `claimEligibleWorkflowTurnIntentsForSession`
+- `makeWorkflowTurnIntentEligible`
+- `resolveWorkflowTurnIntent`
+- `releaseWorkflowTurnIntentClaim`
+- a bounded diagnostic list operation
+
+`ensureWorkflowTurnIntent` is idempotent when all immutable fields match. It fails on an identity collision.
+
+Claim operations use a caller-supplied token and lease duration. Resolution requires the matching live claim token. Conditional updates ensure that natural delivery and fallback cannot both resolve the same intent.
+
+List operations require a positive bounded limit and deterministic ordering.
+
+## Abort ordering
+
+For an eligible active-turn abort, Pi Workflows performs these steps in order:
+
+1. Record abort provenance on the active run.
+2. Build the source event and intent ID.
+3. Attempt to persist the intent.
+4. Record the intent ID in system-abort bookkeeping.
+5. Call `ctx.abort()`.
+
+The persistence attempt is synchronous because cancellation immediately crosses the turn boundary. A store failure does not prevent `ctx.abort()`. Terminal handling retries the same intent ID. If retry also fails, Pi Workflows reports that it could not preserve the successor-turn guarantee.
+
+## Natural delivery
+
+All extension-owned workflow prompts and result presentations pass through one `DeferredTurnCoordinator`.
+
+If no intent exists, the coordinator preserves current message content and delivery options.
+
+If a pending intent exists, the coordinator:
+
+1. waits until the old turn has settled or the session is verified idle;
+2. claims the intent for the run and session;
+3. adds `turnIntentId` to the message details;
+4. sends the normal prompt or presentation;
+5. resolves the intent with the matching resolution and message ID;
+6. releases the claim if sending fails.
+
+A prompt generated during abort handling must not be sent into the aborting turn. The coordinator releases it after `agent_settled`.
+
+## Fallback delivery
+
+Fallback synchronization runs:
+
+- after `agent_settled` and system-abort cleanup;
+- when the target session starts;
+- during the existing periodic synchronization pass while the session is idle.
+
+The fallback custom message uses this details object:
+
+```json
+{
+  "schema": "pi-workflows.deferred-turn-message.v1",
+  "turnIntentId": "deferred-turn:...",
+  "runId": "20260821T081731Z-autoimplement-407480dd",
+  "cause": "failed"
+}
+```
+
+The message type is `pi-workflows-deferred-turn`. Delivery uses:
+
+```ts
+{
+  deliverAs: "followUp",
+  triggerTurn: true,
+}
+```
+
+The visible content reports observed facts and asks the agent to inspect durable state before it decides whether an authorized correction is needed. It does not claim that recovery occurred, resume the old run, or retry work.
+
+Fallback delivery is disabled during session shutdown and while a user-interrupted workflow is held.
+
+## Delivery recovery
+
+Every resolving message includes the intent ID in its custom-message details.
+
+Before sending, the coordinator scans the current session branch for that ID. If the message is already present, the coordinator resolves the intent without sending again. This repairs a crash or SQLite failure that occurs after `sendMessage` succeeds but before resolution is stored.
+
+Store leases prevent concurrent processes from sending the same resolution. Branch identity handles the remaining send-before-resolution window.
+
+## Claim transfer
+
+Claim loss stops the old runner's work and all fenced run-bundle writes. The intent stays pending and fallback-ineligible while another runner can resume the run.
+
+The new runner's next workflow prompt can resolve the intent. If durable state later proves a terminal outcome with no natural successor, terminal handling makes the intent eligible for fallback to its target session.
+
+Time alone does not prove terminal failure.
+
+## Launch notifications
+
+Workflow-authored `progress` and `final` notifications remain passive. They do not trigger model turns.
+
+The `launch_failure` notification kind is removed. Queued launch failure creates an eligible turn intent instead.
+
+Pending `launch_failure` rows from the earlier alpha contract are incompatible. Pi Workflows must stop with a clear controller-store reset instruction. It must not reinterpret, migrate, or silently delete those rows.
+
+## Availability limits
+
+Pi Workflows can guarantee only the facts under its control:
+
+- the intent was stored;
+- a claimant acquired it;
+- a custom message was sent or found in the session branch;
+- the local intent was resolved.
+
+Pi Workflows cannot guarantee model start or completion with the current Pi API. It also cannot deliver after permanent loss of the process, target session, controller store, machine, or model provider.
+
+Undelivered intents remain pending. The implementation does not add a service to process them outside a live Pi session.
+
+## Compatibility
+
+This is an alpha hard cutover.
+
+- Keep `pi-workflows.controller-store.v1`.
+- Add `workflow_turn_intents` to the existing database.
+- Remove the launch-trigger runtime path.
+- Add no v2 schema, compatibility reader, dual write, alias, or feature flag.
+- Keep historical terminal run bundles readable because their contract does not change.
+
+## Conformance
+
+An implementation conforms when:
+
+- one eligible source event produces at most one intent;
+- one intent produces at most one successor message;
+- an agent self-cancel receives one fallback after settlement;
+- an asynchronous crash after a successful start result receives one fallback after settlement;
+- a natural recovery prompt or presentation suppresses fallback by resolving the same intent;
+- direct cancellation, pause, Escape, user hold, and shutdown produce no automatic turn;
+- claim transfer permits natural resolution by the new owner and prevents stale writes;
+- polling, restart, lease expiry, and send-before-resolution failure do not duplicate turns;
+- passive workflow notifications keep their current behavior.

--- a/docs/plans/2026-08-21-deferred-turn-intents-plan.md
+++ b/docs/plans/2026-08-21-deferred-turn-intents-plan.md
@@ -1,0 +1,324 @@
+---
+title: Guarantee one successor turn after workflow interruption
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-08-21
+---
+
+# Guarantee one successor turn after workflow interruption
+
+Pi Workflows can stop the active agent turn before the agent receives a tool result or can take its next action. This happens when an active workflow step is cancelled, times out, loses its queue claim, or is interrupted by a controller. The workflow can also return a successful start result and then fail asynchronously before it sends its first prompt. In that case, the user can see a UI error while the model still believes that the workflow started successfully.
+
+Add one general rule: an eligible workflow event creates one durable obligation for one later agent turn. The next normal workflow prompt or result presentation satisfies the obligation when one exists. Otherwise, Pi Workflows sends one factual fallback turn after the old turn settles.
+
+This plan replaces the earlier corrective-notification idea. A corrective message is one possible fallback. The underlying mechanism is a purpose-neutral successor-turn obligation.
+
+Related documents:
+
+- [Deferred workflow turns](../DEFERRED_TURNS.md)
+- [Make deferred workflow launches durable](../2026-08-20-durable-workflow-launch-plan.md)
+- [Route workflow reports to their starting session](2026-08-13-session-addressed-workflow-notifications-plan.md)
+- [Workflow authoring reference](../workflows.md)
+
+## Goals
+
+- Keep workflow cancellation and process termination immediate.
+- Give an agent that causes its own turn to stop one later normal turn when the Pi session remains available.
+- Give asynchronous workflow failures one model-facing turn when the start tool already returned success.
+- Let the next workflow prompt or presentation satisfy the obligation instead of sending a duplicate fallback.
+- Preserve the obligation across ordinary extension restart, polling, and delivery races.
+- Keep user Escape, pause, direct administrative cancellation, and session shutdown quiet.
+- Keep workflow recovery separate from turn delivery.
+
+## Non-goals
+
+- Do not keep the aborted assistant turn alive.
+- Do not return the cancel tool result to the aborted turn.
+- Do not retry a workflow node, resume a terminal run, or repeat an external mutation.
+- Do not add a workflow-engine primitive or a public workflow-author API.
+- Do not add a service, another database file, an external queue, or a controller.
+- Do not change Pi core or use a private Pi API.
+- Do not guarantee a turn after permanent process, session, machine, storage, or model-provider loss.
+- Do not treat message insertion as proof that the model started or completed a turn.
+- Do not include the separate Autoimplement node-timeout recovery change in this implementation.
+
+## Successor-turn rule
+
+A source event can create at most one `DeferredTurnIntent`. The intent starts pending and resolves once as one of:
+
+- `workflowPrompt`: the next workflow agent prompt was sent;
+- `presentation`: a completed or waiting result presentation was sent;
+- `fallback`: Pi Workflows sent a factual fallback message because no natural successor remained.
+
+The three paths compete for the same record. A successful claim by one path prevents the other paths from sending another turn.
+
+Fallback eligibility is separate from pending state. An intent can remain pending but ineligible while the workflow can still route to another agent step or presentation. Durable terminal or handoff evidence makes the intent eligible only when no immediate natural successor remains.
+
+## Event policy
+
+| Event                                                        | Create an intent | Initial fallback eligibility      | Notes                                                                                                     |
+| ------------------------------------------------------------ | ---------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Agent calls `workflow cancel` during an active workflow turn | Yes              | No                                | Persist before `ctx.abort()`. Terminal cancellation makes it eligible.                                    |
+| Agent-step timeout                                           | Yes              | No                                | A later recovery prompt can resolve it naturally. Terminal timeout makes it eligible.                     |
+| Terminal workflow failure after an active turn abort         | Yes              | No                                | Terminal handling updates the existing intent and makes it eligible.                                      |
+| Workflow reports started, then crashes asynchronously        | Yes              | Yes, after durable failure        | Covers failures before the first workflow prompt, including invalid runtime input discovered after start. |
+| Queued launch activation fails                               | Yes              | Yes, after durable launch failure | Replaces the `launch_failure` notification trigger.                                                       |
+| Controller stops an active workflow agent turn               | Yes              | No                                | Terminal or handoff policy decides eligibility.                                                           |
+| Queue claim is lost during an active agent turn              | Yes              | No                                | Treat as ownership transfer, not failure.                                                                 |
+| Completed or waiting run has a presentation                  | No new intent    | Not applicable                    | The presentation resolves an existing intent when present.                                                |
+| Direct `/workflow cancel`                                    | No               | Not applicable                    | The user explicitly requested control and no automatic model turn.                                        |
+| Ordinary workflow pause                                      | No               | Not applicable                    | The current step stops only at its normal boundary.                                                       |
+| User Escape                                                  | No               | Not applicable                    | Keep the workflow held until explicit resume.                                                             |
+| Session shutdown                                             | No               | Not applicable                    | A closing session cannot run another turn.                                                                |
+
+A later distinct event can create a new intent. Repeated handling of the same source event must return the existing intent.
+
+## Storage
+
+Add `workflow_turn_intents` to the existing `SqliteControllerStore` database. Keep the database path and `pi-workflows.controller-store.v1` schema identifier.
+
+The existing `workflow_notifications` table remains a passive outbox for workflow-authored `progress` and `final` reports. It cannot represent this lifecycle clearly because it has one delivery transition and identifies node notification output. Adding natural resolution, fallback eligibility, and competing claims to that table would mix two different contracts.
+
+The intent table stores:
+
+| Field                       | Meaning                                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| `intent_id`                 | Deterministic primary key                                                                    |
+| `source_event_id`           | Stable identity of the event that requires a successor                                       |
+| `run_id`                    | Related workflow run                                                                         |
+| `workflow_ref`              | Workflow identity used in factual messages                                                   |
+| `target_session_id`         | Pi session that owns the successor turn                                                      |
+| `cause`                     | Closed event cause                                                                           |
+| `node_id`                   | Source node when known                                                                       |
+| `attempt_id`                | Source attempt when known                                                                    |
+| `fallback_facts_json`       | Bounded `pi-workflows.deferred-turn-facts.v1` camelCase facts used to build fallback content |
+| `requested_at`              | Time the obligation was created                                                              |
+| `eligible_at`               | Time fallback became eligible, or null                                                       |
+| `resolved_at`               | Time one path resolved the intent, or null                                                   |
+| `resolution`                | `workflowPrompt`, `presentation`, `fallback`, or null                                        |
+| `resolution_message_id`     | Stable custom-message identity for the resolving send                                        |
+| `delivery_claim_token`      | Current resolution claimant                                                                  |
+| `delivery_claim_expires_at` | Claim lease expiry                                                                           |
+
+Causes are:
+
+```text
+agentCancelled | timedOut | failed | launchFailed | controllerInterrupted | claimLost
+```
+
+The deterministic intent ID includes the target session, run, source event, source node or `$launch`, attempt when known, and cause. Reusing an ID with different immutable facts is an error.
+
+Store methods must support:
+
+- idempotent intent creation;
+- exact lookup;
+- a natural-resolution claim for one run and session;
+- an eligible fallback claim for one session;
+- fallback eligibility updates;
+- resolution with the matching claim token;
+- claim release and lease expiry;
+- bounded diagnostic listing.
+
+Every claim and resolution uses an immediate transaction or conditional update.
+
+## Abort handling
+
+Track abort provenance on the active run before cancellation occurs. The provenance distinguishes:
+
+- agent tool cancellation;
+- direct user cancellation;
+- timeout;
+- controller interruption;
+- claim loss;
+- Escape;
+- shutdown.
+
+When the executor abort callback is about to call `ctx.abort()` for an eligible active turn:
+
+1. Build the deterministic source event and intent ID.
+2. Call `ensureWorkflowTurnIntent` synchronously.
+3. Record the intent ID in system-abort bookkeeping.
+4. Call `ctx.abort()` immediately.
+
+A storage error must not prevent cancellation. Save a bounded error and retry the same intent during terminal handling. If both writes fail, show a clear warning and record a run event. Do not claim that a successor turn is guaranteed.
+
+## Turn coordinator
+
+Add one `DeferredTurnCoordinator` in `src/extension`. All extension-owned workflow agent prompts and result presentations pass through it.
+
+When no intent exists, the coordinator preserves current message content and delivery options.
+
+When an intent exists, the coordinator:
+
+1. Defers the Pi send while the old turn is still active or aborting.
+2. Waits for `agent_settled` or verified idle session state.
+3. Claims the pending intent for natural resolution.
+4. Adds `turnIntentId` to custom-message details.
+5. Sends the normal workflow prompt or presentation.
+6. Resolves the intent as `workflowPrompt` or `presentation`.
+7. Releases the claim if sending fails.
+
+This settlement rule applies to natural prompts as well as fallback messages. A recovery prompt sent while the old turn is aborting can otherwise be lost with that turn.
+
+If the message send succeeds but SQLite resolution fails, later recovery scans the current session branch for `turnIntentId`. An existing message resolves the intent without another send.
+
+## Terminal and asynchronous failures
+
+Terminal handling uses the durable run or launch state as its source of truth.
+
+For `cancelled`, `timed_out`, or `failed` outcomes with no natural successor:
+
+1. Find or recreate the deterministic intent.
+2. Update its bounded fallback facts from the observed terminal state.
+3. Make it fallback-eligible.
+
+A workflow can also fail after `workflow start` returns success but before an active agent step calls `ctx.abort()`. The run completion rejection path must create an already-eligible intent for this case. The current turn can finish normally, and the fallback arrives afterward with the actual failure. This prevents the model from reporting that a crashed workflow is still running.
+
+Completed and waiting outcomes continue through normal presentation. That presentation resolves an existing intent and prevents fallback.
+
+Parked runs remain pending for resume and do not claim a terminal outcome.
+
+## Fallback delivery
+
+The coordinator checks eligible intents:
+
+- after `agent_settled`, after system-abort bookkeeping is clear;
+- when a session starts;
+- during the existing periodic synchronization pass while the session is idle.
+
+For each claimed intent, it sends one `pi-workflows-deferred-turn` custom message with:
+
+- the stable `turnIntentId`;
+- the workflow and run identity;
+- the observed terminal or handoff state;
+- the source node and attempt when known;
+- a bounded safe reason;
+- an instruction to inspect durable state before any authorized correction.
+
+Delivery uses:
+
+```ts
+{
+  deliverAs: "followUp",
+  triggerTurn: true,
+}
+```
+
+The message does not say that recovery ran or succeeded. It does not resume the old run or grant permission for new work.
+
+The coordinator does not deliver while the session is shutting down or while an Escape-interrupted workflow is held.
+
+## Claim loss
+
+Claim loss transfers execution responsibility. It is not proof that the run failed.
+
+The old runner must:
+
+1. Ensure the pending intent before aborting the active turn when possible.
+2. Stop all fenced run-bundle writes.
+3. Leave the intent unresolved and fallback-ineligible while another runner can continue.
+
+The new runner's next workflow prompt can claim and resolve the same intent naturally. Only durable terminal state or explicit no-successor handoff evidence can make the intent fallback-eligible. A timer alone cannot establish failure.
+
+## Launch failure change
+
+Queued launch activation failure moves from `workflow_notifications` to deferred-turn intents.
+
+After the queue row is durably marked failed:
+
+1. Record the launch failure event.
+2. Create one already-eligible intent keyed by the run and `$launch`.
+3. Let post-settlement synchronization deliver the fallback.
+
+Immediate `workflow start` validation errors remain ordinary tool errors in the current live turn and create no intent.
+
+Remove the `launch_failure` runtime notification kind and trigger branch. Existing pending `launch_failure` rows are incompatible alpha state. Detect them before synchronization and give a precise controller-store reset instruction. Do not reinterpret, migrate, or silently delete them.
+
+## Implementation order
+
+1. Add the intent types, validation, row mapping, schema, and store operations.
+2. Add storage tests for identity, eligibility, claims, leases, resolution, and collisions.
+3. Add the event policy, stable identity helper, and fallback builder.
+4. Add abort provenance to active-run control paths.
+5. Persist intents before eligible `ctx.abort()` calls and retry during terminal handling.
+6. Add the coordinator and route workflow prompts and presentations through it.
+7. Add terminal eligibility and asynchronous post-start failure handling.
+8. Move queued launch failure to intents and remove its notification trigger.
+9. Add post-settlement fallback synchronization.
+10. Add claim-loss transfer behavior.
+11. Apply the alpha storage checks and reset error.
+12. Update the workflow documentation to match the shipped behavior.
+13. Run focused tests, real-Pi end-to-end tests, and all repository checks.
+
+## Acceptance criteria
+
+- Agent-issued active cancellation aborts the old turn and produces exactly one later fallback turn.
+- The aborted turn does not receive the cancel result and does not continue work.
+- A timeout with a natural recovery prompt resolves the intent through that prompt and sends no fallback.
+- A terminal timeout sends one fallback after settlement.
+- A workflow that returns a successful start result and then crashes sends one later model-facing failure turn.
+- A completed or waiting presentation resolves an existing intent and sends no fallback.
+- Queued launch failure uses an intent instead of a triggered workflow notification.
+- Direct cancellation, pause, Escape, user hold, and shutdown send no automatic successor turn.
+- Claim loss performs no stale fenced write and can resolve through the new runner's prompt.
+- Polling, extension restart, lease expiry, and repeated terminal handling do not duplicate turns.
+- A send-before-resolution crash is repaired from the session message identity.
+- Permanent intent-store failure is reported without weakening cancellation or claiming delivery.
+- Existing passive progress and final notifications keep their current behavior.
+
+## Tests
+
+Add or extend tests for:
+
+- persisted type validation and JSON round trips;
+- deterministic identity and collision rejection;
+- fresh and existing controller stores;
+- intent creation, eligibility, claims, lease expiry, release, and all resolutions;
+- intent persistence before `ctx.abort()`;
+- agent cancellation and direct user cancellation;
+- terminal timeout and timeout with a natural successor;
+- terminal workflow failure;
+- successful start followed by asynchronous runtime failure before the first prompt;
+- completed and waiting presentation;
+- queued launch failure and immediate start validation failure;
+- controller interruption and claim-loss transfer between two runners;
+- deferred natural prompts and presentations after settlement;
+- busy-session deferral and session-start recovery;
+- duplicate polling and extension restart;
+- send failure and send-before-resolution recovery;
+- Escape, pause, user hold, and shutdown;
+- real-Pi cancellation and timeout ordering with a mock provider.
+
+Use temporary databases and run directories. Tests must not call real models, mutate remote systems, or write outside temporary directories.
+
+## Verification
+
+Run these checks before completion:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+git diff --check
+npx -y @simpledoc/simpledoc check
+```
+
+Keep coverage at or above 85 percent. Inspect the final diff for duplicate turn sources, unresolved claims, stale launch-trigger code, quiet-event regressions, hidden retries, and dependency-boundary violations.
+
+## Rollout
+
+Keep the controller store at `pi-workflows.controller-store.v1` during alpha. Add the intent table in place and remove the launch-trigger runtime path in the same change.
+
+Do not add a schema v2, compatibility reader, dual write, alias, or feature flag. If pending legacy launch notifications exist, stop with a clear reset instruction. Historical terminal run bundles remain readable because this change does not alter the run-bundle contract.
+
+Do not publish a package or create a release without separate authorization.
+
+## Contract impact
+
+- **Session state:** internal workflow messages gain an optional `turnIntentId`; fallback uses `pi-workflows-deferred-turn`.
+- **Controller storage:** add `workflow_turn_intents`; restrict workflow notifications to passive `progress` and `final` kinds.
+- **Run bundles:** unchanged.
+- **Workflow engine:** unchanged.
+- **Workflow author API:** unchanged.
+- **Pi core:** unchanged.
+- **Public Pi APIs:** use existing `sendMessage`, `followUp`, `triggerTurn`, session lifecycle events, and `ctx.abort()`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -502,9 +502,10 @@ use the same card and keep the active attempt id.
 
 Headless RPC execution receives the same complete prompt without TUI metadata.
 Workflow notifications use a separate message type with `triggerTurn: false`,
-so a notification does not start an assistant response. See
-[WORKFLOW_STEP_MESSAGES.md](WORKFLOW_STEP_MESSAGES.md) for the message contract
-and renderer rules.
+so a notification does not start an assistant response. Deferred successor turns
+use an internal turn-intent contract instead of the notification outbox. See
+[WORKFLOW_STEP_MESSAGES.md](WORKFLOW_STEP_MESSAGES.md) for the step-message contract
+and [Deferred workflow turns](DEFERRED_TURNS.md) for the successor-turn contract.
 
 ## Result presentation
 
@@ -527,9 +528,11 @@ After the final run state has been persisted, the Pi extension sends the
 presentation instructions and bounded final result to the model as a hidden
 follow-up message. The next visible message is a normal assistant response.
 Returning `undefined`, returning an empty string, or omitting
-`presentationPrompt` produces no follow-up. Failed, timed-out, and cancelled
-runs are never presented; the extension reports their persisted status and
-error directly. Async prompt builders have 30 seconds to finish and receive an
+`presentationPrompt` produces no presentation. Failed, timed-out, and cancelled
+runs are never presented. When one of those outcomes would otherwise strand an
+agent after a workflow-caused turn abort or asynchronous crash, the extension
+uses the deferred-turn contract to send one factual fallback after settlement.
+Async prompt builders have 30 seconds to finish and receive an
 `AbortSignal` that fires on timeout, session shutdown, or when a new workflow
 or normal user turn starts; stale presentations are discarded. Once a presentation message has
 been queued, another workflow cannot start until that assistant response
@@ -567,13 +570,17 @@ possible. Defaults worth knowing:
   and `running`. `workflow status` and `workflow cancel` accept the run ID before a run bundle
   exists.
 - If deferred activation fails, the queue stores a bounded safe error, releases the session
-  reservation, and sends one follow-up turn to the initiating model. The model can correct the
-  cause and make a new explicit start call. Pi Workflows does not retry blindly.
-- `/workflow cancel` aborts the current node and marks the run `cancelled`.
-  When no run is live but the widget still shows a parked or finished run,
-  the same command clears the widget.
+  reservation, and creates one deferred-turn intent for the initiating session. A workflow that
+  reports `started` and then crashes before its first prompt follows the same path. The model gets
+  one factual follow-up after settlement and can make a new explicit start call. Pi Workflows does
+  not retry blindly.
+- An agent-issued `workflow cancel` aborts the current node and the current Pi turn, then creates
+  one deferred-turn intent. The next natural workflow message resolves it when possible; otherwise
+  one factual fallback starts after settlement. Direct `/workflow cancel` remains quiet because it
+  is explicit user control. When no run is live but the widget still shows a parked or finished run,
+  the command clears the widget.
 - One workflow runs per session at a time.
-- After the workflow tool accepts an agent-step submission, the extension removes any assistant tail text from the rest of that agent run. The next workflow message or notification is the visible continuation. Explicit final presentation remains a separate opt-in response.
+- After the workflow tool accepts an agent-step submission, the extension removes any assistant tail text from the rest of that agent run. The next workflow message is the visible continuation. A deferred intent makes a workflow prompt, presentation, and factual fallback compete to provide one successor turn, so an abort cannot produce two continuation turns.
 - Agent nudges: if the model ends its turn without submitting the pending
   step, it gets a reminder, twice by default, then the step fails.
 

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -34,6 +34,7 @@ const MAX_KEY_LENGTH = 512;
 const MAX_ERROR_LENGTH = 8_192;
 const MAX_EVENT_BYTES = 64 * 1024;
 const MAX_RESOURCE_VALUE_BYTES = 1024 * 1024;
+const TURN_INTENT_FACTS_SCHEMA = "pi-workflows.deferred-turn-facts.v1";
 
 type ResourceRow = {
   controller: string;
@@ -149,7 +150,7 @@ type WorkflowNotificationRow = {
   attempt_id: string;
   notification_index: number;
   target_session_id: string;
-  kind: "progress" | "final" | "launch_failure";
+  kind: string;
   content: string;
   created_at: string;
   delivery_claim_token: string | null;
@@ -164,11 +165,70 @@ export type WorkflowNotificationRecord = {
   attemptId: string;
   notificationIndex: number;
   targetSessionId: string;
-  kind: "progress" | "final" | "launch_failure";
+  kind: "progress" | "final";
   content: string;
   createdAt: string;
   deliveryClaimExpiresAt: string | null;
   deliveredAt: string | null;
+};
+
+export type WorkflowTurnIntentCause =
+  | "agentCancelled"
+  | "timedOut"
+  | "failed"
+  | "launchFailed"
+  | "controllerInterrupted"
+  | "claimLost";
+
+export type WorkflowTurnIntentResolution = "workflowPrompt" | "presentation" | "fallback";
+
+export type WorkflowTurnIntentFacts = JsonObject & {
+  schema: typeof TURN_INTENT_FACTS_SCHEMA;
+  workflowName: string;
+  runId: string;
+  observedState: string;
+  cause: WorkflowTurnIntentCause;
+  nodeId: string | null;
+  attemptId: string | null;
+  reason: string | null;
+  handoff: boolean;
+};
+
+type WorkflowTurnIntentRow = {
+  intent_id: string;
+  source_event_id: string;
+  run_id: string;
+  workflow_ref: string;
+  target_session_id: string;
+  cause: string;
+  node_id: string | null;
+  attempt_id: string | null;
+  fallback_facts_json: string;
+  requested_at: string;
+  eligible_at: string | null;
+  resolved_at: string | null;
+  resolution: string | null;
+  resolution_message_id: string | null;
+  delivery_claim_token: string | null;
+  delivery_claim_expires_at: number | null;
+};
+
+export type WorkflowTurnIntentRecord = {
+  intentId: string;
+  sourceEventId: string;
+  runId: string;
+  workflowRef: string;
+  targetSessionId: string;
+  cause: WorkflowTurnIntentCause;
+  nodeId: string | null;
+  attemptId: string | null;
+  fallbackFacts: WorkflowTurnIntentFacts;
+  requestedAt: string;
+  eligibleAt: string | null;
+  resolvedAt: string | null;
+  resolution: WorkflowTurnIntentResolution | null;
+  resolutionMessageId: string | null;
+  deliveryClaimExpiresAt: string | null;
 };
 
 type RunEventRow = {
@@ -826,7 +886,10 @@ export class SqliteControllerStore implements ControllerStore {
       const existingQueue = this.database
         .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workflow_run_queue'")
         .get();
-      if (existingQueue !== undefined) this.assertAlphaSchemaLayout();
+      if (existingQueue !== undefined) {
+        this.assertAlphaSchemaLayout(false);
+        this.assertNoLegacyPendingLaunchNotifications();
+      }
       this.transaction(() => {
         this.database
           .prepare("INSERT OR IGNORE INTO schema_info (singleton, schema_id) VALUES (1, ?)")
@@ -834,10 +897,11 @@ export class SqliteControllerStore implements ControllerStore {
         this.database.exec(SCHEMA_SQL);
       });
     }
-    this.assertAlphaSchemaLayout();
+    this.assertAlphaSchemaLayout(true);
+    this.assertNoLegacyPendingLaunchNotifications();
   }
 
-  private assertAlphaSchemaLayout(): void {
+  private assertAlphaSchemaLayout(requireTurnIntents: boolean): void {
     const requiredQueueColumns = new Set([
       "run_id",
       "workflow_ref",
@@ -871,6 +935,64 @@ export class SqliteControllerStore implements ControllerStore {
     if (missing.length > 0) {
       throw new Error(
         "Controller store uses an incompatible alpha layout. Preserve needed run bundles, then reset the project controller store.",
+      );
+    }
+    if (!requireTurnIntents) return;
+    const requiredIntentColumns = new Set([
+      "intent_id",
+      "source_event_id",
+      "run_id",
+      "workflow_ref",
+      "target_session_id",
+      "cause",
+      "node_id",
+      "attempt_id",
+      "fallback_facts_json",
+      "requested_at",
+      "eligible_at",
+      "resolved_at",
+      "resolution",
+      "resolution_message_id",
+      "delivery_claim_token",
+      "delivery_claim_expires_at",
+    ]);
+    const intentColumns = new Set(
+      (
+        this.database.pragma("table_info(workflow_turn_intents)") as {
+          name: string;
+        }[]
+      ).map((column) => column.name),
+    );
+    const missingIntentColumns = [...requiredIntentColumns].filter(
+      (column) => !intentColumns.has(column),
+    );
+    if (missingIntentColumns.length > 0) {
+      throw new Error(
+        "Controller store uses an incompatible alpha turn-intent layout. Preserve needed run bundles, then reset the project controller store.",
+      );
+    }
+  }
+
+  private assertNoLegacyPendingLaunchNotifications(): void {
+    const notificationTable = this.database
+      .prepare(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workflow_notifications'",
+      )
+      .get();
+    if (notificationTable === undefined) {
+      throw new Error(
+        "Controller store uses an incompatible alpha notification layout. Preserve needed run bundles, then reset the project controller store.",
+      );
+    }
+    const legacy = this.database
+      .prepare(
+        `SELECT 1 FROM workflow_notifications
+         WHERE kind = 'launch_failure' AND delivered_at IS NULL LIMIT 1`,
+      )
+      .get();
+    if (legacy !== undefined) {
+      throw new Error(
+        "Controller store contains pending alpha launch-failure notifications. Preserve needed run bundles, then reset the project controller store.",
       );
     }
   }
@@ -1526,13 +1648,294 @@ export class SqliteControllerStore implements ControllerStore {
     }));
   }
 
+  ensureWorkflowTurnIntent(options: {
+    intentId: string;
+    sourceEventId: string;
+    runId: string;
+    workflowRef: string;
+    targetSessionId: string;
+    cause: WorkflowTurnIntentCause;
+    nodeId?: string | null;
+    attemptId?: string | null;
+    fallbackFacts: WorkflowTurnIntentFacts;
+    eligible?: boolean;
+    now?: string;
+  }): WorkflowTurnIntentRecord {
+    validateKey(options.intentId, "workflow turn intent id");
+    validateKey(options.sourceEventId, "workflow turn source event id");
+    validateRunId(options.runId);
+    validateKey(options.workflowRef, "workflow turn workflow ref");
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    validateWorkflowTurnIntentCause(options.cause);
+    const nodeId = options.nodeId ?? null;
+    const attemptId = options.attemptId ?? null;
+    if (nodeId !== null) validateKey(nodeId, "workflow turn node id");
+    if (attemptId !== null) validateKey(attemptId, "workflow turn attempt id");
+    const factsJson = workflowTurnIntentFactsJson(options.fallbackFacts);
+    const now = validTimestamp(options.now);
+    const eligibleAt = options.eligible === true ? now : null;
+    this.database
+      .prepare(
+        `INSERT INTO workflow_turn_intents (
+          intent_id, source_event_id, run_id, workflow_ref, target_session_id,
+          cause, node_id, attempt_id, fallback_facts_json, requested_at, eligible_at,
+          resolved_at, resolution, resolution_message_id,
+          delivery_claim_token, delivery_claim_expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL)
+        ON CONFLICT(intent_id) DO NOTHING`,
+      )
+      .run(
+        options.intentId,
+        options.sourceEventId,
+        options.runId,
+        options.workflowRef,
+        options.targetSessionId,
+        options.cause,
+        nodeId,
+        attemptId,
+        factsJson,
+        now,
+        eligibleAt,
+      );
+    const existing = this.getWorkflowTurnIntent(options.intentId);
+    if (existing === undefined) {
+      throw new Error(`Workflow turn intent was not stored: ${options.intentId}`);
+    }
+    if (
+      existing.sourceEventId !== options.sourceEventId ||
+      existing.runId !== options.runId ||
+      existing.workflowRef !== options.workflowRef ||
+      existing.targetSessionId !== options.targetSessionId ||
+      existing.cause !== options.cause ||
+      existing.nodeId !== nodeId ||
+      existing.attemptId !== attemptId
+    ) {
+      throw new Error(`Workflow turn intent identity conflict: ${options.intentId}`);
+    }
+    return existing;
+  }
+
+  getWorkflowTurnIntent(intentId: string): WorkflowTurnIntentRecord | undefined {
+    validateKey(intentId, "workflow turn intent id");
+    const row = this.database
+      .prepare("SELECT * FROM workflow_turn_intents WHERE intent_id = ?")
+      .get(intentId) as WorkflowTurnIntentRow | undefined;
+    return row === undefined ? undefined : workflowTurnIntentFromRow(row);
+  }
+
+  findPendingWorkflowTurnIntent(options: {
+    runId: string;
+    targetSessionId: string;
+  }): WorkflowTurnIntentRecord | undefined {
+    validateRunId(options.runId);
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    const row = this.database
+      .prepare(
+        `SELECT * FROM workflow_turn_intents
+         WHERE run_id = ? AND target_session_id = ? AND resolved_at IS NULL
+         ORDER BY requested_at DESC, intent_id DESC LIMIT 1`,
+      )
+      .get(options.runId, options.targetSessionId) as WorkflowTurnIntentRow | undefined;
+    return row === undefined ? undefined : workflowTurnIntentFromRow(row);
+  }
+
+  claimWorkflowTurnIntent(options: {
+    intentId: string;
+    targetSessionId: string;
+    claimToken: string;
+    leaseMs: number;
+    now?: string;
+  }): WorkflowTurnIntentRecord | undefined {
+    validateKey(options.intentId, "workflow turn intent id");
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    validateKey(options.claimToken, "workflow turn claim token");
+    validateDuration(options.leaseMs, "leaseMs");
+    const nowMs = epoch(validTimestamp(options.now));
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_turn_intents
+         SET delivery_claim_token = ?, delivery_claim_expires_at = ?
+         WHERE intent_id = ? AND target_session_id = ? AND resolved_at IS NULL
+           AND (delivery_claim_expires_at IS NULL OR delivery_claim_expires_at <= ?)`,
+      )
+      .run(
+        options.claimToken,
+        nowMs + options.leaseMs,
+        options.intentId,
+        options.targetSessionId,
+        nowMs,
+      );
+    if (result.changes !== 1) return undefined;
+    const row = this.database
+      .prepare("SELECT * FROM workflow_turn_intents WHERE intent_id = ?")
+      .get(options.intentId) as WorkflowTurnIntentRow;
+    return workflowTurnIntentFromRow(row);
+  }
+
+  claimEligibleWorkflowTurnIntents(options: {
+    targetSessionId: string;
+    claimToken: string;
+    leaseMs: number;
+    limit?: number;
+    now?: string;
+  }): WorkflowTurnIntentRecord[] {
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    validateKey(options.claimToken, "workflow turn claim token");
+    validateDuration(options.leaseMs, "leaseMs");
+    const limit = options.limit ?? 20;
+    if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
+      throw new Error("Workflow turn intent limit must be an integer from 1 through 100");
+    }
+    const now = validTimestamp(options.now);
+    const nowMs = epoch(now);
+    return this.transaction(() => {
+      const ids = this.database
+        .prepare(
+          `SELECT intent_id FROM workflow_turn_intents
+           WHERE target_session_id = ? AND resolved_at IS NULL AND eligible_at IS NOT NULL
+             AND eligible_at <= ?
+             AND (delivery_claim_expires_at IS NULL OR delivery_claim_expires_at <= ?)
+           ORDER BY eligible_at, intent_id LIMIT ?`,
+        )
+        .all(options.targetSessionId, now, nowMs, limit) as { intent_id: string }[];
+      if (ids.length === 0) return [];
+      const placeholders = ids.map(() => "?").join(", ");
+      this.database
+        .prepare(
+          `UPDATE workflow_turn_intents
+           SET delivery_claim_token = ?, delivery_claim_expires_at = ?
+           WHERE intent_id IN (${placeholders}) AND resolved_at IS NULL
+             AND (delivery_claim_expires_at IS NULL OR delivery_claim_expires_at <= ?)`,
+        )
+        .run(
+          options.claimToken,
+          nowMs + options.leaseMs,
+          ...ids.map((row) => row.intent_id),
+          nowMs,
+        );
+      const rows = this.database
+        .prepare(
+          `SELECT * FROM workflow_turn_intents WHERE delivery_claim_token = ?
+           ORDER BY eligible_at, intent_id`,
+        )
+        .all(options.claimToken) as WorkflowTurnIntentRow[];
+      return rows.map(workflowTurnIntentFromRow);
+    });
+  }
+
+  makeWorkflowTurnIntentEligible(options: {
+    intentId: string;
+    fallbackFacts: WorkflowTurnIntentFacts;
+    now?: string;
+  }): boolean {
+    validateKey(options.intentId, "workflow turn intent id");
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_turn_intents
+         SET fallback_facts_json = ?, eligible_at = COALESCE(eligible_at, ?)
+         WHERE intent_id = ? AND resolved_at IS NULL`,
+      )
+      .run(
+        workflowTurnIntentFactsJson(options.fallbackFacts),
+        validTimestamp(options.now),
+        options.intentId,
+      );
+    return result.changes === 1;
+  }
+
+  resolveWorkflowTurnIntent(options: {
+    intentId: string;
+    targetSessionId: string;
+    claimToken: string;
+    resolution: WorkflowTurnIntentResolution;
+    messageId: string;
+    now?: string;
+  }): boolean {
+    validateKey(options.intentId, "workflow turn intent id");
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    validateKey(options.claimToken, "workflow turn claim token");
+    validateWorkflowTurnIntentResolution(options.resolution);
+    validateKey(options.messageId, "workflow turn resolution message id");
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_turn_intents
+         SET resolved_at = ?, resolution = ?, resolution_message_id = ?,
+             delivery_claim_token = NULL, delivery_claim_expires_at = NULL
+         WHERE intent_id = ? AND target_session_id = ? AND resolved_at IS NULL
+           AND delivery_claim_token = ?`,
+      )
+      .run(
+        validTimestamp(options.now),
+        options.resolution,
+        options.messageId,
+        options.intentId,
+        options.targetSessionId,
+        options.claimToken,
+      );
+    return result.changes === 1;
+  }
+
+  releaseWorkflowTurnIntentClaim(options: {
+    intentId: string;
+    targetSessionId: string;
+    claimToken: string;
+  }): boolean {
+    validateKey(options.intentId, "workflow turn intent id");
+    validateKey(options.targetSessionId, "workflow turn target session id");
+    validateKey(options.claimToken, "workflow turn claim token");
+    const result = this.database
+      .prepare(
+        `UPDATE workflow_turn_intents
+         SET delivery_claim_token = NULL, delivery_claim_expires_at = NULL
+         WHERE intent_id = ? AND target_session_id = ? AND resolved_at IS NULL
+           AND delivery_claim_token = ?`,
+      )
+      .run(options.intentId, options.targetSessionId, options.claimToken);
+    return result.changes === 1;
+  }
+
+  listWorkflowTurnIntents(
+    options: {
+      targetSessionId?: string;
+      runId?: string;
+      limit?: number;
+    } = {},
+  ): WorkflowTurnIntentRecord[] {
+    if (options.targetSessionId !== undefined) {
+      validateKey(options.targetSessionId, "workflow turn target session id");
+    }
+    if (options.runId !== undefined) validateRunId(options.runId);
+    const limit = options.limit ?? 20;
+    if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
+      throw new Error("Workflow turn intent limit must be an integer from 1 through 100");
+    }
+    const clauses: string[] = [];
+    const values: unknown[] = [];
+    if (options.targetSessionId !== undefined) {
+      clauses.push("target_session_id = ?");
+      values.push(options.targetSessionId);
+    }
+    if (options.runId !== undefined) {
+      clauses.push("run_id = ?");
+      values.push(options.runId);
+    }
+    const where = clauses.length === 0 ? "" : `WHERE ${clauses.join(" AND ")}`;
+    const rows = this.database
+      .prepare(
+        `SELECT * FROM workflow_turn_intents ${where}
+         ORDER BY requested_at DESC, intent_id DESC LIMIT ?`,
+      )
+      .all(...values, limit) as WorkflowTurnIntentRow[];
+    return rows.map(workflowTurnIntentFromRow);
+  }
+
   enqueueWorkflowNotification(options: {
     runId: string;
     nodeId: string;
     attemptId: string;
     notificationIndex: number;
     targetSessionId: string;
-    kind: "progress" | "final" | "launch_failure";
+    kind: "progress" | "final";
     content: string;
     notificationId?: string;
     now?: string;
@@ -1766,7 +2169,7 @@ const SCHEMA_SQL = `
     attempt_id TEXT NOT NULL,
     notification_index INTEGER NOT NULL CHECK (notification_index > 0),
     target_session_id TEXT NOT NULL,
-    kind TEXT NOT NULL CHECK (kind IN ('progress', 'final', 'launch_failure')),
+    kind TEXT NOT NULL CHECK (kind IN ('progress', 'final')),
     content TEXT NOT NULL,
     created_at TEXT NOT NULL,
     delivery_claim_token TEXT,
@@ -1777,6 +2180,40 @@ const SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS workflow_notifications_pending
     ON workflow_notifications(target_session_id, delivery_claim_expires_at, created_at)
     WHERE delivered_at IS NULL;
+
+  CREATE TABLE IF NOT EXISTS workflow_turn_intents (
+    intent_id TEXT PRIMARY KEY,
+    source_event_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    workflow_ref TEXT NOT NULL,
+    target_session_id TEXT NOT NULL,
+    cause TEXT NOT NULL CHECK (
+      cause IN ('agentCancelled', 'timedOut', 'failed', 'launchFailed',
+                'controllerInterrupted', 'claimLost')
+    ),
+    node_id TEXT,
+    attempt_id TEXT,
+    fallback_facts_json TEXT NOT NULL,
+    requested_at TEXT NOT NULL,
+    eligible_at TEXT,
+    resolved_at TEXT,
+    resolution TEXT CHECK (resolution IN ('workflowPrompt', 'presentation', 'fallback')),
+    resolution_message_id TEXT,
+    delivery_claim_token TEXT,
+    delivery_claim_expires_at INTEGER,
+    CHECK (
+      (resolved_at IS NULL AND resolution IS NULL AND resolution_message_id IS NULL) OR
+      (resolved_at IS NOT NULL AND resolution IS NOT NULL AND resolution_message_id IS NOT NULL)
+    )
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS workflow_turn_intents_one_pending_run
+    ON workflow_turn_intents(run_id, target_session_id) WHERE resolved_at IS NULL;
+  CREATE INDEX IF NOT EXISTS workflow_turn_intents_pending_run
+    ON workflow_turn_intents(run_id, target_session_id, requested_at)
+    WHERE resolved_at IS NULL;
+  CREATE INDEX IF NOT EXISTS workflow_turn_intents_eligible_session
+    ON workflow_turn_intents(target_session_id, eligible_at, intent_id)
+    WHERE resolved_at IS NULL AND eligible_at IS NOT NULL;
 
   CREATE TABLE IF NOT EXISTS effects (
     effect_key TEXT NOT NULL,
@@ -1868,7 +2305,56 @@ function workflowFromRow(row: WorkflowRow): ChildWorkflowRecord {
   };
 }
 
+function workflowTurnIntentFromRow(row: WorkflowTurnIntentRow): WorkflowTurnIntentRecord {
+  const cause = validateWorkflowTurnIntentCause(row.cause);
+  const resolution =
+    row.resolution === null ? null : validateWorkflowTurnIntentResolution(row.resolution);
+  const fallbackFacts = parseStoredJson<unknown>(
+    row.fallback_facts_json,
+    "workflow turn intent facts",
+  );
+  validateWorkflowTurnIntentFacts(fallbackFacts);
+  validateKey(row.intent_id, "workflow turn intent id");
+  validateKey(row.source_event_id, "workflow turn source event id");
+  validateRunId(row.run_id);
+  validateKey(row.workflow_ref, "workflow turn workflow ref");
+  validateKey(row.target_session_id, "workflow turn target session id");
+  validTimestamp(row.requested_at);
+  if (row.eligible_at !== null) validTimestamp(row.eligible_at);
+  if (row.resolved_at !== null) validTimestamp(row.resolved_at);
+  const allResolutionFieldsNull =
+    row.resolved_at === null && row.resolution === null && row.resolution_message_id === null;
+  const allResolutionFieldsSet =
+    row.resolved_at !== null && row.resolution !== null && row.resolution_message_id !== null;
+  if (!allResolutionFieldsNull && !allResolutionFieldsSet) {
+    throw new Error(`Workflow turn intent ${row.intent_id} has inconsistent resolution fields`);
+  }
+  return {
+    intentId: row.intent_id,
+    sourceEventId: row.source_event_id,
+    runId: row.run_id,
+    workflowRef: row.workflow_ref,
+    targetSessionId: row.target_session_id,
+    cause,
+    nodeId: row.node_id,
+    attemptId: row.attempt_id,
+    fallbackFacts,
+    requestedAt: row.requested_at,
+    eligibleAt: row.eligible_at,
+    resolvedAt: row.resolved_at,
+    resolution,
+    resolutionMessageId: row.resolution_message_id,
+    deliveryClaimExpiresAt:
+      row.delivery_claim_expires_at === null ? null : iso(row.delivery_claim_expires_at),
+  };
+}
+
 function workflowNotificationFromRow(row: WorkflowNotificationRow): WorkflowNotificationRecord {
+  if (row.kind !== "progress" && row.kind !== "final") {
+    throw new Error(
+      "Controller store contains an incompatible pending alpha workflow notification. Preserve needed run bundles, then reset the project controller store.",
+    );
+  }
   return {
     notificationId: row.notification_id,
     runId: row.run_id,
@@ -1883,6 +2369,93 @@ function workflowNotificationFromRow(row: WorkflowNotificationRow): WorkflowNoti
       row.delivery_claim_expires_at === null ? null : iso(row.delivery_claim_expires_at),
     deliveredAt: row.delivered_at,
   };
+}
+
+function workflowTurnIntentFactsJson(facts: WorkflowTurnIntentFacts): string {
+  validateWorkflowTurnIntentFacts(facts);
+  const json = canonicalJson(facts, "workflow turn intent facts");
+  validateJsonSize(json, "Workflow turn intent facts", MAX_EVENT_BYTES);
+  return json;
+}
+
+function validateWorkflowTurnIntentFacts(facts: unknown): asserts facts is WorkflowTurnIntentFacts {
+  if (facts === null || typeof facts !== "object" || Array.isArray(facts)) {
+    throw new Error("Workflow turn intent facts must be an object");
+  }
+  const candidate = facts as Record<string, unknown>;
+  if (candidate.schema !== TURN_INTENT_FACTS_SCHEMA) {
+    throw new Error(`Workflow turn intent facts schema must be ${TURN_INTENT_FACTS_SCHEMA}`);
+  }
+  const allowedKeys = new Set([
+    "schema",
+    "workflowName",
+    "runId",
+    "observedState",
+    "cause",
+    "nodeId",
+    "attemptId",
+    "reason",
+    "handoff",
+  ]);
+  for (const key of Object.keys(candidate)) {
+    if (!allowedKeys.has(key)) throw new Error(`Unknown workflow turn intent facts field: ${key}`);
+  }
+  if (typeof candidate.workflowName !== "string") {
+    throw new Error("Workflow turn intent workflowName must be a string");
+  }
+  if (typeof candidate.runId !== "string") {
+    throw new Error("Workflow turn intent runId must be a string");
+  }
+  if (typeof candidate.observedState !== "string") {
+    throw new Error("Workflow turn intent observedState must be a string");
+  }
+  if (typeof candidate.cause !== "string") {
+    throw new Error("Workflow turn intent cause must be a string");
+  }
+  validateKey(candidate.workflowName, "workflow turn facts workflow name");
+  validateRunId(candidate.runId);
+  validateKey(candidate.observedState, "workflow turn facts observed state");
+  validateWorkflowTurnIntentCause(candidate.cause);
+  if (candidate.nodeId !== null && typeof candidate.nodeId !== "string") {
+    throw new Error("Workflow turn intent nodeId must be a string or null");
+  }
+  if (candidate.attemptId !== null && typeof candidate.attemptId !== "string") {
+    throw new Error("Workflow turn intent attemptId must be a string or null");
+  }
+  if (candidate.reason !== null && typeof candidate.reason !== "string") {
+    throw new Error("Workflow turn intent reason must be a string or null");
+  }
+  if (candidate.nodeId !== null) validateKey(candidate.nodeId, "workflow turn facts node id");
+  if (candidate.attemptId !== null) {
+    validateKey(candidate.attemptId, "workflow turn facts attempt id");
+  }
+  if (candidate.reason !== null && candidate.reason.length > MAX_ERROR_LENGTH) {
+    throw new Error(`Workflow turn intent reason must be at most ${MAX_ERROR_LENGTH} characters`);
+  }
+  if (typeof candidate.handoff !== "boolean") {
+    throw new Error("Workflow turn intent handoff must be a boolean");
+  }
+}
+
+function validateWorkflowTurnIntentCause(value: string): WorkflowTurnIntentCause {
+  if (
+    value !== "agentCancelled" &&
+    value !== "timedOut" &&
+    value !== "failed" &&
+    value !== "launchFailed" &&
+    value !== "controllerInterrupted" &&
+    value !== "claimLost"
+  ) {
+    throw new Error(`Invalid workflow turn intent cause: ${value}`);
+  }
+  return value;
+}
+
+function validateWorkflowTurnIntentResolution(value: string): WorkflowTurnIntentResolution {
+  if (value !== "workflowPrompt" && value !== "presentation" && value !== "fallback") {
+    throw new Error(`Invalid workflow turn intent resolution: ${value}`);
+  }
+  return value;
 }
 
 function workflowRunFromRow(row: WorkflowRunQueueRow): WorkflowRunQueueRecord {

--- a/src/extension/deferred-turn-coordinator.ts
+++ b/src/extension/deferred-turn-coordinator.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import type {
+  SqliteControllerStore,
+  WorkflowTurnIntentRecord,
+  WorkflowTurnIntentResolution,
+} from "../controllers/sqlite.js";
+import { deferredTurnMessageId } from "./deferred-turn.js";
+
+export type BranchIntentResolution = {
+  resolution: WorkflowTurnIntentResolution;
+  messageId: string;
+};
+
+type NaturalDelivery = {
+  runId: string;
+  targetSessionId: string;
+  resolution: Exclude<WorkflowTurnIntentResolution, "fallback">;
+  send: (turnIntentId?: string) => void;
+};
+
+type FallbackDelivery = {
+  targetSessionId: string;
+  send: (intent: WorkflowTurnIntentRecord) => void;
+};
+
+export class DeferredTurnCoordinator {
+  private readonly store: () => SqliteControllerStore | null;
+  private readonly branchResolution: (intentId: string) => BranchIntentResolution | null;
+  private readonly leaseMs: number;
+  private readonly deferredNatural = new Map<string, NaturalDelivery>();
+
+  constructor(options: {
+    store: () => SqliteControllerStore | null;
+    branchResolution: (intentId: string) => BranchIntentResolution | null;
+    leaseMs: number;
+  }) {
+    this.store = options.store;
+    this.branchResolution = options.branchResolution;
+    this.leaseMs = options.leaseMs;
+  }
+
+  sendNatural(delivery: NaturalDelivery, idle: boolean): "sent" | "deferred" | "suppressed" {
+    const store = this.store();
+    const intent = store?.findPendingWorkflowTurnIntent({
+      runId: delivery.runId,
+      targetSessionId: delivery.targetSessionId,
+    });
+    if (store === null || store === undefined || intent === undefined) {
+      delivery.send();
+      return "sent";
+    }
+    if (!idle) {
+      this.deferredNatural.set(intent.intentId, delivery);
+      return "deferred";
+    }
+    const result = this.deliverNatural(intent.intentId, delivery);
+    if (result === "deferred") this.deferredNatural.set(intent.intentId, delivery);
+    return result;
+  }
+
+  flushNatural(idle: boolean): number {
+    if (!idle) return 0;
+    let sent = 0;
+    for (const [intentId, delivery] of this.deferredNatural) {
+      const result = this.deliverNatural(intentId, delivery);
+      if (result !== "deferred") {
+        this.deferredNatural.delete(intentId);
+      }
+      if (result === "sent") sent += 1;
+    }
+    return sent;
+  }
+
+  deliverFallbacks(delivery: FallbackDelivery, idle: boolean): number {
+    const store = this.store();
+    if (!idle || store === null) return 0;
+    const claimToken = randomUUID();
+    const intents = store.claimEligibleWorkflowTurnIntents({
+      targetSessionId: delivery.targetSessionId,
+      claimToken,
+      leaseMs: this.leaseMs,
+    });
+    let sent = 0;
+    for (const [index, intent] of intents.entries()) {
+      const branch = this.branchResolution(intent.intentId);
+      if (branch !== null) {
+        store.resolveWorkflowTurnIntent({
+          intentId: intent.intentId,
+          targetSessionId: delivery.targetSessionId,
+          claimToken,
+          resolution: branch.resolution,
+          messageId: branch.messageId,
+        });
+        continue;
+      }
+      try {
+        delivery.send(intent);
+        store.resolveWorkflowTurnIntent({
+          intentId: intent.intentId,
+          targetSessionId: delivery.targetSessionId,
+          claimToken,
+          resolution: "fallback",
+          messageId: deferredTurnMessageId(intent.intentId, "fallback"),
+        });
+        sent += 1;
+      } catch (error) {
+        for (const pending of intents.slice(index)) {
+          store.releaseWorkflowTurnIntentClaim({
+            intentId: pending.intentId,
+            targetSessionId: delivery.targetSessionId,
+            claimToken,
+          });
+        }
+        throw error;
+      }
+    }
+    return sent;
+  }
+
+  clearDeferred(): void {
+    this.deferredNatural.clear();
+  }
+
+  private deliverNatural(
+    intentId: string,
+    delivery: NaturalDelivery,
+  ): "sent" | "deferred" | "suppressed" {
+    const store = this.store();
+    if (store === null) return "deferred";
+    const claimToken = randomUUID();
+    const intent = store.claimWorkflowTurnIntent({
+      intentId,
+      targetSessionId: delivery.targetSessionId,
+      claimToken,
+      leaseMs: this.leaseMs,
+    });
+    if (intent === undefined) {
+      const current = store.getWorkflowTurnIntent(intentId);
+      return current?.resolvedAt === null ? "deferred" : "suppressed";
+    }
+    const branch = this.branchResolution(intent.intentId);
+    if (branch !== null) {
+      store.resolveWorkflowTurnIntent({
+        intentId: intent.intentId,
+        targetSessionId: delivery.targetSessionId,
+        claimToken,
+        resolution: branch.resolution,
+        messageId: branch.messageId,
+      });
+      return "suppressed";
+    }
+    try {
+      delivery.send(intent.intentId);
+      store.resolveWorkflowTurnIntent({
+        intentId: intent.intentId,
+        targetSessionId: delivery.targetSessionId,
+        claimToken,
+        resolution: delivery.resolution,
+        messageId: deferredTurnMessageId(intent.intentId, delivery.resolution),
+      });
+      return "sent";
+    } catch (error) {
+      store.releaseWorkflowTurnIntentClaim({
+        intentId: intent.intentId,
+        targetSessionId: delivery.targetSessionId,
+        claimToken,
+      });
+      throw error;
+    }
+  }
+}

--- a/src/extension/deferred-turn.ts
+++ b/src/extension/deferred-turn.ts
@@ -1,0 +1,166 @@
+import { createHash } from "node:crypto";
+import type {
+  WorkflowTurnIntentCause,
+  WorkflowTurnIntentFacts,
+  WorkflowTurnIntentRecord,
+  WorkflowTurnIntentResolution,
+} from "../controllers/sqlite.js";
+
+export const DEFERRED_TURN_MESSAGE_TYPE = "pi-workflows-deferred-turn";
+export const DEFERRED_TURN_MESSAGE_SCHEMA = "pi-workflows.deferred-turn-message.v1";
+const FACTS_SCHEMA = "pi-workflows.deferred-turn-facts.v1";
+const MAX_REASON_CHARS = 8_192;
+
+export type DeferredTurnSource = {
+  runId: string;
+  workflowName: string;
+  targetSessionId: string;
+  cause: WorkflowTurnIntentCause;
+  sourceEventId: string;
+  observedState: string;
+  nodeId?: string | null;
+  attemptId?: string | null;
+  reason?: string | null;
+  handoff?: boolean;
+};
+
+export type DeferredTurnDescriptor = {
+  intentId: string;
+  sourceEventId: string;
+  runId: string;
+  workflowRef: string;
+  targetSessionId: string;
+  cause: WorkflowTurnIntentCause;
+  nodeId: string | null;
+  attemptId: string | null;
+  fallbackFacts: WorkflowTurnIntentFacts;
+};
+
+export type DeferredTurnMessageDetails = {
+  schema: typeof DEFERRED_TURN_MESSAGE_SCHEMA;
+  turnIntentId: string;
+  runId: string;
+  cause: WorkflowTurnIntentCause;
+};
+
+export function deferredTurnSourceEventId(options: {
+  runId: string;
+  cause: WorkflowTurnIntentCause;
+  nodeId?: string | null;
+  attemptId?: string | null;
+  source?: string;
+}): string {
+  const parts = [
+    options.runId,
+    options.source ?? "run",
+    options.nodeId ?? "$run",
+    options.attemptId ?? "$none",
+    options.cause,
+  ];
+  return `turn-source:${digest(parts)}`;
+}
+
+export function createDeferredTurnDescriptor(source: DeferredTurnSource): DeferredTurnDescriptor {
+  const nodeId = source.nodeId ?? null;
+  const attemptId = source.attemptId ?? null;
+  const fallbackFacts = createDeferredTurnFacts(source);
+  return {
+    intentId: `deferred-turn:${digest([
+      source.targetSessionId,
+      source.runId,
+      source.sourceEventId,
+      nodeId ?? "$run",
+      attemptId ?? "$none",
+      source.cause,
+    ])}`,
+    sourceEventId: source.sourceEventId,
+    runId: source.runId,
+    workflowRef: source.workflowName,
+    targetSessionId: source.targetSessionId,
+    cause: source.cause,
+    nodeId,
+    attemptId,
+    fallbackFacts,
+  };
+}
+
+export function createDeferredTurnFacts(source: DeferredTurnSource): WorkflowTurnIntentFacts {
+  return {
+    schema: FACTS_SCHEMA,
+    workflowName: source.workflowName,
+    runId: source.runId,
+    observedState: source.observedState,
+    cause: source.cause,
+    nodeId: source.nodeId ?? null,
+    attemptId: source.attemptId ?? null,
+    reason: boundedReason(source.reason),
+    handoff: source.handoff ?? false,
+  };
+}
+
+export function deferredTurnMessageId(
+  intentId: string,
+  resolution: WorkflowTurnIntentResolution,
+): string {
+  return `turn-message:${digest([intentId, resolution])}`;
+}
+
+export function deferredTurnMessageDetails(
+  intent: WorkflowTurnIntentRecord,
+): DeferredTurnMessageDetails {
+  return {
+    schema: DEFERRED_TURN_MESSAGE_SCHEMA,
+    turnIntentId: intent.intentId,
+    runId: intent.runId,
+    cause: intent.cause,
+  };
+}
+
+export function buildDeferredTurnContent(intent: WorkflowTurnIntentRecord): string {
+  const facts = intent.fallbackFacts;
+  const source = [
+    facts.nodeId === null ? null : `node ${facts.nodeId}`,
+    facts.attemptId === null ? null : `attempt ${facts.attemptId}`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(", ");
+  const reason =
+    facts.reason === null
+      ? ""
+      : ` Reason: ${facts.reason}${/[.!?]$/.test(facts.reason) ? "" : "."}`;
+  const sourceText = source.length === 0 ? "" : ` Source: ${source}.`;
+  if (facts.cause === "launchFailed") {
+    return [
+      `Workflow ${facts.workflowName} failed to start (run ${facts.runId}).`,
+      `${sourceText}${reason}`.trim(),
+      "Inspect the durable workflow state before you explain the outcome or start a corrected workflow.",
+    ]
+      .filter((part) => part.length > 0)
+      .join(" ");
+  }
+  if (facts.handoff) {
+    return [
+      `Workflow ${facts.workflowName} was handed to another runner (run ${facts.runId}).`,
+      `Observed state: ${facts.observedState}.${sourceText}${reason}`,
+      "Inspect the durable workflow state before you explain the outcome or take any authorized corrective action.",
+    ].join(" ");
+  }
+  return [
+    `Workflow ${facts.workflowName} ended with state ${facts.observedState} (run ${facts.runId}).`,
+    `${sourceText}${reason}`.trim(),
+    "Inspect the durable workflow state before you explain the outcome or take any authorized corrective action.",
+  ]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+function boundedReason(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.length <= MAX_REASON_CHARS ? trimmed : trimmed.slice(0, MAX_REASON_CHARS);
+}
+
+function digest(parts: readonly string[]): string {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex");
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -8,6 +8,10 @@ import {
   SqliteControllerStore,
   type WorkflowRunQueueRecord,
 } from "../controllers/index.js";
+import type {
+  WorkflowTurnIntentCause,
+  WorkflowTurnIntentResolution,
+} from "../controllers/sqlite.js";
 import type { JsonObject } from "../controllers/types.js";
 import type { WorkflowSchedulerResult } from "../controllers/workflows.js";
 import { compositionMetadata } from "../workflows/composition.js";
@@ -63,6 +67,19 @@ import {
   type HumanDecisionChannelAnswer,
   type SettledHumanDecision,
 } from "./decision-channels.js";
+import {
+  DeferredTurnCoordinator,
+  type BranchIntentResolution,
+} from "./deferred-turn-coordinator.js";
+import {
+  buildDeferredTurnContent,
+  createDeferredTurnDescriptor,
+  DEFERRED_TURN_MESSAGE_TYPE,
+  deferredTurnMessageDetails,
+  deferredTurnMessageId,
+  deferredTurnSourceEventId,
+  type DeferredTurnDescriptor,
+} from "./deferred-turn.js";
 import { ConversationStepExecutor } from "./executor.js";
 import {
   HerdrWorkflowViewer,
@@ -108,8 +125,10 @@ const RUN_CLAIM_LEASE_MS = 30_000;
 const RUN_CLAIM_RENEW_MS = 10_000;
 const RUN_SYNC_POLL_MS = 3_000;
 const NOTIFICATION_DELIVERY_LEASE_MS = 30_000;
+const TURN_INTENT_DELIVERY_LEASE_MS = 30_000;
 const WIDGET_KEY = "pi-workflows";
 const PRESENTATION_MESSAGE_TYPE = "pi-workflows-presentation";
+const PRESENTATION_MESSAGE_SCHEMA = "pi-workflows.presentation-message.v1";
 const FINAL_WIDGET_TTL_MS = 60_000;
 const WIDGET_SCROLL_STEP = 3;
 const MAX_PRESENTATION_RESULT_CHARS = 50_000;
@@ -138,6 +157,12 @@ type PresentationPromptBuilder = Exclude<
   string | undefined
 >;
 
+type AbortProvenance = {
+  cause: WorkflowTurnIntentCause;
+  descriptor?: DeferredTurnDescriptor;
+  storageError?: string;
+};
+
 type ActiveRun = {
   runId: string;
   workflowName: string;
@@ -153,6 +178,9 @@ type ActiveRun = {
   onFinish?: (result: WorkflowSchedulerResult) => void;
   completion?: Promise<void>;
   interruptionRequested?: boolean;
+  pendingAbortCause?: WorkflowTurnIntentCause | undefined;
+  abortProvenance?: AbortProvenance | undefined;
+  suppressTurnIntent?: boolean | undefined;
   claimToken?: string | undefined;
   renewTimer?: ReturnType<typeof setInterval> | undefined;
   /** True for runs this session resumed from the queue. */
@@ -400,6 +428,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   let activationRecovery: ((ctx: ExtensionContext) => void) | undefined;
   let decisionRecoveryTimer: ReturnType<typeof setInterval> | null = null;
   let decisionRecoveryActive = false;
+  let turnCoordinator: DeferredTurnCoordinator;
 
   const recordRunEvent = (event: {
     runId: string;
@@ -453,9 +482,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
                 kind: notification.kind,
               },
             },
-            notification.kind === "launch_failure"
-              ? { triggerTurn: true, deliverAs: "followUp" }
-              : { triggerTurn: false },
+            { triggerTurn: false },
           );
           alreadyDelivered.add(notification.notificationId);
         }
@@ -465,6 +492,25 @@ export default function piWorkflows(pi: ExtensionAPI) {
           claimToken,
         });
       }
+      const idle = ctx.isIdle() && systemTurnAbort === null && !sessionClosed && !runHeld();
+      turnCoordinator.flushNatural(idle);
+      turnCoordinator.deliverFallbacks(
+        {
+          targetSessionId: sessionId,
+          send: (intent) => {
+            pi.sendMessage(
+              {
+                customType: DEFERRED_TURN_MESSAGE_TYPE,
+                content: buildDeferredTurnContent(intent),
+                display: true,
+                details: deferredTurnMessageDetails(intent),
+              },
+              { triggerTurn: true, deliverAs: "followUp" },
+            );
+          },
+        },
+        idle,
+      );
     } catch {
       // Delivery retries on the next poll. It never affects workflow execution.
     }
@@ -480,7 +526,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     runSyncTimer.unref?.();
   };
   let activeRun: ActiveRun | null = null;
-  let systemTurnAbort: AgentStepContract | null = null;
+  let systemTurnAbort: { contract: AgentStepContract; intentId?: string } | null = null;
   let suppressWorkflowAssistantTail = false;
   let lastExpiredAttempt: { contract: AgentStepContract; reason: string } | null = null;
   // The interactive run currently parked at a checkpoint, if any.
@@ -500,6 +546,30 @@ export default function piWorkflows(pi: ExtensionAPI) {
   let presentationPending: number | null = null;
   let controllerHost: PiControllerHost | undefined;
   let controllerContext: ExtensionContext | null = null;
+
+  const branchIntentResolution = (intentId: string): BranchIntentResolution | null => {
+    if (controllerContext === null) return null;
+    for (const entry of controllerContext.sessionManager.getBranch()) {
+      if (entry.type !== "custom_message") continue;
+      const details = entry.details;
+      if (details === null || typeof details !== "object" || Array.isArray(details)) continue;
+      if ((details as { turnIntentId?: unknown }).turnIntentId !== intentId) continue;
+      let resolution: WorkflowTurnIntentResolution | null = null;
+      if (entry.customType === WORKFLOW_AGENT_STEP_MESSAGE_TYPE) resolution = "workflowPrompt";
+      if (entry.customType === PRESENTATION_MESSAGE_TYPE) resolution = "presentation";
+      if (entry.customType === DEFERRED_TURN_MESSAGE_TYPE) resolution = "fallback";
+      if (resolution !== null) {
+        return { resolution, messageId: deferredTurnMessageId(intentId, resolution) };
+      }
+    }
+    return null;
+  };
+
+  turnCoordinator = new DeferredTurnCoordinator({
+    store: () => runQueueStore,
+    branchResolution: branchIntentResolution,
+    leaseMs: TURN_INTENT_DELIVERY_LEASE_MS,
+  });
 
   // UI updates are best-effort: a captured ctx becomes stale after session
   // replacement or shutdown, and pi throws on any access (even `ctx.hasUI`).
@@ -541,6 +611,125 @@ export default function piWorkflows(pi: ExtensionAPI) {
   /** True when the run is held for the user (escape or /workflow pause). */
   const runHeld = (): boolean =>
     activeRun !== null && (activeRun.engine.pauseRequested || activeRun.executor.held);
+
+  const originSessionId = (ctx: ExtensionContext, runId: string): string =>
+    ensureRunQueueStore(ctx.cwd).getWorkflowRun(runId)?.originSessionId ??
+    ctx.sessionManager.getSessionId();
+
+  const storeTurnDescriptor = (
+    ctx: ExtensionContext,
+    descriptor: DeferredTurnDescriptor,
+    eligible: boolean,
+  ): void => {
+    ensureRunQueueStore(ctx.cwd).ensureWorkflowTurnIntent({ ...descriptor, eligible });
+  };
+
+  const ensureAbortTurnIntent = (
+    ctx: ExtensionContext,
+    run: ActiveRun,
+    cause: WorkflowTurnIntentCause,
+    contract: AgentStepContract,
+    reason: unknown,
+  ): DeferredTurnDescriptor => {
+    if (run.abortProvenance?.descriptor !== undefined) {
+      return run.abortProvenance.descriptor;
+    }
+    const descriptor = createDeferredTurnDescriptor({
+      runId: run.runId,
+      workflowName: run.workflowName,
+      targetSessionId: originSessionId(ctx, run.runId),
+      cause,
+      sourceEventId: deferredTurnSourceEventId({
+        runId: run.runId,
+        cause,
+        nodeId: contract.nodeId,
+        attemptId: contract.attemptId,
+        source: "agent-step-abort",
+      }),
+      observedState: cause === "claimLost" ? "handedOff" : "interrupted",
+      nodeId: contract.nodeId,
+      attemptId: contract.attemptId,
+      reason: errorMessage(reason),
+      handoff: cause === "claimLost",
+    });
+    run.abortProvenance = { cause, descriptor };
+    try {
+      storeTurnDescriptor(ctx, descriptor, false);
+    } catch (error) {
+      run.abortProvenance.storageError = errorMessage(error);
+    }
+    return descriptor;
+  };
+
+  const makeRunTurnIntentEligible = (
+    ctx: ExtensionContext,
+    run: ActiveRun,
+    observedState: string,
+    reason?: string,
+  ): void => {
+    if (
+      sessionClosed ||
+      run.suppressTurnIntent === true ||
+      (run.childKey !== undefined && run.abortProvenance === undefined) ||
+      run.abortProvenance?.cause === "claimLost"
+    ) {
+      return;
+    }
+    const cause =
+      run.abortProvenance?.cause ?? (observedState === "timed_out" ? "timedOut" : "failed");
+    if (observedState === "cancelled" && run.abortProvenance === undefined) return;
+    const previous = run.abortProvenance?.descriptor;
+    const sourceEventId =
+      previous?.sourceEventId ??
+      deferredTurnSourceEventId({
+        runId: run.runId,
+        cause,
+        nodeId: "$terminal",
+        source: "terminal",
+      });
+    const descriptor = createDeferredTurnDescriptor({
+      runId: run.runId,
+      workflowName: run.workflowName,
+      targetSessionId: originSessionId(ctx, run.runId),
+      cause,
+      sourceEventId,
+      observedState,
+      nodeId: previous?.nodeId ?? "$terminal",
+      attemptId: previous?.attemptId ?? null,
+      reason: reason ?? null,
+      handoff: false,
+    });
+    run.abortProvenance = {
+      cause,
+      descriptor,
+      ...(run.abortProvenance?.storageError === undefined
+        ? {}
+        : { storageError: run.abortProvenance.storageError }),
+    };
+    try {
+      storeTurnDescriptor(ctx, descriptor, false);
+      ensureRunQueueStore(ctx.cwd).makeWorkflowTurnIntentEligible({
+        intentId: descriptor.intentId,
+        fallbackFacts: descriptor.fallbackFacts,
+      });
+      delete run.abortProvenance.storageError;
+      syncArmed = true;
+    } catch (error) {
+      const message = errorMessage(error);
+      run.abortProvenance.storageError = message;
+      recordRunEvent({
+        runId: run.runId,
+        workflowRef: run.workflowName,
+        type: "turn_intent_failed",
+        payload: { error: message },
+      });
+      notify(
+        ctx,
+        `Workflow ${run.workflowName} ended, but Pi Workflows could not preserve its successor turn: ${message}`,
+        "warning",
+      );
+    }
+  };
 
   const footerStatus = (state: WorkflowRunState): string => {
     const label = runHeld() || state.paused ? "paused" : state.status;
@@ -742,24 +931,41 @@ export default function piWorkflows(pi: ExtensionAPI) {
         typeof run.presentationPrompt === "function"
           ? await resolvePresentationPrompt(run.presentationPrompt, state, abort.signal)
           : run.presentationPrompt;
-      if (
-        sessionClosed ||
-        run.generation !== runGeneration ||
-        abort.signal.aborted ||
-        instructions === undefined ||
-        instructions.trim().length === 0
-      ) {
+      if (sessionClosed || run.generation !== runGeneration || abort.signal.aborted) {
         return;
       }
-      presentationPending = run.generation;
-      suppressWorkflowAssistantTail = false;
-      pi.sendMessage(
+      if (instructions === undefined || instructions.trim().length === 0) {
+        if (run.abortProvenance !== undefined) {
+          makeRunTurnIntentEligible(ctx, run, state.status, "No result presentation was available");
+        }
+        return;
+      }
+      turnCoordinator.sendNatural(
         {
-          customType: PRESENTATION_MESSAGE_TYPE,
-          content: buildPresentationMessage(instructions, state),
-          display: false,
+          runId: run.runId,
+          targetSessionId: originSessionId(ctx, run.runId),
+          resolution: "presentation",
+          send: (turnIntentId) => {
+            presentationPending = run.generation;
+            suppressWorkflowAssistantTail = false;
+            pi.sendMessage(
+              {
+                customType: PRESENTATION_MESSAGE_TYPE,
+                content: buildPresentationMessage(instructions, state),
+                display: false,
+                details: {
+                  schema: PRESENTATION_MESSAGE_SCHEMA,
+                  ...(turnIntentId === undefined ? {} : { turnIntentId }),
+                },
+              },
+              {
+                deliverAs: turnIntentId === undefined ? "steer" : "followUp",
+                triggerTurn: true,
+              },
+            );
+          },
         },
-        { deliverAs: "steer", triggerTurn: true },
+        ctx.isIdle() && systemTurnAbort === null,
       );
     } catch (error) {
       if (presentationPending === run.generation) {
@@ -777,6 +983,9 @@ export default function piWorkflows(pi: ExtensionAPI) {
           ? `timed out after ${PRESENTATION_TIMEOUT_MS}ms`
           : errorMessage(error);
       notify(ctx, `Could not present workflow result: ${message}`, "warning");
+      if (run.abortProvenance !== undefined) {
+        makeRunTurnIntentEligible(ctx, run, state.status, message);
+      }
     } finally {
       clearTimeout(timer);
       if (presentationAbort === abort) {
@@ -829,6 +1038,22 @@ export default function piWorkflows(pi: ExtensionAPI) {
       clearWidget(ctx);
       return;
     }
+    if (run.abortProvenance?.cause === "claimLost") {
+      await run.recorder?.stop().catch(() => undefined);
+      releaseClaim(run, "lost");
+      recordRunEvent({
+        runId: run.runId,
+        workflowRef: run.workflowName,
+        type: "claim_lost",
+      });
+      stopWidgetTicker();
+      clearWidget(ctx);
+      notify(
+        ctx,
+        `Workflow ${run.workflowName} continues under another runner (run ${run.runId}).`,
+      );
+      return;
+    }
     releaseClaim(run, "done");
     recordRunEvent({
       runId: run.runId,
@@ -879,6 +1104,15 @@ export default function piWorkflows(pi: ExtensionAPI) {
       run.onFinish?.(childResult);
     } catch (error) {
       notify(ctx, `Could not record child workflow completion: ${errorMessage(error)}`, "warning");
+    }
+    if (state.status === "failed" || state.status === "timed_out" || state.status === "cancelled") {
+      makeRunTurnIntentEligible(ctx, run, state.status, state.error);
+    } else if (
+      run.abortProvenance !== undefined &&
+      run.presentationPrompt === undefined &&
+      (state.status === "completed" || state.status === "waiting")
+    ) {
+      makeRunTurnIntentEligible(ctx, run, state.status, state.error);
     }
     void presentRun(ctx, run, state);
     if (pendingDecision !== null && state.status === "waiting") {
@@ -1011,23 +1245,34 @@ export default function piWorkflows(pi: ExtensionAPI) {
 
     const executor = new ConversationStepExecutor({
       sendPrompt: ({ prompt, contract, presentation, kind, streaming }) => {
-        const details: WorkflowAgentStepMessageDetails = {
-          schema: WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
-          kind,
-          contract,
-          ...(presentation !== undefined ? { presentation } : {}),
-        };
-        pi.sendMessage(
+        turnCoordinator.sendNatural(
           {
-            customType: WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
-            content: prompt,
-            display: true,
-            details,
+            runId,
+            targetSessionId: originSessionId(ctx, runId),
+            resolution: "workflowPrompt",
+            send: (turnIntentId) => {
+              const details: WorkflowAgentStepMessageDetails = {
+                schema: WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA,
+                kind,
+                contract,
+                ...(presentation !== undefined ? { presentation } : {}),
+                ...(turnIntentId === undefined ? {} : { turnIntentId }),
+              };
+              pi.sendMessage(
+                {
+                  customType: WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
+                  content: prompt,
+                  display: true,
+                  details,
+                },
+                {
+                  triggerTurn: true,
+                  deliverAs: streaming ? "steer" : "followUp",
+                },
+              );
+            },
           },
-          {
-            triggerTurn: true,
-            deliverAs: streaming ? "steer" : "followUp",
-          },
+          ctx.isIdle() && systemTurnAbort === null,
         );
       },
       onAbort: (contract, reason) => {
@@ -1036,7 +1281,16 @@ export default function piWorkflows(pi: ExtensionAPI) {
           reason: reason instanceof TimeoutError ? "timed out" : `ended: ${errorMessage(reason)}`,
         };
         if (!executor.held && !ctx.isIdle()) {
-          systemTurnAbort = contract;
+          const cause = reason instanceof TimeoutError ? "timedOut" : run.pendingAbortCause;
+          const descriptor =
+            cause === undefined
+              ? undefined
+              : ensureAbortTurnIntent(ctx, run, cause, contract, reason);
+          run.pendingAbortCause = undefined;
+          systemTurnAbort = {
+            contract,
+            ...(descriptor === undefined ? {} : { intentId: descriptor.intentId }),
+          };
           ctx.abort();
         }
       },
@@ -1137,6 +1391,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           if (
             !store.renewWorkflowRunClaim({ runId, claimToken: token, leaseMs: RUN_CLAIM_LEASE_MS })
           ) {
+            run.pendingAbortCause = "claimLost";
             run.engine.cancel();
           }
         } catch {
@@ -1239,6 +1494,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
         }
         if (terminalStatus !== undefined) {
           recordRunEvent({ runId, workflowRef: workflow.name, type: terminalStatus, payload: {} });
+          if (
+            terminalStatus === "failed" ||
+            terminalStatus === "timed_out" ||
+            terminalStatus === "cancelled"
+          ) {
+            makeRunTurnIntentEligible(ctx, run, terminalStatus, message);
+          }
           notify(ctx, `Workflow ${workflow.name} ${terminalStatus} (run ${runId}).`);
           return;
         }
@@ -1248,6 +1510,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           type: "failed",
           payload: { error: message },
         });
+        makeRunTurnIntentEligible(ctx, run, "failed", message);
         try {
           run.onFinish?.({ state: "failed", runId, error: message });
         } catch {
@@ -1478,11 +1741,14 @@ export default function piWorkflows(pi: ExtensionAPI) {
 
   const cancelWorkflowControl = async (
     ctx: ExtensionContext,
+    origin: "agent" | "user",
     requestedRunId?: string,
   ): Promise<WorkflowControlResult> => {
     if (activeRun && (requestedRunId === undefined || requestedRunId === activeRun.runId)) {
       const workflowName = activeRun.workflowName;
       const runId = activeRun.runId;
+      activeRun.pendingAbortCause = origin === "agent" ? "agentCancelled" : undefined;
+      activeRun.suppressTurnIntent = origin === "user";
       activeRun.engine.cancel();
       return {
         message: `Cancelling workflow ${workflowName}…`,
@@ -1581,6 +1847,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         },
       };
     }
+    activeRun.suppressTurnIntent = true;
     activeRun.engine.pause();
     renderWidget(ctx);
     return {
@@ -1614,6 +1881,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         level: "warning",
       };
     }
+    activeRun.suppressTurnIntent = false;
     activeRun.engine.resume();
     activeRun.executor.release();
     renderWidget(ctx);
@@ -2167,19 +2435,31 @@ export default function piWorkflows(pi: ExtensionAPI) {
         payload: { errorCode: safe.code, error: safe.message },
       });
       const content = `Workflow ${claimed.workflowName} failed to start (run ${claimed.runId}): ${safe.message}. Inspect the error and call workflow start again only after you correct the cause.`;
-      try {
-        queue.enqueueWorkflowNotification({
+      const cause = "launchFailed" as const;
+      const descriptor = createDeferredTurnDescriptor({
+        runId: claimed.runId,
+        workflowName: claimed.workflowName,
+        targetSessionId: claimed.originSessionId ?? ctx.sessionManager.getSessionId(),
+        cause,
+        sourceEventId: deferredTurnSourceEventId({
           runId: claimed.runId,
+          cause,
           nodeId: "$launch",
-          attemptId: claimed.runId,
-          notificationIndex: 1,
-          targetSessionId: claimed.originSessionId ?? ctx.sessionManager.getSessionId(),
-          kind: "launch_failure",
-          content,
-          notificationId: `launch-failure:${claimed.runId}`,
-        });
-      } catch {
-        // A deterministic notification id makes duplicate insertion harmless.
+          source: "queued-launch",
+        }),
+        observedState: "failedToStart",
+        nodeId: "$launch",
+        reason: safe.message,
+      });
+      try {
+        storeTurnDescriptor(ctx, descriptor, true);
+        syncArmed = true;
+      } catch (intentError) {
+        notify(
+          ctx,
+          `Workflow ${claimed.workflowName} failed to start, but Pi Workflows could not preserve its successor turn: ${errorMessage(intentError)}`,
+          "warning",
+        );
       }
       notify(ctx, content, "error");
       runSyncPass(ctx);
@@ -2244,7 +2524,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
         return;
       }
       if (parsed.kind === "cancel") {
-        const result = await cancelWorkflowControl(ctx);
+        const result = await cancelWorkflowControl(ctx, "user");
         notify(ctx, result.message, result.level);
         return;
       }
@@ -2412,6 +2692,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           case "stop":
             if (activeRun?.childKey !== undefined) {
               activeRun.interruptionRequested = true;
+              activeRun.pendingAbortCause = "controllerInterrupted";
               activeRun.engine.cancel();
             }
             await host.stop();
@@ -2454,7 +2735,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
           control = resumeWorkflowControl(ctx);
           break;
         case "cancel":
-          control = await cancelWorkflowControl(ctx, params.runId);
+          control = await cancelWorkflowControl(ctx, "agent", params.runId);
           break;
         case "answer": {
           const waiting = await resolveWaitingWorkflow(ctx, params.runId);
@@ -2636,6 +2917,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (!aborted || runHeld()) {
       return;
     }
+    run.suppressTurnIntent = true;
     run.engine.pause();
     run.executor.hold();
     renderWidget(ctx);
@@ -2686,6 +2968,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", async (_event, ctx) => {
+    systemTurnAbort = null;
     if (activeRun === null) {
       try {
         const prepared = ensureRunQueueStore(ctx.cwd).findSessionReservation(
@@ -2704,15 +2987,20 @@ export default function piWorkflows(pi: ExtensionAPI) {
         return;
       }
     }
+    const flushedNatural = turnCoordinator.flushNatural(
+      ctx.isIdle() && !sessionClosed && !runHeld(),
+    );
     const run = activeRun;
     if (!run) {
       presentationPending = null;
+      runSyncPass(ctx);
       return;
     }
     await run.recorder?.synchronize(ctx).catch(() => undefined);
     run.recorder?.settleAttempt();
     run.executor.setStreaming(false);
-    run.executor.handleAgentSettled();
+    if (flushedNatural === 0) run.executor.handleAgentSettled();
+    runSyncPass(ctx);
   });
 
   pi.on("session_shutdown", async () => {
@@ -2720,8 +3008,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
     herdrProbeGeneration += 1;
     systemTurnAbort = null;
     suppressWorkflowAssistantTail = false;
+    turnCoordinator.clearDeferred();
     supersedePresentation();
     const run = activeRun;
+    if (run !== null) run.suppressTurnIntent = true;
     if (run !== null && run.claimToken !== undefined) {
       // Queued interactive runs park: no terminal event, no recorded partial
       // attempt, and the claim releases so another runner can resume.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -670,16 +670,36 @@ export default function piWorkflows(pi: ExtensionAPI) {
     if (
       sessionClosed ||
       run.suppressTurnIntent === true ||
-      (run.childKey !== undefined && run.abortProvenance === undefined) ||
       run.abortProvenance?.cause === "claimLost"
     ) {
       return;
     }
+    const targetSessionId = originSessionId(ctx, run.runId);
+    const pending = ensureRunQueueStore(ctx.cwd).findPendingWorkflowTurnIntent({
+      runId: run.runId,
+      targetSessionId,
+    });
+    if (
+      run.childKey !== undefined &&
+      run.abortProvenance === undefined &&
+      pending?.cause !== "claimLost"
+    ) {
+      return;
+    }
     const cause =
-      run.abortProvenance?.cause ?? (observedState === "timed_out" ? "timedOut" : "failed");
-    if (observedState === "cancelled" && run.abortProvenance === undefined) return;
+      pending?.cause ??
+      run.abortProvenance?.cause ??
+      (observedState === "timed_out" ? "timedOut" : "failed");
+    if (
+      observedState === "cancelled" &&
+      run.abortProvenance === undefined &&
+      pending === undefined
+    ) {
+      return;
+    }
     const previous = run.abortProvenance?.descriptor;
     const sourceEventId =
+      pending?.sourceEventId ??
       previous?.sourceEventId ??
       deferredTurnSourceEventId({
         runId: run.runId,
@@ -689,13 +709,13 @@ export default function piWorkflows(pi: ExtensionAPI) {
       });
     const descriptor = createDeferredTurnDescriptor({
       runId: run.runId,
-      workflowName: run.workflowName,
-      targetSessionId: originSessionId(ctx, run.runId),
+      workflowName: pending?.workflowRef ?? run.workflowName,
+      targetSessionId,
       cause,
       sourceEventId,
       observedState,
-      nodeId: previous?.nodeId ?? "$terminal",
-      attemptId: previous?.attemptId ?? null,
+      nodeId: pending?.nodeId ?? previous?.nodeId ?? "$terminal",
+      attemptId: pending?.attemptId ?? previous?.attemptId ?? null,
       reason: reason ?? null,
       handoff: false,
     });

--- a/src/extension/step-message.ts
+++ b/src/extension/step-message.ts
@@ -12,6 +12,7 @@ export type WorkflowAgentStepMessageDetails = {
   kind: PromptDeliveryKind;
   contract: AgentStepContract;
   presentation?: AgentStepPresentation;
+  turnIntentId?: string;
 };
 
 type WorkflowAgentStepMessage = {

--- a/test/deferred-turn.test.ts
+++ b/test/deferred-turn.test.ts
@@ -1,0 +1,196 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SqliteControllerStore } from "../src/controllers/sqlite.js";
+import {
+  DeferredTurnCoordinator,
+  type BranchIntentResolution,
+} from "../src/extension/deferred-turn-coordinator.js";
+import {
+  buildDeferredTurnContent,
+  createDeferredTurnDescriptor,
+  deferredTurnMessageId,
+  deferredTurnSourceEventId,
+} from "../src/extension/deferred-turn.js";
+import { makeTempDir } from "./helpers.js";
+
+const stores: SqliteControllerStore[] = [];
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close();
+});
+
+async function makeStore(): Promise<SqliteControllerStore> {
+  const dir = await makeTempDir("pi-deferred-turn");
+  const store = new SqliteControllerStore(path.join(dir, "controller.sqlite"));
+  stores.push(store);
+  return store;
+}
+
+function descriptor(observedState = "interrupted") {
+  const cause = "agentCancelled" as const;
+  return createDeferredTurnDescriptor({
+    runId: "run-1",
+    workflowName: "autoimplement",
+    targetSessionId: "session-a",
+    cause,
+    sourceEventId: deferredTurnSourceEventId({
+      runId: "run-1",
+      cause,
+      nodeId: "implement",
+      attemptId: "attempt-1",
+      source: "agent-step-abort",
+    }),
+    observedState,
+    nodeId: "implement",
+    attemptId: "attempt-1",
+    reason: "cancelled",
+  });
+}
+
+function ensure(store: SqliteControllerStore, eligible = false) {
+  const value = descriptor(eligible ? "cancelled" : "interrupted");
+  return store.ensureWorkflowTurnIntent({ ...value, eligible });
+}
+
+describe("deferred turn policy", () => {
+  it("creates stable identities and factual bounded messages", async () => {
+    const store = await makeStore();
+    const first = descriptor();
+    const second = descriptor();
+    expect(second).toEqual(first);
+    const intent = store.ensureWorkflowTurnIntent({ ...first, eligible: true });
+    expect(buildDeferredTurnContent(intent)).toContain(
+      "Workflow autoimplement ended with state interrupted (run run-1).",
+    );
+    expect(buildDeferredTurnContent(intent)).toContain("Inspect the durable workflow state");
+    expect(buildDeferredTurnContent(intent)).not.toMatch(/resumed|recovered successfully/i);
+  });
+
+  it("defers a natural successor until settlement and resolves it once", async () => {
+    const store = await makeStore();
+    const intent = ensure(store);
+    const branch = new Map<string, BranchIntentResolution>();
+    const coordinator = new DeferredTurnCoordinator({
+      store: () => store,
+      branchResolution: (intentId) => branch.get(intentId) ?? null,
+      leaseMs: 1_000,
+    });
+    const sent: (string | undefined)[] = [];
+    expect(
+      coordinator.sendNatural(
+        {
+          runId: "run-1",
+          targetSessionId: "session-a",
+          resolution: "workflowPrompt",
+          send: (intentId) => {
+            sent.push(intentId);
+            if (intentId !== undefined) {
+              branch.set(intentId, {
+                resolution: "workflowPrompt",
+                messageId: deferredTurnMessageId(intentId, "workflowPrompt"),
+              });
+            }
+          },
+        },
+        false,
+      ),
+    ).toBe("deferred");
+    expect(sent).toEqual([]);
+    expect(coordinator.flushNatural(true)).toBe(1);
+    expect(sent).toEqual([intent.intentId]);
+    expect(store.getWorkflowTurnIntent(intent.intentId)).toMatchObject({
+      resolution: "workflowPrompt",
+    });
+    expect(coordinator.flushNatural(true)).toBe(0);
+  });
+
+  it("releases a fallback claim when message delivery fails", async () => {
+    const store = await makeStore();
+    ensure(store, true);
+    const coordinator = new DeferredTurnCoordinator({
+      store: () => store,
+      branchResolution: () => null,
+      leaseMs: 1_000,
+    });
+    expect(() =>
+      coordinator.deliverFallbacks(
+        {
+          targetSessionId: "session-a",
+          send: () => {
+            throw new Error("send failed");
+          },
+        },
+        true,
+      ),
+    ).toThrow("send failed");
+    const sent: string[] = [];
+    expect(
+      coordinator.deliverFallbacks(
+        {
+          targetSessionId: "session-a",
+          send: (intent) => sent.push(intent.intentId),
+        },
+        true,
+      ),
+    ).toBe(1);
+    expect(sent).toHaveLength(1);
+  });
+
+  it("delivers one eligible fallback and repairs branch delivery without resending", async () => {
+    const store = await makeStore();
+    const first = ensure(store, true);
+    const branch = new Map<string, BranchIntentResolution>();
+    const coordinator = new DeferredTurnCoordinator({
+      store: () => store,
+      branchResolution: (intentId) => branch.get(intentId) ?? null,
+      leaseMs: 1_000,
+    });
+    const sent: string[] = [];
+    expect(
+      coordinator.deliverFallbacks(
+        {
+          targetSessionId: "session-a",
+          send: (intent) => {
+            sent.push(intent.intentId);
+            branch.set(intent.intentId, {
+              resolution: "fallback",
+              messageId: deferredTurnMessageId(intent.intentId, "fallback"),
+            });
+          },
+        },
+        true,
+      ),
+    ).toBe(1);
+    expect(sent).toEqual([first.intentId]);
+    expect(
+      coordinator.deliverFallbacks(
+        { targetSessionId: "session-a", send: () => sent.push("duplicate") },
+        true,
+      ),
+    ).toBe(0);
+
+    const secondDescriptor = createDeferredTurnDescriptor({
+      runId: "run-2",
+      workflowName: "monitor",
+      targetSessionId: "session-a",
+      cause: "failed",
+      sourceEventId: "event-2",
+      observedState: "failed",
+      nodeId: "$terminal",
+      reason: "boom",
+    });
+    const second = store.ensureWorkflowTurnIntent({ ...secondDescriptor, eligible: true });
+    branch.set(second.intentId, {
+      resolution: "fallback",
+      messageId: deferredTurnMessageId(second.intentId, "fallback"),
+    });
+    expect(
+      coordinator.deliverFallbacks(
+        { targetSessionId: "session-a", send: () => sent.push("duplicate") },
+        true,
+      ),
+    ).toBe(0);
+    expect(store.getWorkflowTurnIntent(second.intentId)?.resolution).toBe("fallback");
+    expect(sent).toEqual([first.intentId]);
+  });
+});

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -174,6 +174,36 @@ export default defineWorkflow({
 });
 `;
 
+const POST_START_CRASH_E2E_WORKFLOW = `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "post-start-crash-e2e",
+  startAt: "validate",
+  nodes: {
+    validate: compute({
+      run: ({ input }) => {
+        const scope = input && typeof input === "object" ? input.scope : undefined;
+        if (typeof scope !== "string" || scope.trim().length === 0) {
+          throw new Error("scope must be a non-empty string");
+        }
+        return { scope };
+      },
+    }),
+  },
+  edges: [],
+});
+`;
+
+const SELF_CANCEL_E2E_WORKFLOW = `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "self-cancel-e2e",
+  startAt: "work",
+  nodes: { work: agent({ prompt: () => "Cancel this workflow now." }) },
+  edges: [],
+});
+`;
+
 const COMMAND_BATCH_E2E_WORKFLOW = `import { action, compute, defineWorkflow, runCommandBatch } from "@osolmaz/pi-workflows";
 
 export default defineWorkflow({
@@ -399,6 +429,12 @@ describe.sequential("pi-workflows end to end", () => {
         if (lastUserText.includes("Presentation instructions:")) {
           return { kind: "text", text: "Implemented the boring, proven design." };
         }
+        if (lastUserText.includes("Workflow post-start-crash-e2e ended with state failed")) {
+          return { kind: "text", text: "Post-start crash observed." };
+        }
+        if (lastUserText.includes("Workflow self-cancel-e2e ended with state cancelled")) {
+          return { kind: "text", text: "Self-cancellation observed." };
+        }
         if (
           lastRole === "user" &&
           (lastUserText === "Start the durable launch fixture now." ||
@@ -412,6 +448,20 @@ describe.sequential("pi-workflows end to end", () => {
               workflow: "durable-launch-e2e",
               input: { task: lastUserText },
             },
+          };
+        }
+        if (lastRole === "user" && lastUserText === "Start the post-start crash fixture now.") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: { action: "start", workflow: "post-start-crash-e2e", input: {} },
+          };
+        }
+        if (lastRole === "user" && lastUserText === "Start the self-cancel fixture now.") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: { action: "start", workflow: "self-cancel-e2e", input: {} },
           };
         }
         if (lastRole === "user" && lastUserText === "Start the built-in monitor now.") {
@@ -507,6 +557,12 @@ describe.sequential("pi-workflows end to end", () => {
             },
           };
         }
+        const selfCancelStepMatch = lastUserText.match(
+          /workflow step contract \(workflow: self-cancel-e2e, step: work, attempt: ([a-z0-9-]+)\)/i,
+        );
+        if (selfCancelStepMatch) {
+          return { kind: "tool", toolName: "workflow", args: { action: "cancel" } };
+        }
         const monitorStepMatch = lastUserText.match(
           /workflow step contract \(workflow: monitor, step: ([a-z_]+), attempt: ([a-z0-9-]+)\)/i,
         );
@@ -593,6 +649,16 @@ describe.sequential("pi-workflows end to end", () => {
     await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "durable-launch-e2e.workflow.ts"),
       DURABLE_LAUNCH_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "post-start-crash-e2e.workflow.ts"),
+      POST_START_CRASH_E2E_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "self-cancel-e2e.workflow.ts"),
+      SELF_CANCEL_E2E_WORKFLOW,
       "utf8",
     );
     await fs.writeFile(
@@ -750,6 +816,127 @@ describe.sequential("pi-workflows end to end", () => {
         .filter((record) => record.workflowName === "durable-launch-e2e");
       expect(records.map((record) => record.status).sort()).toEqual(["done", "failed"]);
       expect(records[0]?.runId).not.toBe(records[1]?.runId);
+      expect(
+        store
+          .listWorkflowTurnIntents({ limit: 100 })
+          .filter((intent) => intent.runId === queued.runId),
+      ).toMatchObject([{ cause: "launchFailed", resolution: "fallback" }]);
+    } finally {
+      store.close();
+    }
+  }, 60_000);
+
+  it("starts one later turn after a post-start runtime crash", async () => {
+    const requestsBefore = mock.requests.length;
+    const settledBefore = pi.stdoutLines.filter((line) =>
+      line.includes('"type":"agent_settled"'),
+    ).length;
+    pi.send({
+      id: "post-start-crash",
+      type: "prompt",
+      message: "Start the post-start crash fixture now.",
+    });
+
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "post-start-crash-e2e" && candidate.status === "failed",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    expect(state.error).toContain("scope must be a non-empty string");
+    await waitForCondition(
+      () => {
+        const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+        try {
+          return store
+            .listWorkflowTurnIntents({ runId: state.runId })
+            .some((intent) => intent.cause === "failed" && intent.resolution === "fallback");
+        } finally {
+          store.close();
+        }
+      },
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () => mock.requests.length >= requestsBefore + 3,
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () => pi.stdoutLines.some((line) => line.includes("Post-start crash observed.")),
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () =>
+        pi.stdoutLines.filter((line) => line.includes('"type":"agent_settled"')).length >=
+        settledBefore + 2,
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+    try {
+      expect(store.listWorkflowTurnIntents({ runId: state.runId })).toMatchObject([
+        { cause: "failed", resolution: "fallback", resolvedAt: expect.any(String) },
+      ]);
+    } finally {
+      store.close();
+    }
+  }, 60_000);
+
+  it("starts one later turn after an agent cancels its own workflow", async () => {
+    const requestsBefore = mock.requests.length;
+    const settledBefore = pi.stdoutLines.filter((line) =>
+      line.includes('"type":"agent_settled"'),
+    ).length;
+    pi.send({
+      id: "self-cancel",
+      type: "prompt",
+      message: "Start the self-cancel fixture now.",
+    });
+
+    const { state } = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "self-cancel-e2e" && candidate.status === "cancelled",
+      () =>
+        `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}\n${mock.requests
+          .slice(-5)
+          .map((request) => contentText(request.messages.at(-1)?.content))
+          .join("\n---\n")}`,
+      15_000,
+    );
+    await waitForCondition(
+      () => {
+        const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+        try {
+          return store
+            .listWorkflowTurnIntents({ runId: state.runId })
+            .some(
+              (intent) => intent.cause === "agentCancelled" && intent.resolution === "fallback",
+            );
+        } finally {
+          store.close();
+        }
+      },
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () => mock.requests.length >= requestsBefore + 4,
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () => pi.stdoutLines.some((line) => line.includes("Self-cancellation observed.")),
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    await waitForCondition(
+      () =>
+        pi.stdoutLines.filter((line) => line.includes('"type":"agent_settled"')).length >=
+        settledBefore + 3,
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+    );
+    const store = new SqliteControllerStore(controllerFile, { readOnly: true });
+    try {
+      expect(store.listWorkflowTurnIntents({ runId: state.runId })).toMatchObject([
+        { cause: "agentCancelled", resolution: "fallback", resolvedAt: expect.any(String) },
+      ]);
     } finally {
       store.close();
     }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -883,6 +883,65 @@ describe("pi-workflows extension", () => {
     }
   });
 
+  it("gives an agent one later turn after it cancels its active workflow", async () => {
+    const cwd = await makeTempDir("pi-workflows-self-cancel");
+    const runsDir = await makeTempDir("pi-workflows-self-cancel-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      await writeEchoWorkflow(cwd);
+      const harness = makeHarness({ cwd, respond: () => {} });
+      await harness.emitAsync("session_start");
+      await harness.tool.execute("start-self-cancel", {
+        action: "start",
+        workflow: "mini",
+      });
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-agent-step",
+        ),
+      );
+
+      const cancelled = await harness.tool.execute("cancel-self", { action: "cancel" });
+      expect(cancelled.content[0]?.text).toContain("Cancelling workflow mini");
+      await waitFor(() => harness.abortCalls === 1);
+      await waitFor(() =>
+        harness.notifications.some((note) => note.includes("Workflow mini cancelled")),
+      );
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
+
+      await harness.emitAsync("agent_end", { messages: [{ stopReason: "aborted" }] });
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      );
+      const fallback = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+      );
+      expect(fallback).toMatchObject({
+        options: { triggerTurn: true, deliverAs: "followUp" },
+        message: {
+          content: expect.stringContaining("state cancelled"),
+          details: expect.objectContaining({ cause: "agentCancelled" }),
+        },
+      });
+      await harness.emitAsync("agent_settled");
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("bounds and paginates workflow lists returned to the model", async () => {
     const cwd = await makeTempDir("pi-workflows-tool-list");
     vi.stubEnv("HOME", await makeTempDir("pi-workflows-tool-list-home"));
@@ -1092,18 +1151,19 @@ export default defineWorkflow({
       await harness.emitAsync("agent_settled");
       await waitFor(() =>
         harness.sentMessages.some(
-          (entry) =>
-            entry.message.customType === "pi-workflows-notification" &&
-            entry.message.details?.kind === "launch_failure",
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
         ),
       );
       const failureMessages = harness.sentMessages.filter(
-        (entry) => entry.message.details?.kind === "launch_failure",
+        (entry) => entry.message.customType === "pi-workflows-deferred-turn",
       );
       expect(failureMessages).toHaveLength(1);
       expect(failureMessages[0]).toMatchObject({
         options: { triggerTurn: true, deliverAs: "followUp" },
-        message: { content: expect.stringContaining("failed to start") },
+        message: {
+          content: expect.stringContaining("failed to start"),
+          details: expect.objectContaining({ cause: "launchFailed" }),
+        },
       });
 
       const failed = await harness.tool.execute("status-failed-launch", {
@@ -1131,7 +1191,85 @@ export default defineWorkflow({
       );
       await harness.emitAsync("agent_settled");
       expect(
-        harness.sentMessages.filter((entry) => entry.message.details?.kind === "launch_failure"),
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("starts a later turn when a successfully queued workflow crashes before its first prompt", async () => {
+    const cwd = await makeTempDir("pi-workflows-post-start-crash");
+    const runsDir = await makeTempDir("pi-workflows-post-start-crash-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      const dir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "crash.workflow.ts"),
+        `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  name: "crash",
+  startAt: "validate",
+  nodes: {
+    validate: compute({
+      run: ({ input }) => {
+        const scope = input && typeof input === "object" ? input.scope : undefined;
+        if (typeof scope !== "string" || scope.trim().length === 0) {
+          throw new Error("scope must be a non-empty string");
+        }
+        return { scope };
+      },
+    }),
+  },
+  edges: [],
+});
+`,
+        "utf8",
+      );
+      const harness = makeHarness({ cwd, respond: () => {} });
+      await harness.emitAsync("session_start");
+
+      const queued = await harness.tool.execute("start-crash", {
+        action: "start",
+        workflow: "crash",
+        input: {},
+      });
+      expect(queued.details).toMatchObject({ action: "start", queued: true });
+
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.notifications.some((note) => note.includes("scope must be a non-empty string")),
+      );
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
+
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      );
+      const fallback = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+      );
+      expect(fallback).toMatchObject({
+        options: { triggerTurn: true, deliverAs: "followUp" },
+        message: {
+          content: expect.stringContaining("scope must be a non-empty string"),
+          details: expect.objectContaining({ cause: "failed" }),
+        },
+      });
+      await harness.emitAsync("agent_settled");
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
       ).toHaveLength(1);
     } finally {
       vi.unstubAllEnvs();
@@ -1429,7 +1567,7 @@ export default defineWorkflow({
       const harness = makeHarness({
         cwd,
         respond: (prompt) => {
-          contract = stepFromPrompt(prompt);
+          contract = stepFromPrompt(prompt) ?? contract;
         },
       });
 
@@ -1453,6 +1591,17 @@ export default defineWorkflow({
           (entry) => entry.message.customType === "pi-workflows-agent-step",
         ),
       ).toHaveLength(1);
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      );
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(1);
 
       const capturedContract = contract as unknown as {
         step: string;
@@ -1469,6 +1618,134 @@ export default defineWorkflow({
           output: { too: "late" },
         }),
       ).rejects.toThrow(/timed out; its output is no longer accepted/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("uses the next recovery prompt instead of a timeout fallback", async () => {
+    const cwd = await makeTempDir("pi-workflows-timeout-recovery");
+    const runsDir = await makeTempDir("pi-workflows-timeout-recovery-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      const dir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "timeout-recovery.workflow.ts"),
+        `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  name: "timeout-recovery",
+  startAt: "wait",
+  nodes: {
+    wait: agent({ prompt: () => "Wait.", timeoutMs: 30 }),
+    recover: agent({ prompt: () => "Inspect the timed-out work." }),
+  },
+  edges: [
+    { from: "wait", switch: { on: "$result.outcome", cases: { timed_out: "recover" } } },
+  ],
+});
+`,
+        "utf8",
+      );
+      const harness = makeHarness({ cwd, respond: () => {} });
+
+      await harness.command.handler("timeout-recovery", harness.ctx);
+      await waitFor(() => harness.abortCalls === 1);
+      await harness.emitAsync("agent_end", { messages: [{ stopReason: "aborted" }] });
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some((entry) =>
+          entry.message.content.includes("Inspect the timed-out work."),
+        ),
+      );
+      const recovery = harness.sentMessages.find((entry) =>
+        entry.message.content.includes("Inspect the timed-out work."),
+      );
+      expect(recovery).toMatchObject({
+        message: {
+          customType: "pi-workflows-agent-step",
+          details: expect.objectContaining({ turnIntentId: expect.any(String) }),
+        },
+        options: { triggerTurn: true },
+      });
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
+      const store = new SqliteControllerStore(projectControllerStorePath(cwd), { readOnly: true });
+      try {
+        expect(store.listWorkflowTurnIntents()).toMatchObject([
+          { resolution: "workflowPrompt", resolvedAt: expect.any(String) },
+        ]);
+      } finally {
+        store.close();
+      }
+      await harness.emitAsync("session_shutdown");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("uses a completed presentation instead of a timeout fallback", async () => {
+    const cwd = await makeTempDir("pi-workflows-timeout-presentation");
+    const runsDir = await makeTempDir("pi-workflows-timeout-presentation-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      const dir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "timeout-presentation.workflow.ts"),
+        `import { agent, compute, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  name: "timeout-presentation",
+  presentationPrompt: "Explain that recovery completed.",
+  startAt: "wait",
+  nodes: {
+    wait: agent({ prompt: () => "Wait.", timeoutMs: 30 }),
+    recover: compute({ run: () => ({ recovered: true }) }),
+  },
+  edges: [
+    { from: "wait", switch: { on: "$result.outcome", cases: { timed_out: "recover" } } },
+  ],
+});
+`,
+        "utf8",
+      );
+      const harness = makeHarness({ cwd, respond: () => {} });
+
+      await harness.command.handler("timeout-presentation", harness.ctx);
+      await waitFor(() => harness.abortCalls === 1);
+      await harness.emitAsync("agent_end", { messages: [{ stopReason: "aborted" }] });
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-presentation",
+        ),
+      );
+      const presentation = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-presentation",
+      );
+      expect(presentation).toMatchObject({
+        message: {
+          content: expect.stringContaining("Explain that recovery completed."),
+          details: expect.objectContaining({ turnIntentId: expect.any(String) }),
+        },
+        options: { triggerTurn: true, deliverAs: "followUp" },
+      });
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
+      const store = new SqliteControllerStore(projectControllerStorePath(cwd), { readOnly: true });
+      try {
+        expect(store.listWorkflowTurnIntents()).toMatchObject([
+          { resolution: "presentation", resolvedAt: expect.any(String) },
+        ]);
+      } finally {
+        store.close();
+      }
     } finally {
       vi.unstubAllEnvs();
     }
@@ -1495,8 +1772,14 @@ export default defineWorkflow({
       harness.setIdle(false);
 
       await waitFor(() => harness.notifications.some((note) => note.includes("timed_out")));
+      await harness.emitAsync("agent_settled");
 
       expect(harness.abortCalls).toBe(0);
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
     } finally {
       vi.unstubAllEnvs();
     }
@@ -2415,6 +2698,12 @@ export default defineWorkflow({
       expect(harness.notifications.at(-1)).toContain("is not paused");
       await workflow?.handler("cancel", harness.ctx);
       await waitFor(() => harness.notifications.some((note) => note.includes("cancelled")));
+      await harness.emitAsync("agent_settled");
+      expect(
+        harness.sentMessages.filter(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      ).toHaveLength(0);
       await harness.emitAsync("session_shutdown");
     } finally {
       vi.unstubAllEnvs();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SqliteControllerStore } from "../src/controllers/sqlite.js";
 import { projectControllerStorePath } from "../src/controllers/store.js";
+import {
+  createDeferredTurnDescriptor,
+  deferredTurnSourceEventId,
+} from "../src/extension/deferred-turn.js";
 import piWorkflows from "../src/extension/index.js";
 import type { WorkflowToolInput } from "../src/extension/workflow-tool.js";
 import { HumanDecisionStore } from "../src/workflows/human-decision.js";
@@ -1271,6 +1275,101 @@ export default defineWorkflow({
           (entry) => entry.message.customType === "pi-workflows-deferred-turn",
         ),
       ).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("reuses a pending claim-loss intent when the new runner fails terminally", async () => {
+    const cwd = await makeTempDir("pi-workflows-claim-loss-terminal");
+    const runsDir = await makeTempDir("pi-workflows-claim-loss-terminal-runs");
+    vi.stubEnv("PI_WORKFLOWS_RUNS_DIR", runsDir);
+    try {
+      const dir = path.join(cwd, ".pi", "workflows");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "claim-transfer.workflow.ts"),
+        `import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+export default defineWorkflow({
+  name: "claim-transfer",
+  startAt: "fail",
+  nodes: { fail: compute({ run: () => { throw new Error("new runner failed"); } }) },
+  edges: [],
+});
+`,
+        "utf8",
+      );
+      const harness = makeHarness({ cwd, sessionId: "session-a", respond: () => {} });
+      await harness.emitAsync("session_start");
+      const queued = await harness.tool.execute("start-claim-transfer", {
+        action: "start",
+        workflow: "claim-transfer",
+      });
+      const runId = queued.details.runId as string;
+      const sourceEventId = deferredTurnSourceEventId({
+        runId,
+        cause: "claimLost",
+        nodeId: "work",
+        attemptId: "attempt-1",
+        source: "agent-step-abort",
+      });
+      const descriptor = createDeferredTurnDescriptor({
+        runId,
+        workflowName: "claim-transfer",
+        targetSessionId: "session-a",
+        cause: "claimLost",
+        sourceEventId,
+        observedState: "handedOff",
+        nodeId: "work",
+        attemptId: "attempt-1",
+        reason: "claim transferred",
+        handoff: true,
+      });
+      const queue = new SqliteControllerStore(projectControllerStorePath(cwd));
+      queue.ensureWorkflowTurnIntent({ ...descriptor, eligible: false });
+      queue.close();
+
+      await harness.emitAsync("agent_settled");
+      await waitFor(() => harness.notifications.some((note) => note.includes("new runner failed")));
+      await harness.emitAsync("agent_settled");
+      await waitFor(() =>
+        harness.sentMessages.some(
+          (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+        ),
+      );
+
+      const fallback = harness.sentMessages.find(
+        (entry) => entry.message.customType === "pi-workflows-deferred-turn",
+      );
+      expect(fallback).toMatchObject({
+        options: { triggerTurn: true, deliverAs: "followUp" },
+        message: {
+          content: expect.stringContaining("ended with state failed"),
+          details: expect.objectContaining({
+            cause: "claimLost",
+            turnIntentId: descriptor.intentId,
+          }),
+        },
+      });
+      expect(fallback?.message.content).not.toContain("handed to another runner");
+
+      const reader = new SqliteControllerStore(projectControllerStorePath(cwd), {
+        readOnly: true,
+      });
+      try {
+        expect(reader.listWorkflowTurnIntents({ runId })).toEqual([
+          expect.objectContaining({
+            intentId: descriptor.intentId,
+            resolution: "fallback",
+            fallbackFacts: expect.objectContaining({
+              observedState: "failed",
+              handoff: false,
+            }),
+          }),
+        ]);
+      } finally {
+        reader.close();
+      }
     } finally {
       vi.unstubAllEnvs();
     }

--- a/test/run-queue.test.ts
+++ b/test/run-queue.test.ts
@@ -349,6 +349,161 @@ describe("workflow run queue", () => {
     ).toBe(false);
   });
 
+  it("stores and resolves deferred turn intents exactly once", async () => {
+    const store = await makeStore();
+    const fallbackFacts = {
+      schema: "pi-workflows.deferred-turn-facts.v1" as const,
+      workflowName: "autoimplement",
+      runId: "run-1",
+      observedState: "interrupted",
+      cause: "agentCancelled" as const,
+      nodeId: "implement",
+      attemptId: "attempt-1",
+      reason: "cancelled",
+      handoff: false,
+    };
+    const first = store.ensureWorkflowTurnIntent({
+      intentId: "intent-1",
+      sourceEventId: "event-1",
+      runId: "run-1",
+      workflowRef: "autoimplement",
+      targetSessionId: "session-a",
+      cause: "agentCancelled",
+      nodeId: "implement",
+      attemptId: "attempt-1",
+      fallbackFacts,
+      now: T0,
+    });
+    expect(
+      store.ensureWorkflowTurnIntent({
+        intentId: "intent-1",
+        sourceEventId: "event-1",
+        runId: "run-1",
+        workflowRef: "autoimplement",
+        targetSessionId: "session-a",
+        cause: "agentCancelled",
+        nodeId: "implement",
+        attemptId: "attempt-1",
+        fallbackFacts,
+        now: T1,
+      }),
+    ).toEqual(first);
+    expect(() =>
+      store.ensureWorkflowTurnIntent({
+        intentId: "intent-1",
+        sourceEventId: "different-event",
+        runId: "run-1",
+        workflowRef: "autoimplement",
+        targetSessionId: "session-a",
+        cause: "agentCancelled",
+        fallbackFacts,
+        now: T1,
+      }),
+    ).toThrow(/identity conflict/);
+    expect(
+      store.claimEligibleWorkflowTurnIntents({
+        targetSessionId: "session-a",
+        claimToken: "claim-a",
+        leaseMs: 1_000,
+        now: T0,
+      }),
+    ).toEqual([]);
+    expect(
+      store.makeWorkflowTurnIntentEligible({
+        intentId: "intent-1",
+        fallbackFacts: { ...fallbackFacts, observedState: "cancelled" },
+        now: T1,
+      }),
+    ).toBe(true);
+    expect(
+      store.claimWorkflowTurnIntent({
+        intentId: "intent-1",
+        targetSessionId: "session-a",
+        claimToken: "natural-claim",
+        leaseMs: 1_000,
+        now: T1,
+      })?.eligibleAt,
+    ).toBe(T1);
+    expect(
+      store.resolveWorkflowTurnIntent({
+        intentId: "intent-1",
+        targetSessionId: "session-a",
+        claimToken: "wrong-claim",
+        resolution: "workflowPrompt",
+        messageId: "message-1",
+        now: T2,
+      }),
+    ).toBe(false);
+    expect(
+      store.resolveWorkflowTurnIntent({
+        intentId: "intent-1",
+        targetSessionId: "session-a",
+        claimToken: "natural-claim",
+        resolution: "workflowPrompt",
+        messageId: "message-1",
+        now: T2,
+      }),
+    ).toBe(true);
+    expect(store.getWorkflowTurnIntent("intent-1")).toMatchObject({
+      resolvedAt: T2,
+      resolution: "workflowPrompt",
+      resolutionMessageId: "message-1",
+    });
+    expect(
+      store.claimEligibleWorkflowTurnIntents({
+        targetSessionId: "session-a",
+        claimToken: "fallback-claim",
+        leaseMs: 1_000,
+        now: T3,
+      }),
+    ).toEqual([]);
+  });
+
+  it("rejects pending legacy launch-failure notifications", async () => {
+    const dir = await makeTempDir("pi-run-queue-legacy-launch");
+    const databasePath = path.join(dir, "state", "controller.sqlite");
+    const store = new SqliteControllerStore(databasePath);
+    store.close();
+    const raw = new Database(databasePath);
+    raw.pragma("ignore_check_constraints = ON");
+    raw
+      .prepare(
+        `INSERT INTO workflow_notifications (
+          notification_id, run_id, node_id, attempt_id, notification_index,
+          target_session_id, kind, content, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "legacy-launch",
+        "run-1",
+        "$launch",
+        "run-1",
+        1,
+        "session-a",
+        "launch_failure",
+        "failed",
+        T0,
+      );
+    raw.exec("DROP TABLE workflow_turn_intents");
+    raw.close();
+
+    expect(() => new SqliteControllerStore(databasePath)).toThrow(
+      /pending alpha launch-failure notifications.*reset the project controller store/,
+    );
+    const unchanged = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        unchanged
+          .prepare(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workflow_turn_intents'",
+          )
+          .get(),
+      ).toBeUndefined();
+    } finally {
+      unchanged.close();
+    }
+  });
+
   it("rejects duplicate run ids and unsafe inputs", async () => {
     const store = await makeStore();
     enqueue(store);


### PR DESCRIPTION
> Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A workflow could stop the active agent turn and leave the model with no chance to see the outcome or correct it.
A workflow could also report that it started, crash before its first prompt, and show the error only in the UI.
This change records one durable successor-turn obligation and resolves it through the next workflow prompt, result presentation, or one factual fallback after settlement.

## What Changed

Pi Workflows now owns one internal turn-intent lifecycle. The workflow engine and workflow-author API remain unchanged.

- Added `workflow_turn_intents` to the existing controller SQLite database.
- Added deterministic intent identities, fallback eligibility, claim leases, one-time resolution, and session-branch deduplication.
- Added a `DeferredTurnCoordinator` for workflow prompts, presentations, and fallback turns.
- Persisted eligible intent identity before workflow-caused `ctx.abort()` calls when storage is available.
- Added post-settlement fallback handling for agent cancellation, terminal timeout or failure, controller interruption, and asynchronous post-start crashes.
- Treated queue claim loss as ownership transfer instead of an unproved terminal failure.
- Kept direct cancellation, pause, Escape, user hold, and session shutdown quiet.
- Replaced the launch-specific `launch_failure` notification trigger with the general turn-intent path.
- Added the [deferred-turn specification](https://github.com/osolmaz/pi-workflows/blob/feat/deferred-turn-intents/docs/DEFERRED_TURNS.md) and [implementation plan](https://github.com/osolmaz/pi-workflows/blob/feat/deferred-turn-intents/docs/plans/2026-08-21-deferred-turn-intents-plan.md).

## Testing

Local checks cover storage races, natural prompt and presentation resolution, fallback delivery, restart recovery, quiet user-control paths, claim transfer, and real Pi lifecycle ordering.
The real-Pi tests include agent self-cancellation and the exact case where start succeeds before `scope must be a non-empty string` crashes the run.

- `npm run check` — passed; 70 test files and 953 tests passed with coverage above all 85% thresholds.
- `npm run test:e2e` — passed; 3 files and 18 real-Pi tests passed.
- `npx slophammer-ts@latest dry .` — passed with no candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — passed with no findings.
- `git diff --check` — passed.
- `npx -y @simpledoc/simpledoc check` — still reports the repository's existing migration work for 10 older documents; no changed deferred-turn document was listed.

## Risks

The intent is durable only while the local controller store and target Pi session remain available.
Current Pi APIs prove message insertion or branch presence, not that a model turn started or completed.

- A failed pre-abort store write is retried at terminal handling. Permanent store failure is reported and cannot provide the guarantee.
- Pending alpha `launch_failure` notification rows require the documented controller-store reset. There is no compatibility reader or silent migration.
- The separate Autoimplement node-timeout recovery plan remains outside this change.
