### PR TITLE
chore: release 0.12.0

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "osolmaz.pi-workflows"
 name = "pi-workflows"
-version = "0.11.2"
+version = "0.12.0"
 min_herdr_version = "0.7.0"
 description = "Open the active pi-workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.11.2",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows run bundles"
 license = "MIT"


### PR DESCRIPTION
## Summary

This prepares pi-workflows 0.12.0 for publication.
The release includes the new Autoimplement timeout fallback, explicit null timeout policy, durable successor turns, the sanity-check workflow, and one-shot workflow skill calls.
All JavaScript, Rust, plugin, and lock-file versions now agree on 0.12.0.

## What Changed

Only release metadata changed in this commit.
The package, lock file, Herdr plugin, and Rust viewer now use the same version.

- Set the npm package and lock-file version to 0.12.0.
- Set the Herdr plugin version to 0.12.0.
- Set the Rust crate and Cargo lock version to 0.12.0.

## Testing

The complete local release checks passed.
The package and Cargo metadata also report 0.12.0, and npm confirms that version is not published yet.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`

## Risks

This commit changes version metadata only.
The GitHub Release workflow will still verify the tag, default-branch ancestry, package availability, tests, and npm registry publication before it succeeds.
