### PR TITLE
fix: preserve assistant text after workflow submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ While a run is on screen, the footer status bar shows a compact
 
 `presentationPrompt` is optional. When present, pi-workflows uses it after the
 structured run ends to request one normal, human-readable assistant response.
-Workflows without it remain silent after their final structured output, which
-keeps shell-only and machine-consumed workflows model-free.
+Without it, pi-workflows does not request a separate final response. If the
+model writes text after submitting its last agent step, that text stays visible.
+Shell-only and machine-consumed workflows remain model-free.
 
 Use `expectedOutput: assistantMessage()` when a normal assistant response must
 be a node inside the graph rather than a presentation after the run. Its exact

--- a/docs/plans/2026-08-23-assistant-agent-completion-plan.md
+++ b/docs/plans/2026-08-23-assistant-agent-completion-plan.md
@@ -195,7 +195,7 @@ For assistant completion:
 9. Record the conversation range.
 10. Resolve the node with the exact assistant text.
 
-Do not set `suppressWorkflowAssistantTail` for this mode. The response must stay visible.
+Pi Workflows does not remove assistant text after a workflow submission. The response stays visible.
 
 When the model calls `workflow submit` during an assistant step, return a clear error:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -684,7 +684,7 @@ possible. Defaults worth knowing:
   is explicit user control. When no run is live but the widget still shows a parked or finished run,
   the command clears the widget.
 - One workflow runs per session at a time.
-- After the workflow tool accepts an agent-step submission, the extension removes any assistant tail text from the rest of that agent run. The next workflow message is the visible continuation. A deferred intent makes a workflow prompt, presentation, and factual fallback compete to provide one successor turn, so an abort cannot produce two continuation turns.
+- After the workflow tool accepts an agent-step submission, any assistant text that follows remains visible. The next workflow message continues the graph. A deferred intent makes a workflow prompt, presentation, and factual fallback compete to provide one successor turn, so an abort cannot produce two continuation turns.
 - Agent nudges: if the model ends its turn without submitting the pending
   step, it gets a reminder, twice by default, then the step fails.
 

--- a/src/extension/executor.ts
+++ b/src/extension/executor.ts
@@ -253,10 +253,7 @@ export class ConversationStepExecutor implements AgentStepExecutor {
     });
     return {
       accepted: true,
-      message: [
-        `Output accepted for step ${JSON.stringify(stepId)}.`,
-        "If the workflow continues, the next step arrives as a new workflow message. End your turn now.",
-      ].join(" "),
+      message: `Output accepted for step ${JSON.stringify(stepId)}.`,
     };
   }
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -560,7 +560,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   };
   let activeRun: ActiveRun | null = null;
   let systemTurnAbort: { contract: AgentStepContract; intentId?: string } | null = null;
-  let suppressWorkflowAssistantTail = false;
   let lastExpiredAttempt: { contract: AgentStepContract; reason: string } | null = null;
   // The interactive run currently parked at a checkpoint, if any.
   let lastWaitingRunId: string | null = null;
@@ -999,7 +998,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
           resolution: "presentation",
           send: (turnIntentId) => {
             presentationPending = run.generation;
-            suppressWorkflowAssistantTail = false;
             pi.sendMessage(
               {
                 customType: PRESENTATION_MESSAGE_TYPE,
@@ -2916,7 +2914,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
           if (!result.accepted) {
             throw new Error(result.message);
           }
-          suppressWorkflowAssistantTail = true;
           return {
             content: [{ type: "text", text: result.message }],
             details: { action: "submit", step: params.step, accepted: true },
@@ -2994,7 +2991,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_start", () => {
-    suppressWorkflowAssistantTail = false;
     if (!activeRun && presentationPending === null && presentationAbort) {
       // A normal user turn started while an async presentation prompt was
       // still resolving. The user's new request supersedes that old result.
@@ -3005,7 +3001,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("agent_end", (event, ctx) => {
-    suppressWorkflowAssistantTail = false;
     const aborted = event.messages.some(
       (message) =>
         typeof message === "object" &&
@@ -3057,14 +3052,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
   });
 
   pi.on("message_end", (event) => {
-    if (suppressWorkflowAssistantTail && event.message.role === "assistant") {
-      const message = {
-        ...event.message,
-        content: event.message.content.filter((part) => part.type !== "text"),
-      };
-      activeRun?.recorder?.handleMessageEnd({ ...event, message });
-      return { message };
-    }
     activeRun?.recorder?.handleMessageEnd(event);
   });
 
@@ -3127,7 +3114,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
     sessionClosed = true;
     herdrProbeGeneration += 1;
     systemTurnAbort = null;
-    suppressWorkflowAssistantTail = false;
     turnCoordinator.clearDeferred();
     supersedePresentation();
     const run = activeRun;

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -116,15 +116,23 @@ const ASSISTANT_OUTPUT_E2E_WORKFLOW = `import { agent, assistantMessage, compute
 
 export default defineWorkflow({
   name: "assistant-output-e2e",
-  startAt: "present",
+  startAt: "prepare",
   nodes: {
+    prepare: agent({
+      prompt: () => "Submit the assistant-output fixture input.",
+      expectedOutput: '{ "ready": true }',
+    }),
     present: agent({
-      prompt: () => "Write the assistant-output fixture response.",
+      prompt: ({ outputs }) =>
+        \`Write the assistant-output fixture response for: \${JSON.stringify(outputs.prepare)}\`,
       expectedOutput: assistantMessage(),
     }),
     finish: compute({ run: ({ outputs }) => ({ text: outputs.present }) }),
   },
-  edges: [{ from: "present", to: "finish" }],
+  edges: [
+    { from: "prepare", to: "present" },
+    { from: "present", to: "finish" },
+  ],
 });
 `;
 
@@ -762,11 +770,22 @@ describe.sequential("pi-workflows end to end", () => {
             },
           };
         }
-        if (
-          /workflow step contract \(workflow: assistant-output-e2e, step: present/i.test(
-            lastUserText,
-          )
-        ) {
+        const assistantOutputStepMatch = lastUserText.match(
+          /workflow step contract \(workflow: assistant-output-e2e, step: (prepare|present), attempt: ([a-z0-9-]+)\)/i,
+        );
+        if (assistantOutputStepMatch?.[1] === "prepare") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "submit",
+              step: "prepare",
+              attempt: assistantOutputStepMatch[2] ?? "",
+              output: { ready: true },
+            },
+          };
+        }
+        if (assistantOutputStepMatch?.[1] === "present") {
           return { kind: "text", text: "This is one normal visible assistant response." };
         }
         const timeoutStepMatch = lastUserText.match(
@@ -1477,29 +1496,38 @@ describe.sequential("pi-workflows end to end", () => {
       () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
     );
 
-    expect(state.steps.map((step) => step.nodeId)).toEqual(["present", "finish"]);
+    expect(state.steps.map((step) => step.nodeId)).toEqual(["prepare", "present", "finish"]);
+    expect(state.outputs.prepare).toEqual({ ready: true });
     expect(state.outputs.present).toBe("This is one normal visible assistant response.");
     expect(state.finalOutput).toEqual({ text: "This is one normal visible assistant response." });
-    expect(state.steps[0]).toMatchObject({
+    expect(state.steps[1]).toMatchObject({
       assistantMessage: { sha256: expect.stringMatching(/^[0-9a-f]{64}$/) },
     });
     const records = readWorkflowRun(runId, { databasePath: runsDir })?.sessionEntries ?? [];
-    const visible = records.filter(
-      (record) =>
-        record.entry.type === "message" &&
-        contentText((record.entry.message as { content?: unknown } | undefined)?.content) ===
-          "This is one normal visible assistant response.",
-    );
-    expect(visible).toHaveLength(1);
-    const request = mock.requests.find((candidate) =>
+    const visibleText = records.flatMap((record) => {
+      if (record.entry.type !== "message") return [];
+      return [contentText((record.entry.message as { content?: unknown } | undefined)?.content)];
+    });
+    expect(
+      visibleText.filter((text) => text === "This is one normal visible assistant response."),
+    ).toHaveLength(1);
+    const requests = mock.requests.filter((candidate) =>
       candidate.messages.some((message) =>
         contentText(message.content)
           .toLowerCase()
-          .includes("workflow step contract (workflow: assistant-output-e2e, step: present"),
+          .includes("workflow step contract (workflow: assistant-output-e2e"),
       ),
     );
-    expect(request).toBeDefined();
-    expect(JSON.stringify(request?.messages)).not.toContain('"action":"submit"');
+    expect(
+      requests.some((request) =>
+        JSON.stringify(request.messages).includes("assistant-output-e2e, step: prepare"),
+      ),
+    ).toBe(true);
+    const presentationRequest = requests.find((request) =>
+      JSON.stringify(request.messages).includes("assistant-output-e2e, step: present"),
+    );
+    expect(presentationRequest).toBeDefined();
+    expect(JSON.stringify(presentationRequest?.messages)).not.toContain('"action":"submit"');
   }, 90_000);
 
   it("stops the real Pi turn when an agent node times out", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -885,7 +885,7 @@ describe("pi-workflows extension", () => {
     expect(harness.shortcuts.has("ctrl+shift+r")).toBe(false);
   });
 
-  it("removes assistant tail text after an accepted workflow submission", async () => {
+  it("keeps assistant text visible after an accepted workflow submission", async () => {
     const cwd = await makeTempDir("pi-workflows-tail");
     const runsDir = await makeTempDir("pi-workflows-tail-runs");
     vi.stubEnv("HOME", runsDir);
@@ -912,23 +912,11 @@ describe("pi-workflows extension", () => {
         role: "assistant",
         content: [
           { type: "thinking", thinking: "The workflow submission is complete." },
-          { type: "text", text: "This reply must not appear." },
+          { type: "text", text: "The workflow submission is complete." },
         ],
       };
-      await harness.emitAsync("turn_end", { message: assistantMessage, toolResults: [] });
-      const [replacement] = await harness.emitAsync("message_end", {
-        message: assistantMessage,
-      });
-      expect(replacement).toEqual({
-        message: {
-          ...assistantMessage,
-          content: [{ type: "thinking", thinking: "The workflow submission is complete." }],
-        },
-      });
-
-      await harness.emitAsync("agent_end", { messages: [] });
-      const [normal] = await harness.emitAsync("message_end", { message: assistantMessage });
-      expect(normal).toBeUndefined();
+      const [result] = await harness.emitAsync("message_end", { message: assistantMessage });
+      expect(result).toBeUndefined();
     } finally {
       vi.unstubAllEnvs();
     }


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Pi Workflows deleted assistant text after a model submitted a workflow step.
That cleanup also deleted real answers from immediate successor steps.
This change removes the cleanup, keeps all assistant text visible, and adds a real-Pi regression test for the broken sequence.

## What Changed

Assistant messages now pass through unchanged after workflow submissions.
The old suppression flag, message replacement, and instruction to end the turn were removed instead of replaced with another compatibility path.

- Removed `suppressWorkflowAssistantTail` and all related lifecycle resets.
- Simplified accepted submit receipts to one factual sentence.
- Updated the extension test to require message pass-through.
- Extended the real-Pi assistant-output fixture with a submitted predecessor step.
- Updated user and workflow documentation to state that model text remains visible.

## Testing

The complete local quality gate and real-Pi suite pass.
The regression test verifies that a submitted step can lead directly to an assistant-message step and preserve its exact visible output.

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`

## Risks

The intentional behavior change is that users can now see short model acknowledgements after workflow submissions.
This is safer than silently deleting model output, and it changes no public schema or persisted data format.
