### PR TITLE
feat(skills): add one-shot workflow start contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,39 @@ Repository rules:
   destructive actions.
 - New engine features need unit tests and a section in `docs/workflows.md`.
 
+## Built-in workflow skill style
+
+Skills that start a built-in workflow must help the model make one complete start call. Follow this
+structure in every such `SKILL.md`:
+
+1. Put a `Start the workflow` section near the top.
+2. State when to list workflows and when to make the single `start` call.
+3. List every input field that affects scope, authority, safety, routing, or completion. Explain how to
+   derive it from the conversation, when to omit it, and its safe default.
+4. Include one exact, valid JSON `workflow` start example. Use obvious placeholder values and tell the
+   model to replace them with facts from the conversation. Do not use comments or ellipses inside the
+   JSON.
+5. Tell the model to build the complete input before it starts. Do not rely on later turns to repair
+   omitted fields.
+6. Keep the active-workflow guard: a skill loaded inside a workflow step completes that step and does
+   not start a nested workflow.
+
+For workflows that can mutate code or remote state, examples and field rules must include:
+
+- an absolute repository path;
+- a concrete scope that names allowed repositories and allowed edit, test, commit, push,
+  pull-request, merge, release, and deployment actions;
+- inherited user and repository constraints;
+- the base branch; and
+- explicit merge and release authority, defaulting to false when authority is absent.
+
+When one repository and task are unambiguous, instruct the model to derive a narrow scope instead of
+asking the user to restate it. A repository path alone is not a scope. The derived scope must exclude
+unrelated repositories and consequential actions that the user did not authorize.
+
+Keep examples short enough to copy as a unit, but complete enough to execute after placeholder values
+are replaced. Use the same headings and field language across the built-in workflow skills.
+
 ## Alpha compatibility policy
 
 pi-workflows is in alpha. Until the repository explicitly leaves alpha:

--- a/skills/autodoc/SKILL.md
+++ b/skills/autodoc/SKILL.md
@@ -6,7 +6,38 @@ compatibility: Requires pi-workflows and the built-in autodoc workflow.
 
 # Autodoc
 
-Use the built-in `autodoc` Pi Workflow when it is available. At top level, list workflows, then start `autodoc` once with the task, existing plan, repository, known documents, and evidence from the conversation. Do not manually duplicate stages owned by the workflow.
+## Start the workflow
+
+Use the built-in `autodoc` workflow when it is available. At top level, list workflows, build the complete input, and start `autodoc` once. Do not manually duplicate stages owned by the workflow.
+
+Build the input as follows:
+
+- `task`: State what selected plan must be recorded and that this run is documentation-only.
+- `plan`: Pass the complete selected plan. Autodoc does not devise or improve it.
+- `repository`: Use the absolute path of the repository that owns the canonical documentation.
+- `documents`: Include every known canonical specification or plan candidate. Use an empty array when none is known.
+- `evidence`: Include implementation evidence or current-document evidence when it affects whether documentation is current.
+
+Replace the example values below with facts from the conversation, then make one start call:
+
+```json
+{
+  "action": "start",
+  "workflow": "autodoc",
+  "input": {
+    "task": "Record the selected timeout fallback plan without implementing it.",
+    "plan": {
+      "summary": "Add one bounded read-only timeout fallback.",
+      "requirements": ["Keep cancellation terminal."]
+    },
+    "repository": "/absolute/path/to/repository",
+    "documents": ["docs/plans/timeout-fallback-plan.md"],
+    "evidence": {
+      "currentBehavior": "A timeout ends the run."
+    }
+  }
+}
+```
 
 When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract.
 

--- a/skills/autoimplement/SKILL.md
+++ b/skills/autoimplement/SKILL.md
@@ -4,9 +4,54 @@ description: Use when the user asks to implement a plan end-to-end, test it, run
 compatibility: Requires Pi Workflows and the built-in autoimplement workflow.
 ---
 
-Use the built-in `autoimplement` Pi Workflow when it is available. At top level, list workflows, then start `autoimplement` once with the task, existing plan, repository, scope, constraints, base branch, merge policy, and any explicit command concurrency limits from the conversation. Set `merge: true` only when the user explicitly requested merge or an applicable standing instruction authorizes it. Otherwise set it to false. Do not manually duplicate stages already owned by the workflow.
+# Autoimplement
 
-Autoimplement runs independent pi-reviewer commands, pending CI watches, and local verification commands from separate repositories in bounded batches. It keeps model turns, fixes, pushes, comment changes, merges, and releases ordered. One repository uses the same batch path with concurrency one.
+## Start the workflow
+
+Use the built-in `autoimplement` workflow when it is available. At top level, list workflows, build the complete input, and start `autoimplement` once. Do not start with a partial input and repair it in later turns.
+
+Build the input as follows:
+
+- `task`: Preserve the user's requested end state.
+- `plan`: Pass the selected plan or the full contents of its canonical plan document. Do not devise a new initial plan.
+- `repository`: Use the absolute path of the repository that owns the work.
+- `scope`: Always include a concrete authority statement. Name every allowed repository and the allowed edit, test, commit, push, pull-request, merge, and release actions. Carry forward exclusions from the conversation. A repository path alone is not a scope.
+- `constraints`: Include all applicable user and repository constraints. Use an empty array when none apply.
+- `baseBranch`: Use the requested base or the repository default branch.
+- `merge`: Set `true` only when the user explicitly requested merge or an applicable standing instruction authorizes it. Otherwise set `false`.
+- `documents`: Include known canonical plan or specification paths. Use an empty array when none are known.
+- `concurrency`: Include it only when the conversation gives explicit limits.
+
+When one repository is clearly named, derive the scope without asking the user to restate it. A safe derived scope permits only work needed for the task in that repository, including local verification and normal branch and pull-request publication. It excludes unrelated repositories, merge, release, deployment, credentials, and policy changes unless those actions are explicitly authorized.
+
+Replace the example values below with facts from the conversation, then make one start call:
+
+```json
+{
+  "action": "start",
+  "workflow": "autoimplement",
+  "input": {
+    "task": "Implement the selected timeout fallback plan end to end.",
+    "plan": {
+      "canonicalDocument": "docs/plans/timeout-fallback-plan.md",
+      "summary": "Add a bounded timeout fallback.",
+      "requirements": [
+        "Route supported timeouts to one read-only fallback.",
+        "Keep cancellation terminal."
+      ],
+      "verification": ["npm run check", "npm run test:e2e"]
+    },
+    "repository": "/absolute/path/to/repository",
+    "scope": "Only /absolute/path/to/repository. May edit and test task-related files, create commits, push the task branch, and open or update its pull request. Must not modify other repositories, merge, release, deploy, change credentials, or change repository policy.",
+    "constraints": ["Preserve immediate cancellation.", "Keep deferred-turn work separate."],
+    "baseBranch": "main",
+    "merge": false,
+    "documents": ["docs/plans/timeout-fallback-plan.md"]
+  }
+}
+```
+
+Do not manually duplicate stages already owned by the workflow. Autoimplement runs independent pi-reviewer commands, pending CI watches, and local verification commands from separate repositories in bounded batches. It keeps model turns, fixes, pushes, comment changes, merges, and releases ordered. One repository uses the same batch path with concurrency one.
 
 When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract with the available tools.
 

--- a/skills/autoplan/SKILL.md
+++ b/skills/autoplan/SKILL.md
@@ -6,7 +6,31 @@ compatibility: Requires pi-workflows and the built-in autoplan workflow.
 
 # Autoplan
 
-Use the built-in `autoplan` Pi Workflow when it is available. At top level, list workflows, then start `autoplan` once with the problem, authorized scope, constraints, previous plan, and new evidence from the conversation.
+## Start the workflow
+
+Use the built-in `autoplan` workflow when it is available. At top level, list workflows, build the complete input, and start `autoplan` once.
+
+Build the input as follows:
+
+- `problem`: State the decision or implementation-planning problem and its observable end state.
+- `scope`: Name the repositories, systems, and interfaces that may change. State important exclusions. Derive an unambiguous repository-local scope without asking the user to restate it.
+- `constraints`: Preserve all user, repository, safety, compatibility, cost, and authority limits. Use an empty array when none apply.
+- `previousPlan`: Include it only when revising an existing plan.
+- `newEvidence`: Include it only when evidence caused the revision request.
+
+Replace the example values below with facts from the conversation, then make one start call:
+
+```json
+{
+  "action": "start",
+  "workflow": "autoplan",
+  "input": {
+    "problem": "Choose a production-ready timeout fallback and write its implementation plan.",
+    "scope": "Only /absolute/path/to/repository. Plan changes to its public workflow API, built-in workflow, tests, and documentation. Exclude Pi core, external services, credentials, releases, and unrelated repositories.",
+    "constraints": ["Keep cancellation terminal.", "Use only documented public interfaces."]
+  }
+}
+```
 
 When this skill is loaded inside an active workflow step, do not start another workflow. Complete the current step contract.
 

--- a/skills/monitor/SKILL.md
+++ b/skills/monitor/SKILL.md
@@ -10,9 +10,9 @@ Use the built-in Pi `monitor` workflow as an autopilot for the requested objecti
 
 A monitor request authorizes routine, bounded work needed to preserve and finish the stated objective, subject to the conversation and repository approval boundaries. Apply other skills as safety and operating instructions. Do not turn their normal checks into new approval requests when the monitored objective and an existing approval already cover the action. Monitoring does not authorize changing the objective, method, model, data source, production selection, or other consequential contract.
 
-## Prepare and start without delay
+## Start the workflow without delay
 
-As soon as the user invokes this skill:
+Build the complete input and start the workflow in the same turn. As soon as the user invokes this skill:
 
 1. Read the current conversation, active plan, repository instructions, and applicable compute, runtime, credential, deployment, or publication skills.
 2. Preserve the exact objective, immutable execution contract, current identifiers, durable progress, cost already spent, approval ceilings, finish criteria, and known recovery rules in the workflow input. Write or update a durable plan or incident note first only when the work needs one for safe continuation.
@@ -30,6 +30,36 @@ Derive the workflow input from the full conversation:
 - `everyMinutes`: Use the user's interval when present. Use `30` when the user gives no interval. The built-in workflow accepts intervals from 1 minute through 24 hours.
 - `stopWhen`: Infer verified completion from the full conversation. Describe completion of the complete objective, not only the end of one physical process. Also name material blockers that require human intervention.
 - `repair`: Include this object only when the request or an existing approval authorizes mutation. Set `authorized: true` and record the repository, scope, base branch, merge policy, and constraints that apply. Omit it for observation-only work.
+
+Replace the example values below with facts from the conversation, then make one start call:
+
+```json
+{
+  "action": "start",
+  "workflow": "monitor",
+  "input": {
+    "task": "Monitor GitHub Actions run 123456 in owner/repository. Inspect the run and its artifacts, retry only transient status reads, and report each check. Do not change code or repository state.",
+    "everyMinutes": 5,
+    "stopWhen": "Stop when run 123456 completes and its required artifacts are verified, or when a material external blocker prevents truthful verification.",
+    "checkTimeoutMinutes": 10
+  }
+}
+```
+
+For authorized repair, add a complete `repair` object instead of leaving mutation authority implicit:
+
+```json
+{
+  "repair": {
+    "authorized": true,
+    "repository": "/absolute/path/to/repository",
+    "scope": "Only /absolute/path/to/repository. May diagnose and fix failures related to the monitored objective, test, commit, push, and update its pull request. Must not modify other repositories, merge, release, deploy, change credentials, or change repository policy.",
+    "constraints": ["Keep the monitored objective and method unchanged."],
+    "baseBranch": "main",
+    "merge": false
+  }
+}
+```
 
 When the conversation gives no clear finish criterion, set `stopWhen` to `Stop only when the user explicitly asks to stop.` Do not use that fallback when a broader implementation, repair, publication, or deployment objective is clear from context.
 
@@ -60,23 +90,7 @@ When the paid action remains within the approved method, hardware, concurrency, 
 
 The monitor may use a credential only when the conversation or repository has already authorized that credential's source, destination, and purpose. It may reuse that authorization for retries and replacement attempts under the same objective. It must not discover unrelated credentials, broaden scopes, copy credentials to a new store, or print secret values.
 
-## Start the workflow
-
-Start the built-in workflow in the current session with this shape:
-
-```text
-workflow({
-  action: "start",
-  workflow: "monitor",
-  input: {
-    task: "<complete objective, contract, recovery authority, and verification task>",
-    everyMinutes: 30,
-    stopWhen: "<derived finish criterion or explicit-user-stop fallback>"
-  }
-})
-```
-
-Use the user-supplied interval instead of `30` when present. Add `maxChecks` only when the user explicitly supplies that limit. Do not send `reportWhen`; the current monitor reports every accepted check.
+Use the user-supplied interval instead of the example value when present. Add `maxChecks` only when the user explicitly supplies that limit. Do not send `reportWhen`; the current monitor reports every accepted check.
 
 Do not start a second monitor for the same objective while one is active. Update or replace the run only when the objective or contract changes. A replacement must preserve the previous accepted observation and durable recovery state.
 

--- a/skills/pi-workflows/SKILL.md
+++ b/skills/pi-workflows/SKILL.md
@@ -22,7 +22,21 @@ Use the smallest applicable action:
 - `update` publishes a non-completing durable update for the active step attempt.
 - `submit` completes the active agent step with its required output.
 
-Use `start` only once for one requested run. Do not build a manual polling loop around a workflow that already schedules its own work. Use the `monitor` skill for monitoring requests.
+Use `start` only once for one requested run. Before starting, load the matching workflow skill when one exists and build its complete input. Include scope, authority, constraints, identifiers, and finish criteria required by that skill. Do not start with placeholders that still need user or model repair.
+
+For a workflow without a specialized skill, inspect its input contract and make one complete call. For example:
+
+```json
+{
+  "action": "start",
+  "workflow": "examples/workflows/echo.workflow.ts",
+  "input": {
+    "task": "Summarize this repository in one sentence."
+  }
+}
+```
+
+Do not build a manual polling loop around a workflow that already schedules its own work. Use the `monitor` skill for monitoring requests.
 
 ## Complete agent steps
 

--- a/test/bundled-skills.test.ts
+++ b/test/bundled-skills.test.ts
@@ -25,7 +25,7 @@ describe("bundled workflow skills", () => {
   it.each(["autodoc", "autoimplement", "autoplan"])(
     "routes %s through its built-in workflow",
     (name) => {
-      expect(skill(name)).toContain(`built-in \`${name}\` Pi Workflow`);
+      expect(skill(name)).toContain(`built-in \`${name}\` workflow`);
     },
   );
 

--- a/test/package-resources.test.ts
+++ b/test/package-resources.test.ts
@@ -101,6 +101,39 @@ describe("Pi package resources", () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  it("ships one-shot start contracts for built-in workflow skills", async () => {
+    const expectedWorkflows = ["autodoc", "autoimplement", "autoplan", "monitor"] as const;
+
+    for (const workflow of expectedWorkflows) {
+      const markdown = await fs.readFile(path.join(skillsRoot, workflow, "SKILL.md"), "utf8");
+      const exampleMatch = /```json\n([\s\S]*?)\n```/u.exec(markdown);
+      const exampleText = exampleMatch?.[1];
+      if (exampleText === undefined) {
+        throw new Error(`${workflow} skill has no JSON start example.`);
+      }
+      const example = JSON.parse(exampleText) as {
+        action?: unknown;
+        workflow?: unknown;
+        input?: Record<string, unknown>;
+      };
+
+      expect(markdown).toContain("## Start the workflow");
+      expect(markdown.toLowerCase()).toContain("build the complete input");
+      expect(example.action).toBe("start");
+      expect(example.workflow).toBe(workflow);
+      expect(example.input).toBeTypeOf("object");
+    }
+
+    const autoimplement = await fs.readFile(
+      path.join(skillsRoot, "autoimplement", "SKILL.md"),
+      "utf8",
+    );
+    expect(autoimplement).toContain('"repository": "/absolute/path/to/repository"');
+    expect(autoimplement).toContain('"scope": "Only /absolute/path/to/repository.');
+    expect(autoimplement).toContain('"merge": false');
+    expect(autoimplement).toContain('"constraints": [');
+  });
+
   it("keeps routine work moving without inventing paid-compute approval", async () => {
     const markdown = await fs.readFile(path.join(skillsRoot, "monitor", "SKILL.md"), "utf8");
 


### PR DESCRIPTION
## Summary

Models could start built-in workflows with incomplete input, especially without an explicit Autoimplement scope.
This change gives each workflow-starting skill one complete JSON start example and clear rules for deriving scope, authority, constraints, defaults, and finish criteria before the first call.
It also records the shared authoring style in `AGENTS.md` so future skills follow the same pattern.

## What Changed

The packaged skills now show models how to make one complete start call instead of repairing missing fields in later turns.
Autoimplement explicitly requires a concrete authority statement and shows a safe single-repository default that excludes merge, release, deployment, credentials, policy changes, and unrelated repositories unless authorized.

- Added one-shot start contracts to Autoimplement, Autoplan, Autodoc, and Monitor.
- Added exact valid JSON examples with placeholder values that must be replaced from the conversation.
- Updated the general Pi Workflows skill to require complete workflow-specific input before `start`.
- Added repository guidance for future built-in workflow skills.
- Added package-resource tests that parse and validate the examples and enforce Autoimplement's repository, scope, constraints, and merge fields.

## Testing

The complete repository checks and real-Pi package tests pass.
The new focused tests also parse every example as JSON.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`

## Risks

The change affects model instructions rather than workflow runtime behavior.
Models can still ignore skill text, but the concrete examples, repeated field rules, and regression tests make the intended call shape much harder to miss.
