### PR TITLE
fix(state): normalize workflow persistence

### DIFF
--- a/docs/SQLITE_STATE.md
+++ b/docs/SQLITE_STATE.md
@@ -49,6 +49,8 @@ Read-only tools open the same file with SQLite read-only mode and `PRAGMA query_
 
 Opening code verifies the application ID, user version, schema metadata, compiled DDL digest, and exact SQLite schema shape. An incompatible database fails with an instruction to clear the incompatible alpha state. Pi Workflows does not import, reinterpret, or delete that state.
 
+The normalized run layout is an in-place alpha cutover. It keeps SQLite user version `1` and the current `v1` public record identifiers. A database with the former nested run-snapshot layout is incompatible and must be moved or removed. There is no migration, compatibility reader, dual write, alias, or second schema generation.
+
 ## Shared records
 
 Four record groups provide the common lifecycle rules.
@@ -91,18 +93,18 @@ Local effects use deterministic transactions. Run queue settlement effects are c
 
 The shared records do not replace domain schemas. The following `STRICT` tables keep the state explicit:
 
-| Area                | Tables                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------ |
-| Schema and projects | `schema_meta`, `projects`                                                                        |
-| Content             | `blobs`                                                                                          |
-| Shared lifecycle    | `resources`, `leases`, `events`                                                                  |
-| Workflows           | `workflow_definitions`, `runs`, `run_bindings`, `run_queue`, `node_attempts`, `workflow_updates` |
-| Session capture     | `session_segments`, `session_entries`, `session_events`                                          |
-| Human decisions     | `human_decisions`, `human_decision_resolutions`, `human_decision_submissions`, `continuations`   |
-| Controllers         | `controller_resources`, `controller_finalizers`, `controller_queue`, `controller_workflows`      |
-| Effects             | `effects`, `effect_attempts`                                                                     |
-| Pi delivery         | `notifications`, `turn_intents`                                                                  |
-| Channels            | `channels`, `channel_cursors`, `channel_inbox`, `channel_messages`, `channel_message_parts`      |
+| Area                | Tables                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Schema and projects | `schema_meta`, `projects`                                                                                     |
+| Content             | `blobs`                                                                                                       |
+| Shared lifecycle    | `resources`, `leases`, `events`                                                                               |
+| Workflows           | `workflow_definitions`, `runs`, `run_steps`, `run_bindings`, `run_queue`, `node_attempts`, `workflow_updates` |
+| Session capture     | `session_segments`, `session_entries`, `session_events`                                                       |
+| Human decisions     | `human_decisions`, `human_decision_resolutions`, `human_decision_submissions`, `continuations`                |
+| Controllers         | `controller_resources`, `controller_finalizers`, `controller_queue`, `controller_workflows`                   |
+| Effects             | `effects`, `effect_attempts`                                                                                  |
+| Pi delivery         | `notifications`, `turn_intents`                                                                               |
+| Channels            | `channels`, `channel_cursors`, `channel_inbox`, `channel_messages`, `channel_message_parts`                   |
 
 Foreign keys join projects, runs, attempts, decisions, controllers, effects, and channel records. Partial unique indexes enforce one active node attempt per run, one queued or running reservation per Pi session, one decision winner, and one deterministic effect key. A parked waiting parent does not block its continuation. Reserving that continuation settles the parked parent queue in the same transaction, so a failed reservation leaves the parent recoverable.
 
@@ -110,7 +112,9 @@ Foreign keys join projects, runs, attempts, decisions, controllers, effects, and
 
 `blobs` stores canonical JSON and UTF-8 text as bytes. Its primary key is the 32-byte SHA-256 digest of the bytes.
 
-Insertion verifies the digest, media type, byte length, and exact bytes. Repeated content adopts the existing row. This replaces separate artifact files while keeping large prompts, outputs, errors, session payloads, and rendered channel text deduplicated.
+Insertion verifies the digest, media type, byte length, and exact bytes. Repeated content adopts the existing row. This replaces separate artifact files while keeping large prompts, outputs, errors, session payloads, and rendered channel text deduplicated. A writable open removes blobs that no foreign-key column references.
+
+Runs do not store a nested `WorkflowRunState` blob. `runs` stores scalar run facts and hashes for independent values. `node_attempts` stores each prompt and output once. `run_steps` stores ordered attempt membership and only stores an output override when a continuation changes a carried checkpoint answer. Readers derive `steps`, `outputs`, and `results` from these rows. Compact trace events do not copy node outputs, run inputs, or final outputs.
 
 ### Assistant-message attempts
 
@@ -122,7 +126,7 @@ An interrupted assistant-message attempt keeps its attempt ID when the origin Pi
 
 ## Write contract
 
-A write command uses this order:
+A resource command uses this order:
 
 ```text
 BEGIN IMMEDIATE
@@ -140,6 +144,8 @@ COMMIT
 ```
 
 Any failed check rolls back the complete command.
+
+Session-event batches use `session_events` as their journal. They update the contiguous segment counter in the same transaction and do not create a generic `session.events_appended` event for each flush. The recorder stores lifecycle boundaries and settled events. It discards token deltas and incremental tool progress.
 
 A TypeScript write permit carries the expected facts between layers. It is not authority by itself. The store verifies durable ownership and revision data again inside the transaction.
 

--- a/docs/session-event-journal.md
+++ b/docs/session-event-journal.md
@@ -45,14 +45,13 @@ The current event types are:
 - `assistant_event`
 - `message_finished`
 - `tool_execution_started`
-- `tool_execution_updated`
 - `tool_execution_finished`
 
 Unknown future event types remain visible to generic readers.
 
 ## Write rules
 
-The recorder queues hot-path Pi events in memory and writes bounded batches. One transaction writes the complete batch, updates the segment count, increments the segment resource revision, and appends its audit event.
+The recorder stores lifecycle boundaries and settled content. It does not store token deltas or incremental tool progress. It queues these bounded records in memory. One transaction writes each complete batch and updates the segment count. The session-event rows are the audit journal; the store does not add one generic event for each flush.
 
 The writer checks:
 
@@ -68,7 +67,7 @@ Workflow execution does not fail because temporal capture failed. The run and th
 
 ## Settled entries
 
-A `message_finished` event can refer to the Pi entry ID that settled the message. Replay first shows temporal deltas, then switches to the verbatim entry when that settled link is available.
+A `message_finished` event can refer to the Pi entry ID that settled the message. Replay uses settled assistant content and switches to the verbatim entry when that link is available.
 
 Agent workflow steps also store their first and last Pi entry IDs. This makes the conversation slice for each step explicit without changing Pi session data.
 

--- a/fixtures/session-events/aborted.json
+++ b/fixtures/session-events/aborted.json
@@ -33,16 +33,6 @@
     },
     {
       "seq": 4,
-      "at": "2026-07-30T11:00:00.004Z",
-      "nodeId": "review",
-      "attemptId": "a1",
-      "turnId": "t1",
-      "messageId": "m1",
-      "type": "assistant_event",
-      "payload": { "type": "text_delta", "contentIndex": 0, "delta": "partial" }
-    },
-    {
-      "seq": 5,
       "at": "2026-07-30T11:00:00.005Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -52,7 +42,7 @@
       "payload": { "type": "error", "reason": "aborted" }
     },
     {
-      "seq": 6,
+      "seq": 5,
       "at": "2026-07-30T11:00:00.006Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -62,7 +52,7 @@
       "payload": { "role": "assistant", "settled": false }
     },
     {
-      "seq": 7,
+      "seq": 6,
       "at": "2026-07-30T11:00:00.007Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -73,15 +63,15 @@
   ],
   "positions": [
     {
-      "throughSeq": 4,
+      "throughSeq": 3,
       "expected": {
-        "throughSeq": 4,
+        "throughSeq": 3,
         "messages": [
           {
             "messageId": "m1",
             "role": "assistant",
             "status": "streaming",
-            "blocks": [{ "contentIndex": 0, "kind": "text", "text": "partial" }]
+            "blocks": [{ "contentIndex": 0, "kind": "text", "text": "" }]
           }
         ],
         "tools": [],
@@ -90,15 +80,15 @@
       }
     },
     {
-      "throughSeq": 7,
+      "throughSeq": 6,
       "expected": {
-        "throughSeq": 7,
+        "throughSeq": 6,
         "messages": [
           {
             "messageId": "m1",
             "role": "assistant",
             "status": "unsettled",
-            "blocks": [{ "contentIndex": 0, "kind": "text", "text": "partial" }]
+            "blocks": [{ "contentIndex": 0, "kind": "text", "text": "" }]
           }
         ],
         "tools": [],

--- a/fixtures/session-events/normal.json
+++ b/fixtures/session-events/normal.json
@@ -57,16 +57,6 @@
     },
     {
       "seq": 4,
-      "at": "2026-07-30T10:00:00.004Z",
-      "nodeId": "review",
-      "attemptId": "a1",
-      "turnId": "t1",
-      "messageId": "m1",
-      "type": "assistant_event",
-      "payload": { "type": "thinking_delta", "contentIndex": 0, "delta": "plan" }
-    },
-    {
-      "seq": 5,
       "at": "2026-07-30T10:00:00.005Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -76,7 +66,7 @@
       "payload": { "type": "thinking_end", "contentIndex": 0, "content": "plan" }
     },
     {
-      "seq": 6,
+      "seq": 5,
       "at": "2026-07-30T10:00:00.006Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -86,17 +76,7 @@
       "payload": { "type": "text_start", "contentIndex": 1 }
     },
     {
-      "seq": 7,
-      "at": "2026-07-30T10:00:00.007Z",
-      "nodeId": "review",
-      "attemptId": "a1",
-      "turnId": "t1",
-      "messageId": "m1",
-      "type": "assistant_event",
-      "payload": { "type": "text_delta", "contentIndex": 1, "delta": "hello" }
-    },
-    {
-      "seq": 8,
+      "seq": 6,
       "at": "2026-07-30T10:00:00.008Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -106,7 +86,7 @@
       "payload": { "type": "text_end", "contentIndex": 1, "content": "hello" }
     },
     {
-      "seq": 9,
+      "seq": 7,
       "at": "2026-07-30T10:00:00.009Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -116,21 +96,7 @@
       "payload": { "type": "toolcall_start", "contentIndex": 2 }
     },
     {
-      "seq": 10,
-      "at": "2026-07-30T10:00:00.010Z",
-      "nodeId": "review",
-      "attemptId": "a1",
-      "turnId": "t1",
-      "messageId": "m1",
-      "type": "assistant_event",
-      "payload": {
-        "type": "toolcall_delta",
-        "contentIndex": 2,
-        "delta": "{\"path\":\"README.md\"}"
-      }
-    },
-    {
-      "seq": 11,
+      "seq": 8,
       "at": "2026-07-30T10:00:00.011Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -144,7 +110,7 @@
       }
     },
     {
-      "seq": 12,
+      "seq": 9,
       "at": "2026-07-30T10:00:00.012Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -155,18 +121,7 @@
       "payload": { "toolName": "read", "args": { "path": "README.md" } }
     },
     {
-      "seq": 13,
-      "at": "2026-07-30T10:00:00.013Z",
-      "nodeId": "review",
-      "attemptId": "a1",
-      "turnId": "t1",
-      "messageId": "m1",
-      "toolCallId": "call-1",
-      "type": "tool_execution_updated",
-      "payload": {}
-    },
-    {
-      "seq": 14,
+      "seq": 10,
       "at": "2026-07-30T10:00:00.014Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -177,7 +132,7 @@
       "payload": { "toolName": "read", "isError": false, "result": { "content": "ok" } }
     },
     {
-      "seq": 15,
+      "seq": 11,
       "at": "2026-07-30T10:00:00.015Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -187,7 +142,7 @@
       "payload": { "type": "done", "reason": "toolUse" }
     },
     {
-      "seq": 16,
+      "seq": 12,
       "at": "2026-07-30T10:00:01.001Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -197,7 +152,7 @@
       "payload": { "role": "assistant", "settled": true, "entryId": "entry-1" }
     },
     {
-      "seq": 17,
+      "seq": 13,
       "at": "2026-07-30T10:00:01.002Z",
       "nodeId": "review",
       "attemptId": "a1",
@@ -208,9 +163,9 @@
   ],
   "positions": [
     {
-      "throughSeq": 7,
+      "throughSeq": 6,
       "expected": {
-        "throughSeq": 7,
+        "throughSeq": 6,
         "messages": [
           {
             "messageId": "m1",
@@ -228,9 +183,9 @@
       }
     },
     {
-      "throughSeq": 17,
+      "throughSeq": 13,
       "expected": {
-        "throughSeq": 17,
+        "throughSeq": 13,
         "messages": [
           {
             "messageId": "m1",
@@ -243,7 +198,7 @@
               {
                 "contentIndex": 2,
                 "kind": "toolCall",
-                "text": "{\"path\":\"README.md\"}",
+                "text": "",
                 "value": { "id": "call-1", "name": "read", "arguments": { "path": "README.md" } }
               }
             ]
@@ -255,7 +210,6 @@
             "messageId": "m1",
             "toolName": "read",
             "status": "finished",
-            "updates": 1,
             "args": { "path": "README.md" },
             "result": { "content": "ok" }
           }

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -156,9 +156,9 @@ type RunRow = {
   workflowRef: string;
   runStatus: string;
   workflowSourceHash: Buffer;
+  workflowSourcesHash: Buffer | null;
   definitionDigest: Buffer;
   inputHash: Buffer;
-  outputHash: Buffer | null;
   launchOptionsHash: Buffer;
   status: WorkflowRunLaunchStatus;
   availableAt: number;
@@ -1049,34 +1049,11 @@ export class SqliteControllerStore implements ControllerStore {
       const resourceId = resourceIdFor("run", options.runId);
       const definitionHash = this.state.putJson(options.definitionSnapshot, now);
       const queuedSource = queuedWorkflowSource(options.workflowSource);
-      const sourceHash = this.state.putJson(options.workflowSource, now);
+      const sourceHash = this.state.putJson(queuedSource.root, now);
+      const mountedSourcesHash =
+        queuedSource.mounted.length === 0 ? null : this.state.putJson(queuedSource.mounted, now);
       const inputHash = this.state.putJson(options.input ?? null, now);
       const launchHash = this.state.putJson(options.launchOptions ?? {}, now);
-      const queuedStateHash = this.state.putJson(
-        {
-          schema: "pi-workflows.run-state.v1",
-          traceSeq: 1,
-          runId: options.runId,
-          workflowName: options.workflowName,
-          workflowSource: queuedSource.root,
-          ...(queuedSource.mounted.length === 0
-            ? {}
-            : {
-                workflowSources: queuedSource.mounted,
-                definitionDigest: options.definitionDigest,
-              }),
-          ...(options.parentRunId === undefined ? {} : { parentRunId: options.parentRunId }),
-          startedAt: new Date(now).toISOString(),
-          updatedAt: new Date(now).toISOString(),
-          status: "running",
-          input: options.input ?? null,
-          outputs: {},
-          results: {},
-          steps: [],
-          updates: [],
-        },
-        now,
-      );
       this.state.connection
         .prepare(
           `INSERT INTO workflow_definitions(
@@ -1101,7 +1078,7 @@ export class SqliteControllerStore implements ControllerStore {
              run_id, resource_id, project_id, parent_run_id, definition_digest,
              workflow_ref, workflow_source_hash, launch_options_hash,
              source_type, source_ref, source_revision, status, paused,
-             input_hash, output_hash, created_at, updated_at
+             input_hash, workflow_sources_hash, created_at, updated_at
            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', 0, ?, ?, ?, ?)`,
         )
         .run(
@@ -1117,7 +1094,7 @@ export class SqliteControllerStore implements ControllerStore {
           source.ref,
           source.revision,
           inputHash,
-          queuedStateHash,
+          mountedSourcesHash,
           now,
           now,
         );
@@ -2261,7 +2238,11 @@ export class SqliteControllerStore implements ControllerStore {
       runId: row.runId,
       workflowName: row.workflowName,
       workflowSourceRef: row.workflowRef,
-      workflowSource: this.state.readJson(row.workflowSourceHash),
+      workflowSource: {
+        root: this.state.readJson(row.workflowSourceHash),
+        mounted:
+          row.workflowSourcesHash === null ? [] : this.state.readJson(row.workflowSourcesHash),
+      },
       initialized: row.runStatus !== "queued",
       definitionDigest: `sha256:${row.definitionDigest.toString("hex")}`,
       input: this.state.readJson(row.inputHash),
@@ -2461,27 +2442,8 @@ export class SqliteControllerStore implements ControllerStore {
       ) {
         return false;
       }
-      if (row.outputHash === null) throw new Error(`Workflow run ${runId} has no state projection`);
-      const projected = this.state.readJson(row.outputHash);
-      if (!isRecord(projected)) throw new Error(`Workflow run ${runId} state is invalid`);
       const revision = this.resourceRevision(row.resourceId);
-      const at = new Date(now).toISOString();
-      const terminalState: Record<string, unknown> = {
-        ...projected,
-        traceSeq: revision + 1,
-        status,
-        updatedAt: at,
-        finishedAt: at,
-        error,
-      };
-      delete terminalState.currentNode;
-      delete terminalState.currentAttemptId;
-      delete terminalState.currentNodeStartedAt;
-      delete terminalState.statusDetail;
-      delete terminalState.paused;
-      delete terminalState.waitingOn;
       const errorHash = this.state.putText(error, now);
-      const outputHash = this.state.putJson(terminalState, now);
       const queueUpdate = this.state.connection
         .prepare(
           `UPDATE run_queue
@@ -2506,10 +2468,13 @@ export class SqliteControllerStore implements ControllerStore {
       this.state.connection
         .prepare(
           `UPDATE runs
-           SET status = ?, output_hash = ?, error_hash = ?, updated_at = ?, finished_at = ?
+           SET status = ?, paused = 0, status_detail = NULL, error_hash = ?,
+               current_node = NULL, current_attempt_id = NULL,
+               current_node_started_at = NULL, waiting_on = NULL,
+               updated_at = ?, finished_at = ?
            WHERE run_id = ?`,
         )
-        .run(status, outputHash, errorHash, now, now, runId);
+        .run(status, errorHash, now, now, runId);
       this.bumpResource(row.resourceId, revision, now);
       this.insertEvent(
         row.resourceId,
@@ -2811,8 +2776,9 @@ function workflowSelect(clause: string): string {
 function workflowRunSelect(clause: string): string {
   return `SELECT r.run_id AS runId, r.resource_id AS resourceId,
     d.workflow_name AS workflowName, r.workflow_ref AS workflowRef, r.status AS runStatus,
-    r.workflow_source_hash AS workflowSourceHash, r.definition_digest AS definitionDigest,
-    r.input_hash AS inputHash, r.output_hash AS outputHash,
+    r.workflow_source_hash AS workflowSourceHash,
+    r.workflow_sources_hash AS workflowSourcesHash,
+    r.definition_digest AS definitionDigest, r.input_hash AS inputHash,
     r.launch_options_hash AS launchOptionsHash,
     q.status, q.available_at AS availableAt, q.affinity_runner_id AS affinityRunnerId,
     q.consecutive_errors AS consecutiveErrors, q.error_code AS errorCode,

--- a/src/extension/decision-channels.ts
+++ b/src/extension/decision-channels.ts
@@ -28,6 +28,7 @@ const TELEGRAM_TEXT_LIMIT = 4_096;
 const PI_PRESENTATION_WINDOW_LINES = 18;
 const DEFAULT_API_BASE = "https://api.telegram.org";
 const LEASE_TTL_MS = 60_000;
+const LEASE_RENEW_WINDOW_MS = 20_000;
 const LEASE_RETRY_MS = 5_000;
 const POLL_BACKOFF_MS = 1_000;
 const MAX_SETTLEMENT_ATTEMPTS = 3;
@@ -428,6 +429,21 @@ class TelegramProjection {
   }
 
   acquire(now = Date.now()): boolean {
+    const observed = this.lease();
+    const observedToken = tokenHash(this.token);
+    const ownedByThis =
+      observed.ownerId === this.owner &&
+      observed.tokenHash !== null &&
+      observed.tokenHash.equals(observedToken) &&
+      observed.expiresAt !== null &&
+      observed.expiresAt > now;
+    if (ownedByThis) {
+      this.generation = observed.generation;
+      return true;
+    }
+    if (observed.ownerId !== null && observed.expiresAt !== null && observed.expiresAt > now) {
+      return false;
+    }
     return this.state.transaction(() => {
       const lease = this.lease();
       if (
@@ -438,7 +454,11 @@ class TelegramProjection {
       ) {
         return false;
       }
-      const generation = lease.ownerId === this.owner ? lease.generation : lease.generation + 1;
+      const sameToken =
+        lease.ownerId === this.owner &&
+        lease.tokenHash !== null &&
+        lease.tokenHash.equals(observedToken);
+      const generation = sameToken ? lease.generation : lease.generation + 1;
       const result = this.state.connection
         .prepare(
           `UPDATE leases
@@ -449,7 +469,7 @@ class TelegramProjection {
         .run(
           generation,
           this.owner,
-          tokenHash(this.token),
+          observedToken,
           now,
           now,
           now + LEASE_TTL_MS,
@@ -465,6 +485,18 @@ class TelegramProjection {
   }
 
   renew(now = Date.now()): boolean {
+    const lease = this.lease();
+    if (
+      lease.ownerId !== this.owner ||
+      lease.generation !== this.generation ||
+      lease.tokenHash === null ||
+      !lease.tokenHash.equals(tokenHash(this.token)) ||
+      lease.expiresAt === null ||
+      lease.expiresAt <= now
+    ) {
+      return false;
+    }
+    if (lease.expiresAt - now > LEASE_RENEW_WINDOW_MS) return true;
     return (
       this.state.connection
         .prepare(
@@ -1222,11 +1254,11 @@ export class TelegramDecisionChannel implements HumanDecisionChannel {
 
   private async poll(signal: AbortSignal): Promise<void> {
     while (this.running && !signal.aborted) {
-      if (!this.projection.acquire()) {
-        await wait(LEASE_RETRY_MS, signal);
-        continue;
-      }
       try {
+        if (!this.projection.acquire()) {
+          await wait(leaseRetryDelay(), signal);
+          continue;
+        }
         await this.deliverPendingRequests();
         const result = await this.call(
           "getUpdates",
@@ -1246,7 +1278,11 @@ export class TelegramDecisionChannel implements HumanDecisionChannel {
         if (!this.projection.renew()) this.projection.release();
       } catch {
         if (signal.aborted) return;
-        await wait(POLL_BACKOFF_MS, signal);
+        try {
+          await wait(POLL_BACKOFF_MS, signal);
+        } catch {
+          if (signal.aborted) return;
+        }
       }
     }
   }
@@ -1771,6 +1807,10 @@ async function writePrivateJson(filePath: string, value: unknown): Promise<void>
   await fsp.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
   await fsp.rename(temporary, filePath);
   await fsp.chmod(filePath, 0o600);
+}
+
+function leaseRetryDelay(): number {
+  return LEASE_RETRY_MS + Math.floor(Math.random() * 1_000);
 }
 
 async function wait(milliseconds: number, signal: AbortSignal): Promise<void> {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,6 +9,7 @@ import type {
 } from "../controllers/sqlite.js";
 import type { JsonObject } from "../controllers/types.js";
 import type { WorkflowSchedulerResult } from "../controllers/workflows.js";
+import { canonicalJson } from "../state/json.js";
 import { compositionMetadata } from "../workflows/composition.js";
 import { humanDecisionChannelRequest } from "../workflows/decision-presentation.js";
 import { WorkflowEngine } from "../workflows/engine.js";
@@ -219,7 +220,7 @@ type StartRunOptions = {
 };
 
 function definitionDigest(snapshot: WorkflowDefinitionSnapshot): string {
-  return `sha256:${createHash("sha256").update(JSON.stringify(snapshot)).digest("hex")}`;
+  return `sha256:${createHash("sha256").update(canonicalJson(snapshot)).digest("hex")}`;
 }
 
 function launchSourceIdentity(workflow: WorkflowDefinition, root: unknown): unknown {

--- a/src/extension/recorder.ts
+++ b/src/extension/recorder.ts
@@ -246,6 +246,13 @@ export class SessionRecorder {
       return;
     }
     const normalized = normalizeAssistantEvent(event.assistantMessageEvent);
+    if (
+      normalized.type === "text_delta" ||
+      normalized.type === "thinking_delta" ||
+      normalized.type === "toolcall_delta"
+    ) {
+      return;
+    }
     const toolCallId = toolCallIdFromAssistantEvent(normalized);
     if (toolCallId) {
       this.toolOwners.set(toolCallId, owner);
@@ -295,14 +302,9 @@ export class SessionRecorder {
     });
   }
 
-  handleToolUpdate(event: ToolExecutionUpdateEventLike): void {
-    const owner = this.toolOwners.get(event.toolCallId);
-    if (!owner) {
-      return;
-    }
-    this.enqueue(owner, "tool_execution_updated", {}, undefined, {
-      toolCallId: event.toolCallId,
-    });
+  handleToolUpdate(_event: ToolExecutionUpdateEventLike): void {
+    // Incremental tool progress is transient. The recorder stores the settled
+    // tool result and the surrounding lifecycle facts.
   }
 
   handleToolEnd(event: ToolExecutionEndEventLike): void {

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -97,7 +97,6 @@ export class StateDatabase {
       if (this.mode === "read-only") {
         this.connection.pragma("query_only = ON");
       } else {
-        this.pruneUnreferencedBlobs();
         fs.chmodSync(this.filePath, 0o600);
       }
     } catch (error) {
@@ -195,52 +194,6 @@ export class StateDatabase {
     if (!Array.isArray(foreignKeys) || foreignKeys.length !== 0) {
       throw new Error("Pi Workflows SQLite foreign-key check failed");
     }
-  }
-
-  pruneUnreferencedBlobs(): number {
-    if (this.mode === "read-only") {
-      throw new Error("Cannot prune blobs through a read-only Pi Workflows database");
-    }
-    return this.transaction(() => {
-      this.connection.exec(
-        "CREATE TEMP TABLE referenced_blobs(blob_hash BLOB PRIMARY KEY) WITHOUT ROWID",
-      );
-      const tables = this.connection
-        .prepare(
-          `SELECT name FROM sqlite_schema
-           WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name <> 'blobs'`,
-        )
-        .all()
-        .filter(isTableNameRow);
-      for (const table of tables) {
-        const columns = this.connection
-          .prepare(
-            `SELECT "from" AS columnName FROM pragma_foreign_key_list(?)
-             WHERE "table" = 'blobs' AND "to" = 'blob_hash'`,
-          )
-          .all(table.name)
-          .filter(isColumnNameRow);
-        for (const column of columns) {
-          this.connection
-            .prepare(
-              `INSERT OR IGNORE INTO referenced_blobs(blob_hash)
-               SELECT ${quoteIdentifier(column.columnName)} FROM ${quoteIdentifier(table.name)}
-               WHERE ${quoteIdentifier(column.columnName)} IS NOT NULL`,
-            )
-            .run();
-        }
-      }
-      const result = this.connection
-        .prepare(
-          `DELETE FROM blobs
-           WHERE NOT EXISTS (
-             SELECT 1 FROM referenced_blobs r WHERE r.blob_hash = blobs.blob_hash
-           )`,
-        )
-        .run();
-      this.connection.exec("DROP TABLE referenced_blobs");
-      return result.changes;
-    });
   }
 
   async backup(destination: string): Promise<void> {
@@ -415,18 +368,6 @@ function isBlobRow(value: unknown): value is BlobRow {
     typeof value.byteLength === "number" &&
     Buffer.isBuffer(value.content)
   );
-}
-
-function isTableNameRow(value: unknown): value is { name: string } {
-  return isRecord(value) && typeof value.name === "string";
-}
-
-function isColumnNameRow(value: unknown): value is { columnName: string } {
-  return isRecord(value) && typeof value.columnName === "string";
-}
-
-function quoteIdentifier(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -97,6 +97,7 @@ export class StateDatabase {
       if (this.mode === "read-only") {
         this.connection.pragma("query_only = ON");
       } else {
+        this.pruneUnreferencedBlobs();
         fs.chmodSync(this.filePath, 0o600);
       }
     } catch (error) {
@@ -194,6 +195,52 @@ export class StateDatabase {
     if (!Array.isArray(foreignKeys) || foreignKeys.length !== 0) {
       throw new Error("Pi Workflows SQLite foreign-key check failed");
     }
+  }
+
+  pruneUnreferencedBlobs(): number {
+    if (this.mode === "read-only") {
+      throw new Error("Cannot prune blobs through a read-only Pi Workflows database");
+    }
+    return this.transaction(() => {
+      this.connection.exec(
+        "CREATE TEMP TABLE referenced_blobs(blob_hash BLOB PRIMARY KEY) WITHOUT ROWID",
+      );
+      const tables = this.connection
+        .prepare(
+          `SELECT name FROM sqlite_schema
+           WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name <> 'blobs'`,
+        )
+        .all()
+        .filter(isTableNameRow);
+      for (const table of tables) {
+        const columns = this.connection
+          .prepare(
+            `SELECT "from" AS columnName FROM pragma_foreign_key_list(?)
+             WHERE "table" = 'blobs' AND "to" = 'blob_hash'`,
+          )
+          .all(table.name)
+          .filter(isColumnNameRow);
+        for (const column of columns) {
+          this.connection
+            .prepare(
+              `INSERT OR IGNORE INTO referenced_blobs(blob_hash)
+               SELECT ${quoteIdentifier(column.columnName)} FROM ${quoteIdentifier(table.name)}
+               WHERE ${quoteIdentifier(column.columnName)} IS NOT NULL`,
+            )
+            .run();
+        }
+      }
+      const result = this.connection
+        .prepare(
+          `DELETE FROM blobs
+           WHERE NOT EXISTS (
+             SELECT 1 FROM referenced_blobs r WHERE r.blob_hash = blobs.blob_hash
+           )`,
+        )
+        .run();
+      this.connection.exec("DROP TABLE referenced_blobs");
+      return result.changes;
+    });
   }
 
   async backup(destination: string): Promise<void> {
@@ -368,6 +415,18 @@ function isBlobRow(value: unknown): value is BlobRow {
     typeof value.byteLength === "number" &&
     Buffer.isBuffer(value.content)
   );
+}
+
+function isTableNameRow(value: unknown): value is { name: string } {
+  return isRecord(value) && typeof value.name === "string";
+}
+
+function isColumnNameRow(value: unknown): value is { columnName: string } {
+  return isRecord(value) && typeof value.columnName === "string";
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -106,8 +106,15 @@ CREATE TABLE runs (
   paused INTEGER NOT NULL DEFAULT 0 CHECK (paused IN (0, 1)),
   status_detail TEXT,
   input_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
-  output_hash BLOB REFERENCES blobs(blob_hash),
+  workflow_sources_hash BLOB REFERENCES blobs(blob_hash),
+  human_decision_hash BLOB REFERENCES blobs(blob_hash),
+  final_output_hash BLOB REFERENCES blobs(blob_hash),
   error_hash BLOB REFERENCES blobs(blob_hash),
+  carried_step_count INTEGER NOT NULL DEFAULT 0 CHECK (carried_step_count >= 0),
+  current_node TEXT,
+  current_attempt_id TEXT,
+  current_node_started_at INTEGER,
+  waiting_on TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   finished_at INTEGER,
@@ -159,9 +166,9 @@ CREATE TABLE node_attempts (
   )),
   input_hash BLOB REFERENCES blobs(blob_hash),
   contract_hash BLOB REFERENCES blobs(blob_hash),
-  presentation_hash BLOB REFERENCES blobs(blob_hash),
+  prompt_hash BLOB REFERENCES blobs(blob_hash),
   output_hash BLOB REFERENCES blobs(blob_hash),
-  result_hash BLOB REFERENCES blobs(blob_hash),
+  step_metadata_hash BLOB REFERENCES blobs(blob_hash),
   error_hash BLOB REFERENCES blobs(blob_hash),
   started_at INTEGER,
   deadline_at INTEGER,
@@ -175,10 +182,22 @@ CREATE UNIQUE INDEX node_attempts_active_idx ON node_attempts(run_id)
 WHERE status IN ('pending', 'running', 'waiting');
 CREATE INDEX node_attempts_run_idx ON node_attempts(run_id, created_at);
 
+CREATE TABLE run_steps (
+  run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+  step_index INTEGER NOT NULL CHECK (step_index >= 0),
+  attempt_id TEXT NOT NULL REFERENCES node_attempts(attempt_id),
+  output_override_hash BLOB REFERENCES blobs(blob_hash),
+  PRIMARY KEY (run_id, step_index),
+  UNIQUE (run_id, attempt_id)
+) STRICT;
+
+CREATE INDEX run_steps_attempt_idx ON run_steps(attempt_id);
+
 CREATE TABLE workflow_updates (
   update_id TEXT PRIMARY KEY,
   attempt_id TEXT NOT NULL REFERENCES node_attempts(attempt_id) ON DELETE CASCADE,
   update_seq INTEGER NOT NULL CHECK (update_seq > 0),
+  run_revision INTEGER NOT NULL CHECK (run_revision > 0),
   update_type TEXT NOT NULL,
   update_key TEXT NOT NULL,
   data_hash BLOB NOT NULL REFERENCES blobs(blob_hash),

--- a/src/viewer/session-reducer.ts
+++ b/src/viewer/session-reducer.ts
@@ -20,7 +20,6 @@ export type TemporalTool = {
   messageId: string;
   toolName: string;
   status: "running" | "finished" | "failed";
-  updates: number;
   args?: unknown;
   result?: unknown;
 };
@@ -157,22 +156,6 @@ function foldSessionEvents(
           );
         } else if (
           contentIndex !== undefined &&
-          (assistantType === "text_delta" ||
-            assistantType === "thinking_delta" ||
-            assistantType === "toolcall_delta")
-        ) {
-          const block = ensureBlock(
-            message,
-            contentIndex,
-            assistantType === "text_delta"
-              ? "text"
-              : assistantType === "thinking_delta"
-                ? "thinking"
-                : "toolCall",
-          );
-          block.text += payloadString(event.payload, "delta") ?? "";
-        } else if (
-          contentIndex !== undefined &&
           (assistantType === "text_end" || assistantType === "thinking_end")
         ) {
           const block = ensureBlock(
@@ -181,10 +164,10 @@ function foldSessionEvents(
             assistantType === "text_end" ? "text" : "thinking",
           );
           const content = payloadString(event.payload, "content") ?? "";
-          if (block.text !== content) {
+          if (block.text.length > 0 && block.text !== content) {
             diagnostics.push(`${assistantType} mismatch for ${event.messageId}:${contentIndex}`);
-            block.text = content;
           }
+          block.text = content;
         } else if (contentIndex !== undefined && assistantType === "toolcall_end") {
           const block = ensureBlock(message, contentIndex, "toolCall");
           block.value = event.payload.toolCall;
@@ -229,20 +212,10 @@ function foldSessionEvents(
           messageId: event.messageId,
           toolName: payloadString(event.payload, "toolName") ?? "tool",
           status: "running",
-          updates: 0,
           ...(event.payload.args === undefined ? {} : { args: event.payload.args }),
         };
         tools.set(event.toolCallId, tool);
         toolOrder.push(event.toolCallId);
-        break;
-      }
-      case "tool_execution_updated": {
-        const tool = event.toolCallId ? tools.get(event.toolCallId) : undefined;
-        if (tool) {
-          tool.updates += 1;
-        } else {
-          diagnostics.push(`tool_execution_updated ${event.seq} precedes start`);
-        }
         break;
       }
       case "tool_execution_finished": {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import { canonicalJson } from "../state/json.js";
 import {
   compileWorkflowDefinition,
   compositionMetadata,
@@ -723,8 +724,8 @@ export class WorkflowEngine {
         throw new RunParkedError();
       }
       this.recordAttempt(workflow, state, attempt);
-      // The terminal node event carries the output, receipt, and conversation
-      // linkage so the trace alone is sufficient to reconstruct the run.
+      // The durable step row owns the output. The trace keeps the terminal fact
+      // and compact execution metadata without copying the output value.
       await this.persist(runId, state, {
         scope: "node",
         type: attempt.result.outcome === "ok" ? "node_finished" : "node_failed",
@@ -1561,7 +1562,7 @@ function workflowIdentityMismatch(
 
 function definitionDigest(workflow: WorkflowDefinition): string {
   return `sha256:${createHash("sha256")
-    .update(JSON.stringify(createDefinitionSnapshot(workflow)))
+    .update(canonicalJson(createDefinitionSnapshot(workflow)))
     .digest("hex")}`;
 }
 

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1613,7 +1613,10 @@ function compactTracePayload(
   eventType: string,
   payload: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (eventType === "node_finished" && Object.hasOwn(payload, "output")) {
+  if (
+    (eventType === "node_finished" || eventType === "include_exited") &&
+    Object.hasOwn(payload, "output")
+  ) {
     const { output: _output, ...rest } = payload;
     return { ...rest, outputStored: true };
   }

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -7,8 +7,10 @@ import type {
   WorkflowDefinition,
   WorkflowDefinitionSnapshot,
   WorkflowNodeDefinition,
+  WorkflowNodeResult,
   WorkflowNodeSnapshot,
   WorkflowRunState,
+  WorkflowStepRecord,
   WorkflowSessionBinding,
   WorkflowSessionCapture,
   WorkflowSessionEntryRecord,
@@ -58,9 +60,57 @@ type RunContext = {
 type RunRow = {
   runId: string;
   resourceId: string;
-  stateHash: Buffer;
   definitionHash: Buffer;
+  definitionDigest: Buffer;
+  workflowRef: string;
+  sourceRef: string;
+  workflowSourceHash: Buffer;
+  workflowSourcesHash: Buffer | null;
+  parentRunId: string | null;
+  title: string | null;
   status: string;
+  paused: number;
+  statusDetail: string | null;
+  inputHash: Buffer;
+  humanDecisionHash: Buffer | null;
+  finalOutputHash: Buffer | null;
+  errorHash: Buffer | null;
+  carriedStepCount: number;
+  currentNode: string | null;
+  currentAttemptId: string | null;
+  currentNodeStartedAt: number | null;
+  waitingOn: string | null;
+  createdAt: number;
+  updatedAt: number;
+  finishedAt: number | null;
+};
+
+type StoredStepMetadata = Pick<WorkflowStepRecord, "action" | "assistantMessage" | "conversation">;
+
+type StepRow = {
+  stepIndex: number;
+  attemptId: string;
+  nodeId: string;
+  nodeType: WorkflowStepRecord["nodeType"];
+  status: string;
+  promptHash: Buffer | null;
+  outputHash: Buffer | null;
+  outputOverrideHash: Buffer | null;
+  stepMetadataHash: Buffer | null;
+  errorHash: Buffer | null;
+  startedAt: number;
+  finishedAt: number;
+};
+
+type UpdateRow = {
+  updateId: string;
+  runRevision: number;
+  nodeId: string;
+  attemptId: string;
+  updateType: string;
+  updateKey: string;
+  dataHash: Buffer;
+  recordedAt: number;
 };
 
 type EventRow = {
@@ -228,7 +278,14 @@ export class WorkflowRunStore {
         const inputHash = this.state.putJson(state.input, now);
         const workflowSourceHash = this.state.putJson(state.workflowSource ?? source, now);
         const launchOptionsHash = this.state.putJson({}, now);
-        const stateHash = this.state.putJson(state, now);
+        const workflowSourcesHash =
+          state.workflowSources === undefined
+            ? null
+            : this.state.putJson(state.workflowSources, now);
+        const humanDecisionHash =
+          state.humanDecision === undefined ? null : this.state.putJson(state.humanDecision, now);
+        const finalOutputHash =
+          state.finalOutput === undefined ? null : this.state.putJson(state.finalOutput, now);
         const errorHash = state.error === undefined ? null : this.state.putText(state.error, now);
         this.state.connection
           .prepare(
@@ -236,9 +293,11 @@ export class WorkflowRunStore {
                run_id, resource_id, project_id, parent_run_id, definition_digest,
                workflow_ref, workflow_source_hash, launch_options_hash,
                source_type, source_ref, source_revision, title, status, paused,
-               status_detail, input_hash, output_hash, error_hash,
+               status_detail, input_hash, workflow_sources_hash, human_decision_hash,
+               final_output_hash, error_hash, carried_step_count, current_node,
+               current_attempt_id, current_node_started_at, waiting_on,
                created_at, updated_at, finished_at
-             ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           )
           .run(
             state.runId,
@@ -256,8 +315,17 @@ export class WorkflowRunStore {
             state.paused === true ? 1 : 0,
             state.statusDetail ?? null,
             inputHash,
-            stateHash,
+            workflowSourcesHash,
+            humanDecisionHash,
+            finalOutputHash,
             errorHash,
+            state.carriedStepCount ?? 0,
+            state.currentNode ?? null,
+            state.currentAttemptId ?? null,
+            state.currentNodeStartedAt === undefined
+              ? null
+              : Date.parse(state.currentNodeStartedAt),
+            state.waitingOn ?? null,
             Date.parse(state.startedAt),
             now,
             state.finishedAt === undefined ? null : Date.parse(state.finishedAt),
@@ -393,10 +461,20 @@ export class WorkflowRunStore {
         this.state.connection
           .prepare(
             `INSERT INTO workflow_updates(
-               update_id, attempt_id, update_seq, update_type, update_key, data_hash, recorded_at
-             ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+               update_id, attempt_id, update_seq, run_revision,
+               update_type, update_key, data_hash, recorded_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           )
-          .run(updateId, attemptId, nextUpdateSeq, update.type, update.key, dataHash, Date.now());
+          .run(
+            updateId,
+            attemptId,
+            nextUpdateSeq,
+            revision,
+            update.type,
+            update.key,
+            dataHash,
+            Date.now(),
+          );
         insertRunEvent(this.state, run.resourceId, revision, at, event);
         this.persistRunState(run, state, revision, Date.now());
         context.revision = revision;
@@ -528,7 +606,7 @@ export class WorkflowRunStore {
             ...(attemptId !== undefined ? { captureAttemptId: attemptId } : {}),
           },
         });
-        const current = this.readState(run.stateHash);
+        const current = this.readRunState(run, this.readDefinition(run.definitionHash));
         current.traceSeq = revision;
         current.updatedAt = at;
         this.persistRunState(run, current, revision, now);
@@ -616,24 +694,9 @@ export class WorkflowRunStore {
           );
         expected += 1;
       }
-      const now = Date.now();
       this.state.connection
         .prepare("UPDATE session_segments SET event_count = ? WHERE segment_id = ?")
         .run(expected - 1, current.segmentId);
-      const resourceId = segmentResourceId(current);
-      const revision = this.requireResourceRevision(resourceId);
-      this.bumpResource(resourceId, revision, now);
-      const payloadHash = this.state.putJson({ count: records.length, lastSeq: expected - 1 }, now);
-      insertGenericEvent(
-        this.state,
-        resourceId,
-        revision + 1,
-        "session.events_appended",
-        "session",
-        current.sessionId,
-        payloadHash,
-        now,
-      );
     });
   }
 
@@ -698,8 +761,8 @@ export class WorkflowRunStore {
   readRun(runId: string, options: ReadWorkflowRunOptions = {}): LoadedWorkflowRun | null {
     const row = this.readRunRow(runId);
     if (row === undefined) return null;
-    const state = this.readState(row.stateHash);
     const snapshot = this.readDefinition(row.definitionHash);
+    const state = this.readRunState(row, snapshot);
     const segments = this.segmentRows(runId).map((segment) => this.loadSegment(segment, state));
     const flat = segments.find((segment) => segment.attemptId === "") ?? emptySegment();
     return {
@@ -831,13 +894,20 @@ export class WorkflowRunStore {
     now: number,
   ): void {
     this.bumpResource(run.resourceId, expectedRevision - 1, now);
-    const stateHash = this.state.putJson(state, now);
+    const workflowSourcesHash =
+      state.workflowSources === undefined ? null : this.state.putJson(state.workflowSources, now);
+    const humanDecisionHash =
+      state.humanDecision === undefined ? null : this.state.putJson(state.humanDecision, now);
+    const finalOutputHash =
+      state.finalOutput === undefined ? null : this.state.putJson(state.finalOutput, now);
     const errorHash = state.error === undefined ? null : this.state.putText(state.error, now);
     const update = this.state.connection
       .prepare(
         `UPDATE runs
-         SET title = ?, status = ?, paused = ?, status_detail = ?, output_hash = ?,
-             error_hash = ?, updated_at = ?, finished_at = ?
+         SET title = ?, status = ?, paused = ?, status_detail = ?,
+             workflow_sources_hash = ?, human_decision_hash = ?, final_output_hash = ?,
+             error_hash = ?, carried_step_count = ?, current_node = ?, current_attempt_id = ?,
+             current_node_started_at = ?, waiting_on = ?, updated_at = ?, finished_at = ?
          WHERE run_id = ?`,
       )
       .run(
@@ -845,8 +915,15 @@ export class WorkflowRunStore {
         state.status,
         state.paused === true ? 1 : 0,
         state.statusDetail ?? null,
-        stateHash,
+        workflowSourcesHash,
+        humanDecisionHash,
+        finalOutputHash,
         errorHash,
+        state.carriedStepCount ?? 0,
+        state.currentNode ?? null,
+        state.currentAttemptId ?? null,
+        state.currentNodeStartedAt === undefined ? null : Date.parse(state.currentNodeStartedAt),
+        state.waitingOn ?? null,
         now,
         state.finishedAt === undefined ? null : Date.parse(state.finishedAt),
         state.runId,
@@ -855,7 +932,6 @@ export class WorkflowRunStore {
     if (state.status !== "running") {
       this.enqueueRunSettlementEffect(run.resourceId, expectedRevision, state, now);
     }
-    run.stateHash = stateHash;
   }
 
   private enqueueRunSettlementEffect(
@@ -931,7 +1007,9 @@ export class WorkflowRunStore {
     now: number,
   ): void {
     for (const step of state.steps.slice(state.carriedStepCount ?? 0)) {
-      const resultHash = this.state.putJson(step, now);
+      const metadata = stepMetadata(step);
+      const stepMetadataHash =
+        Object.keys(metadata).length === 0 ? null : this.state.putJson(metadata, now);
       const outputHash = step.output === undefined ? null : this.state.putJson(step.output, now);
       const errorHash = step.error === undefined ? null : this.state.putText(step.error, now);
       const promptHash = step.prompt === null ? null : this.state.putJson(step.prompt, now);
@@ -944,7 +1022,7 @@ export class WorkflowRunStore {
           .prepare(
             `INSERT INTO node_attempts(
                attempt_id, run_id, node_id, attempt_number, node_type, status,
-               presentation_hash, output_hash, result_hash, error_hash,
+               prompt_hash, output_hash, step_metadata_hash, error_hash,
                started_at, finished_at, created_at, updated_at
              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           )
@@ -957,7 +1035,7 @@ export class WorkflowRunStore {
             outcomeStatus(step.outcome),
             promptHash,
             outputHash,
-            resultHash,
+            stepMetadataHash,
             errorHash,
             Date.parse(step.startedAt),
             Date.parse(step.finishedAt),
@@ -968,7 +1046,7 @@ export class WorkflowRunStore {
         this.state.connection
           .prepare(
             `UPDATE node_attempts
-             SET status = ?, presentation_hash = ?, output_hash = ?, result_hash = ?,
+             SET status = ?, prompt_hash = ?, output_hash = ?, step_metadata_hash = ?,
                  error_hash = ?, finished_at = ?, updated_at = ?
              WHERE attempt_id = ?`,
           )
@@ -976,7 +1054,7 @@ export class WorkflowRunStore {
             outcomeStatus(step.outcome),
             promptHash,
             outputHash,
-            resultHash,
+            stepMetadataHash,
             errorHash,
             Date.parse(step.finishedAt),
             now,
@@ -986,6 +1064,49 @@ export class WorkflowRunStore {
     }
     if (state.currentAttemptId !== undefined && state.currentNode !== undefined) {
       this.ensureAttempt(state, state.currentNode, state.currentAttemptId, now, snapshot);
+    }
+    this.syncRunSteps(state, now);
+  }
+
+  private syncRunSteps(state: WorkflowRunState, now: number): void {
+    const existingRows = this.state.connection
+      .prepare(
+        `SELECT step_index AS stepIndex, attempt_id AS attemptId
+         FROM run_steps WHERE run_id = ? ORDER BY step_index`,
+      )
+      .all(state.runId)
+      .filter(isRunStepIdentityRow);
+    if (existingRows.length > state.steps.length) {
+      throw new Error(`Workflow run steps cannot shrink: ${state.runId}`);
+    }
+    for (const existing of existingRows) {
+      if (state.steps[existing.stepIndex]?.attemptId !== existing.attemptId) {
+        throw new Error(`Workflow run step history changed at index ${existing.stepIndex}`);
+      }
+    }
+    for (let stepIndex = existingRows.length; stepIndex < state.steps.length; stepIndex += 1) {
+      const step = state.steps[stepIndex];
+      /* istanbul ignore if -- array index follows a checked bound */
+      if (step === undefined) throw new Error("Workflow run step became unavailable");
+      const attempt = this.state.connection
+        .prepare("SELECT output_hash AS outputHash FROM node_attempts WHERE attempt_id = ?")
+        .get(step.attemptId);
+      if (!isAttemptOutputRow(attempt)) {
+        throw new Error(`Workflow node attempt is missing: ${step.attemptId}`);
+      }
+      const carried = stepIndex < (state.carriedStepCount ?? 0);
+      const outputOverrideHash =
+        carried &&
+        (attempt.outputHash === null ||
+          canonicalJson(this.state.readJson(attempt.outputHash)) !== canonicalJson(step.output))
+          ? this.state.putJson(step.output, now)
+          : null;
+      this.state.connection
+        .prepare(
+          `INSERT INTO run_steps(run_id, step_index, attempt_id, output_override_hash)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run(state.runId, stepIndex, step.attemptId, outputOverrideHash);
     }
   }
 
@@ -1057,8 +1178,17 @@ export class WorkflowRunStore {
     const row = this.state.connection
       .prepare(
         `SELECT r.run_id AS runId, r.resource_id AS resourceId,
-                r.output_hash AS stateHash, d.definition_hash AS definitionHash,
-                r.status
+                d.definition_hash AS definitionHash, r.definition_digest AS definitionDigest,
+                d.workflow_name AS workflowRef, r.source_ref AS sourceRef,
+                r.workflow_source_hash AS workflowSourceHash,
+                r.workflow_sources_hash AS workflowSourcesHash, r.parent_run_id AS parentRunId,
+                r.title, r.status, r.paused, r.status_detail AS statusDetail,
+                r.input_hash AS inputHash, r.human_decision_hash AS humanDecisionHash,
+                r.final_output_hash AS finalOutputHash, r.error_hash AS errorHash,
+                r.carried_step_count AS carriedStepCount, r.current_node AS currentNode,
+                r.current_attempt_id AS currentAttemptId,
+                r.current_node_started_at AS currentNodeStartedAt, r.waiting_on AS waitingOn,
+                r.created_at AS createdAt, r.updated_at AS updatedAt, r.finished_at AS finishedAt
          FROM runs r
          JOIN workflow_definitions d ON d.definition_digest = r.definition_digest
          WHERE r.run_id = ?`,
@@ -1073,12 +1203,151 @@ export class WorkflowRunStore {
     return row;
   }
 
-  private readState(hash: Buffer): WorkflowRunState {
-    const value = this.state.readJson(hash);
-    if (!isRecord(value) || value.schema !== RUN_STATE_SCHEMA) {
-      throw new Error("Workflow run state has an incompatible schema");
+  private readRunState(row: RunRow, snapshot: WorkflowDefinitionSnapshot): WorkflowRunState {
+    const steps = this.readSteps(row.runId);
+    const outputs: Record<string, unknown> = {};
+    const results: Record<string, WorkflowNodeResult> = {};
+    for (const step of steps) {
+      const result = resultForStep(step);
+      results[step.nodeId] = result;
+      if (step.outcome === "ok") outputs[step.nodeId] = step.output;
+      else delete outputs[step.nodeId];
+      const node = snapshot.nodes[step.nodeId];
+      const mountPath =
+        node?.includeTransition === "exit" && node.mountPath !== undefined
+          ? node.mountPath.join("/")
+          : undefined;
+      if (mountPath !== undefined && step.outcome === "ok") {
+        outputs[mountPath] = step.output;
+        results[mountPath] = { ...result, nodeId: mountPath };
+      }
     }
-    return value as WorkflowRunState;
+    const revision = this.requireResourceRevision(row.resourceId);
+    return {
+      schema: RUN_STATE_SCHEMA,
+      traceSeq: revision,
+      runId: row.runId,
+      workflowName: row.workflowRef,
+      ...(row.parentRunId === null ? {} : { parentRunId: row.parentRunId }),
+      ...(row.carriedStepCount === 0 ? {} : { carriedStepCount: row.carriedStepCount }),
+      ...(row.title === null ? {} : { runTitle: row.title }),
+      ...(row.sourceRef.startsWith("inline:")
+        ? {}
+        : { workflowSource: this.readJsonAs(row.workflowSourceHash) }),
+      ...(row.workflowSourcesHash === null
+        ? {}
+        : { workflowSources: this.readJsonAs(row.workflowSourcesHash) }),
+      ...(row.workflowSourcesHash !== null || snapshot.composition?.mounts.length
+        ? { definitionDigest: `sha256:${row.definitionDigest.toString("hex")}` }
+        : {}),
+      startedAt: new Date(row.createdAt).toISOString(),
+      ...(row.finishedAt === null ? {} : { finishedAt: new Date(row.finishedAt).toISOString() }),
+      updatedAt: new Date(row.updatedAt).toISOString(),
+      status: row.status as WorkflowRunState["status"],
+      input: this.state.readJson(row.inputHash),
+      outputs,
+      results,
+      steps,
+      ...this.readUpdates(row.runId),
+      ...(row.currentNode === null ? {} : { currentNode: row.currentNode }),
+      ...(row.currentAttemptId === null ? {} : { currentAttemptId: row.currentAttemptId }),
+      ...(row.currentNodeStartedAt === null
+        ? {}
+        : { currentNodeStartedAt: new Date(row.currentNodeStartedAt).toISOString() }),
+      ...(row.statusDetail === null ? {} : { statusDetail: row.statusDetail }),
+      ...(row.humanDecisionHash === null
+        ? {}
+        : { humanDecision: this.readJsonAs(row.humanDecisionHash) }),
+      ...(row.paused === 0 ? {} : { paused: true }),
+      ...(row.waitingOn === null ? {} : { waitingOn: row.waitingOn }),
+      ...(row.finalOutputHash === null
+        ? {}
+        : { finalOutput: this.state.readJson(row.finalOutputHash) }),
+      ...(row.errorHash === null ? {} : { error: this.readText(row.errorHash) }),
+    };
+  }
+
+  private readSteps(runId: string): WorkflowStepRecord[] {
+    const rows = this.state.connection
+      .prepare(
+        `SELECT s.step_index AS stepIndex, a.attempt_id AS attemptId, a.node_id AS nodeId,
+                a.node_type AS nodeType, a.status, a.prompt_hash AS promptHash,
+                a.output_hash AS outputHash, s.output_override_hash AS outputOverrideHash,
+                a.step_metadata_hash AS stepMetadataHash, a.error_hash AS errorHash,
+                a.started_at AS startedAt, a.finished_at AS finishedAt
+         FROM run_steps s
+         JOIN node_attempts a ON a.attempt_id = s.attempt_id
+         WHERE s.run_id = ? ORDER BY s.step_index`,
+      )
+      .all(runId)
+      .filter(isStepRow);
+    return rows.map((row, index) => {
+      if (row.stepIndex !== index)
+        throw new Error(`Workflow run step sequence has a gap: ${runId}`);
+      const metadata =
+        row.stepMetadataHash === null
+          ? {}
+          : this.readJsonAs<StoredStepMetadata>(row.stepMetadataHash);
+      const prompt = row.promptHash === null ? null : this.readJsonAs<string>(row.promptHash);
+      const outputHash = row.outputOverrideHash ?? row.outputHash;
+      const output = outputHash === null ? null : this.state.readJson(outputHash);
+      const error = row.errorHash === null ? undefined : this.readText(row.errorHash);
+      return {
+        attemptId: row.attemptId,
+        nodeId: row.nodeId,
+        nodeType: row.nodeType,
+        outcome: outcomeForStatus(row.status),
+        startedAt: new Date(row.startedAt).toISOString(),
+        finishedAt: new Date(row.finishedAt).toISOString(),
+        prompt,
+        output,
+        ...(error === undefined ? {} : { error }),
+        ...metadata,
+      };
+    });
+  }
+
+  private readUpdates(runId: string): Pick<WorkflowRunState, "updates"> {
+    const rows = this.state.connection
+      .prepare(
+        `SELECT u.update_id AS updateId, u.run_revision AS runRevision,
+                a.node_id AS nodeId, u.attempt_id AS attemptId,
+                u.update_type AS updateType, u.update_key AS updateKey,
+                u.data_hash AS dataHash, u.recorded_at AS recordedAt
+         FROM workflow_updates u
+         JOIN node_attempts a ON a.attempt_id = u.attempt_id
+         WHERE a.run_id = ? ORDER BY u.run_revision`,
+      )
+      .all(runId)
+      .filter(isUpdateRow);
+    if (rows.length === 0) return {};
+    let updates: WorkflowUpdateRecord[] | undefined;
+    for (const row of rows) {
+      updates = updateProjection(updates, {
+        updateId: row.updateId,
+        seq: row.runRevision,
+        at: new Date(row.recordedAt).toISOString(),
+        runId,
+        nodeId: row.nodeId,
+        attemptId: row.attemptId,
+        type: row.updateType,
+        key: row.updateKey,
+        data: this.readJsonAs<Record<string, unknown>>(row.dataHash),
+      });
+    }
+    return updates === undefined ? {} : { updates };
+  }
+
+  private readJsonAs<T>(hash: Buffer): T {
+    return this.state.readJson(hash) as T;
+  }
+
+  private readText(hash: Buffer): string {
+    const blob = this.state.readBlob(hash);
+    if (blob === undefined || blob.mediaType !== "text/plain") {
+      throw new Error("Text blob is missing or has the wrong media type");
+    }
+    return blob.content.toString("utf8");
   }
 
   private readDefinition(hash: Buffer): WorkflowDefinitionSnapshot {
@@ -1318,12 +1587,13 @@ function insertRunEvent(
   at: string,
   event: WorkflowTraceEventDraft | WorkflowTraceEvent,
 ): void {
+  const payload = compactTracePayload(event.type, event.payload);
   const payloadHash = state.putJson(
     {
       scope: event.scope,
       ...(event.nodeId === undefined ? {} : { nodeId: event.nodeId }),
       ...(event.attemptId === undefined ? {} : { attemptId: event.attemptId }),
-      payload: event.payload,
+      payload,
     },
     Date.parse(at),
   );
@@ -1337,6 +1607,25 @@ function insertRunEvent(
     payloadHash,
     Date.parse(at),
   );
+}
+
+function compactTracePayload(
+  eventType: string,
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
+  if (eventType === "node_finished" && Object.hasOwn(payload, "output")) {
+    const { output: _output, ...rest } = payload;
+    return { ...rest, outputStored: true };
+  }
+  if (eventType === "run_started" && Object.hasOwn(payload, "input")) {
+    const { input: _input, ...rest } = payload;
+    return { ...rest, inputStored: true };
+  }
+  if (Object.hasOwn(payload, "finalOutput")) {
+    const { finalOutput: _finalOutput, ...rest } = payload;
+    return { ...rest, finalOutputStored: true };
+  }
+  return payload;
 }
 
 function insertGenericEvent(
@@ -1407,6 +1696,43 @@ function outcomeStatus(outcome: string): string {
   }
 }
 
+function outcomeForStatus(status: string): WorkflowStepRecord["outcome"] {
+  switch (status) {
+    case "completed":
+      return "ok";
+    case "timed_out":
+      return "timed_out";
+    case "cancelled":
+      return "cancelled";
+    case "failed":
+      return "failed";
+    default:
+      throw new Error(`Workflow step has nonterminal status: ${status}`);
+  }
+}
+
+function stepMetadata(step: WorkflowStepRecord): StoredStepMetadata {
+  return {
+    ...(step.action === undefined ? {} : { action: step.action }),
+    ...(step.assistantMessage === undefined ? {} : { assistantMessage: step.assistantMessage }),
+    ...(step.conversation === undefined ? {} : { conversation: step.conversation }),
+  };
+}
+
+function resultForStep(step: WorkflowStepRecord): WorkflowNodeResult {
+  return {
+    attemptId: step.attemptId,
+    nodeId: step.nodeId,
+    nodeType: step.nodeType,
+    outcome: step.outcome,
+    startedAt: step.startedAt,
+    finishedAt: step.finishedAt,
+    durationMs: Date.parse(step.finishedAt) - Date.parse(step.startedAt),
+    ...(step.outcome === "ok" ? { output: step.output } : {}),
+    ...(step.error === undefined ? {} : { error: step.error }),
+  };
+}
+
 function traceScope(value: unknown): WorkflowTraceEvent["scope"] {
   return value === "node" || value === "agent" || value === "action" || value === "session"
     ? value
@@ -1437,6 +1763,12 @@ function validateSessionEventRecord(record: WorkflowSessionEventRecord): void {
     Array.isArray(record.payload)
   ) {
     throw new Error("Session event is missing required envelope fields");
+  }
+  if (
+    record.type === "assistant_event" &&
+    ["text_delta", "thinking_delta", "toolcall_delta"].includes(String(record.payload.type))
+  ) {
+    throw new Error("Incremental assistant events are not durable session facts");
   }
 }
 
@@ -1477,6 +1809,25 @@ function isRunRow(value: unknown): value is RunRow {
 }
 
 function isRunIdRow(value: unknown): value is { runId: string } {
+  return isRecord(value);
+}
+
+function isRunStepIdentityRow(value: unknown): value is {
+  stepIndex: number;
+  attemptId: string;
+} {
+  return isRecord(value);
+}
+
+function isAttemptOutputRow(value: unknown): value is { outputHash: Buffer | null } {
+  return isRecord(value) && (value.outputHash === null || Buffer.isBuffer(value.outputHash));
+}
+
+function isStepRow(value: unknown): value is StepRow {
+  return isRecord(value);
+}
+
+function isUpdateRow(value: unknown): value is UpdateRow {
   return isRecord(value);
 }
 

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -760,7 +760,6 @@ export type WorkflowSessionEventType =
   | "assistant_event"
   | "message_finished"
   | "tool_execution_started"
-  | "tool_execution_updated"
   | "tool_execution_finished";
 
 /** One normalized temporal Pi event in `session/events.ndjson`. */

--- a/test/composition.test.ts
+++ b/test/composition.test.ts
@@ -125,7 +125,10 @@ describe("workflow composition", () => {
     expect(bundle?.snapshot.composition?.mounts).toHaveLength(1);
     const trace = bundle?.traceEvents ?? [];
     expect(trace.filter((event) => event.type === "include_entered")).toHaveLength(1);
-    expect(trace.filter((event) => event.type === "include_exited")).toHaveLength(1);
+    const includeExit = trace.filter((event) => event.type === "include_exited");
+    expect(includeExit).toHaveLength(1);
+    expect(includeExit[0]?.payload).toMatchObject({ outputStored: true });
+    expect(includeExit[0]?.payload).not.toHaveProperty("output");
   });
 
   it("starts every re-entry with empty child-local state", async () => {

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -12,7 +12,7 @@ import {
   readWorkflowRun,
   workflowStateDatabasePath,
 } from "../../src/workflows/store.js";
-import type { WorkflowRunState, WorkflowSessionEventRecord } from "../../src/workflows/types.js";
+import type { WorkflowRunState } from "../../src/workflows/types.js";
 import { makeTempDir } from "../helpers.js";
 import { startMockOpenAiServer } from "./mock-openai.js";
 
@@ -1336,13 +1336,13 @@ describe.sequential("pi-workflows end to end", () => {
       async () => {
         try {
           return listWorkflowRuns({ databasePath: runsDir }).some((run) => {
-            const deltas = run.sessionEvents.filter(
+            const starts = run.sessionEvents.filter(
               (event) =>
                 event.type === "assistant_event" &&
-                event.payload.type === "toolcall_delta" &&
+                event.payload.type === "toolcall_start" &&
                 event.messageId !== undefined,
             );
-            return deltas.length >= 2;
+            return starts.length >= 1;
           });
         } catch {
           return false;
@@ -1440,106 +1440,19 @@ describe.sequential("pi-workflows end to end", () => {
     });
     expect(duplicateUserPrompts).toHaveLength(0);
 
-    const streamGroups = (deltaType: "text_delta" | "thinking_delta" | "toolcall_delta") => {
-      const groups = new Map<string, WorkflowSessionEventRecord[]>();
-      for (const event of sessionEvents) {
-        if (
-          event.type !== "assistant_event" ||
-          event.payload.type !== deltaType ||
-          event.messageId === undefined ||
-          typeof event.payload.contentIndex !== "number"
-        ) {
-          continue;
-        }
-        const key = `${event.messageId}:${event.payload.contentIndex}`;
-        const group = groups.get(key) ?? [];
-        group.push(event);
-        groups.set(key, group);
-      }
-      return groups;
-    };
-    const textGroups = streamGroups("text_delta");
-    const thinkingGroups = streamGroups("thinking_delta");
-    const toolGroups = streamGroups("toolcall_delta");
-    const fragmentedTextGroups = [...textGroups.values()].filter((group) => group.length > 1);
-    const fragmentedThinkingGroups = [...thinkingGroups.values()].filter(
-      (group) => group.length > 1,
+    const incrementalEvents = sessionEvents.filter(
+      (event) =>
+        event.type === "assistant_event" &&
+        ["text_delta", "thinking_delta", "toolcall_delta"].includes(String(event.payload.type)),
     );
-    const fragmentedToolGroups = [...toolGroups.values()].filter((group) => group.length > 1);
-    expect(fragmentedTextGroups.length).toBeGreaterThanOrEqual(1);
-    expect(fragmentedThinkingGroups.length).toBeGreaterThanOrEqual(1);
-    expect(fragmentedToolGroups.length).toBeGreaterThanOrEqual(1);
-    for (const group of [
-      ...fragmentedTextGroups,
-      ...fragmentedThinkingGroups,
-      ...fragmentedToolGroups,
-    ]) {
-      expect(new Set(group.map((event) => event.at)).size).toBeGreaterThan(1);
+    expect(incrementalEvents).toHaveLength(0);
+    for (const settledType of ["text_end", "thinking_end", "toolcall_end"]) {
+      expect(
+        sessionEvents.some(
+          (event) => event.type === "assistant_event" && event.payload.type === settledType,
+        ),
+      ).toBe(true);
     }
-
-    const textEnds = sessionEvents.filter(
-      (event) => event.type === "assistant_event" && event.payload.type === "text_end",
-    );
-    for (const end of textEnds) {
-      const key = `${end.messageId}:${String(end.payload.contentIndex)}`;
-      const deltas = textGroups.get(key) ?? [];
-      expect(deltas.map((event) => event.payload.delta).join("")).toBe(end.payload.content);
-    }
-    const thinkingEnds = sessionEvents.filter(
-      (event) => event.type === "assistant_event" && event.payload.type === "thinking_end",
-    );
-    for (const end of thinkingEnds) {
-      const key = `${end.messageId}:${String(end.payload.contentIndex)}`;
-      const deltas = thinkingGroups.get(key) ?? [];
-      expect(deltas.map((event) => event.payload.delta).join("")).toBe(end.payload.content);
-    }
-    const toolEnds = sessionEvents.filter(
-      (event) => event.type === "assistant_event" && event.payload.type === "toolcall_end",
-    );
-    for (const end of toolEnds) {
-      const key = `${end.messageId}:${String(end.payload.contentIndex)}`;
-      const deltas = toolGroups.get(key) ?? [];
-      const toolCall = end.payload.toolCall as { arguments?: unknown };
-      expect(JSON.parse(deltas.map((event) => event.payload.delta).join(""))).toEqual(
-        toolCall.arguments,
-      );
-    }
-
-    const textPrefix = fragmentedTextGroups[0]!;
-    const textReplay = reduceSessionEvents(sessionEntries, sessionEvents, textPrefix[1]!.seq);
-    const textMessage = textReplay.messages.find(
-      (message) => message.messageId === textPrefix[0]!.messageId,
-    );
-    expect(textMessage?.status).toBe("streaming");
-    expect(
-      textMessage?.blocks.find(
-        (block) => block.contentIndex === textPrefix[0]!.payload.contentIndex,
-      )?.text,
-    ).toBe(
-      textPrefix
-        .slice(0, 2)
-        .map((event) => event.payload.delta)
-        .join(""),
-    );
-    expect(textReplay.diagnostics).toEqual([]);
-
-    const toolPrefix = fragmentedToolGroups[0]!;
-    const toolReplay = reduceSessionEvents(sessionEntries, sessionEvents, toolPrefix[1]!.seq);
-    const toolMessage = toolReplay.messages.find(
-      (message) => message.messageId === toolPrefix[0]!.messageId,
-    );
-    expect(toolMessage?.status).toBe("streaming");
-    expect(
-      toolMessage?.blocks.find(
-        (block) => block.contentIndex === toolPrefix[0]!.payload.contentIndex,
-      )?.text,
-    ).toBe(
-      toolPrefix
-        .slice(0, 2)
-        .map((event) => event.payload.delta)
-        .join(""),
-    );
-    expect(toolReplay.diagnostics).toEqual([]);
 
     const finalReplay = reduceSessionEvents(sessionEntries, sessionEvents);
     expect(finalReplay.diagnostics).toEqual([]);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -47,23 +47,7 @@ export async function seedHumanDecisionRequest(
         now,
       );
       const launchHash = state.putJson({}, now);
-      const runState = {
-        schema: "pi-workflows.run-state.v1",
-        traceSeq: 1,
-        runId: request.runId,
-        workflowName: request.workflowName,
-        startedAt: request.createdAt,
-        updatedAt: request.createdAt,
-        finishedAt: request.createdAt,
-        status: "waiting",
-        input: {},
-        outputs: {},
-        results: {},
-        steps: [],
-        waitingOn: request.nodeId,
-        finalOutput: request,
-      };
-      const stateHash = state.putJson(runState, now);
+      const finalOutputHash = state.putJson(request, now);
       state.connection
         .prepare(
           `INSERT INTO workflow_definitions(
@@ -87,8 +71,9 @@ export async function seedHumanDecisionRequest(
              run_id, resource_id, definition_digest, workflow_ref,
              workflow_source_hash, launch_options_hash,
              source_type, source_ref, source_revision, status, paused,
-             input_hash, output_hash, created_at, updated_at, finished_at
-           ) VALUES (?, ?, ?, ?, ?, ?, 'file', ?, 'test', 'waiting', 0, ?, ?, ?, ?, ?)`,
+             input_hash, final_output_hash, current_node, current_attempt_id,
+             waiting_on, created_at, updated_at, finished_at
+           ) VALUES (?, ?, ?, ?, ?, ?, 'file', ?, 'test', 'waiting', 0, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           request.runId,
@@ -99,7 +84,10 @@ export async function seedHumanDecisionRequest(
           launchHash,
           `inline:${request.workflowName}`,
           inputHash,
-          stateHash,
+          finalOutputHash,
+          request.nodeId,
+          request.attemptId,
+          request.nodeId,
           now,
           now,
           now,

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -250,10 +250,8 @@ describe("SessionRecorder", () => {
       "message_started",
       "assistant_event",
       "assistant_event",
-      "assistant_event",
       "message_finished",
       "tool_execution_started",
-      "tool_execution_updated",
       "tool_execution_finished",
       "turn_finished",
     ]);

--- a/test/session-reducer.test.ts
+++ b/test/session-reducer.test.ts
@@ -74,7 +74,7 @@ describe("session event reducer fixtures", () => {
         turnId: "t",
         messageId: "m",
         type: "assistant_event",
-        payload: { type: "text_delta", contentIndex: 0, delta: "a" },
+        payload: { type: "text_start", contentIndex: 0 },
       },
       {
         seq: 4,
@@ -100,9 +100,6 @@ describe("session event reducer fixtures", () => {
     const state = reduceSessionEvents(entries, events);
     expect(state.messages[0]?.blocks[0]?.text).toBe("b");
     expect(state.settledEntryIds).toEqual(["e1"]);
-    expect(state.diagnostics).toEqual([
-      "session event sequence gap at 1",
-      "text_end mismatch for m:0",
-    ]);
+    expect(state.diagnostics).toEqual(["session event sequence gap at 1"]);
   });
 });

--- a/test/state-database.test.ts
+++ b/test/state-database.test.ts
@@ -57,18 +57,6 @@ describe("StateDatabase", () => {
     });
   });
 
-  it("removes unreferenced blobs when a writable database opens", async () => {
-    const filePath = path.join(await makeTempDir("state-blob-prune"), "state.sqlite");
-    const first = open(filePath);
-    const orphan = first.putJson({ large: "x".repeat(100_000) });
-    expect(first.readBlob(orphan)?.byteLength).toBeGreaterThan(100_000);
-    first.close();
-    opened.splice(opened.indexOf(first), 1);
-
-    const second = open(filePath);
-    expect(second.readBlob(orphan)).toBeUndefined();
-  });
-
   it("rejects incompatible or changed schemas", async () => {
     const filePath = path.join(await makeTempDir("state-incompatible"), "state.sqlite");
     const state = open(filePath);

--- a/test/state-database.test.ts
+++ b/test/state-database.test.ts
@@ -39,7 +39,7 @@ describe("StateDatabase", () => {
       state.connection
         .prepare("SELECT count(*) AS count FROM sqlite_schema WHERE sql LIKE '% STRICT'")
         .get(),
-    ).toEqual({ count: 32 });
+    ).toEqual({ count: 33 });
     state.integrityCheck();
   });
 
@@ -55,6 +55,18 @@ describe("StateDatabase", () => {
     expect(state.connection.prepare("SELECT count(*) AS count FROM blobs").get()).toEqual({
       count: 2,
     });
+  });
+
+  it("removes unreferenced blobs when a writable database opens", async () => {
+    const filePath = path.join(await makeTempDir("state-blob-prune"), "state.sqlite");
+    const first = open(filePath);
+    const orphan = first.putJson({ large: "x".repeat(100_000) });
+    expect(first.readBlob(orphan)?.byteLength).toBeGreaterThan(100_000);
+    first.close();
+    opened.splice(opened.indexOf(first), 1);
+
+    const second = open(filePath);
+    expect(second.readBlob(orphan)).toBeUndefined();
   });
 
   it("rejects incompatible or changed schemas", async () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -47,6 +47,33 @@ describe("WorkflowRunStore SQLite", () => {
     store.close();
   });
 
+  it("stores a large output once instead of writing nested run snapshots", async () => {
+    const databasePath = await makeStateDatabasePath("run-store-large-output");
+    const output = { reply: "x".repeat(1024 * 1024) };
+    await new WorkflowEngine({
+      databasePath,
+      executor: new ScriptedExecutor().respond("reply", { output }),
+    }).run(workflow, { task: "reply" });
+
+    const store = new WorkflowRunStore(databasePath, { readOnly: true });
+    const stats = store.state.connection
+      .prepare(
+        `SELECT COUNT(*) AS count, MAX(byte_length) AS largest,
+                SUM(byte_length) AS total
+         FROM blobs`,
+      )
+      .get() as { count: number; largest: number; total: number };
+    const outputBytes = Buffer.byteLength(JSON.stringify(output), "utf8");
+    expect(stats.largest).toBeLessThanOrEqual(outputBytes + 1_000);
+    expect(stats.total).toBeLessThan(outputBytes + 100_000);
+    expect(
+      store.state.connection
+        .prepare("SELECT 1 FROM pragma_table_info('runs') WHERE name = 'output_hash'")
+        .get(),
+    ).toBeUndefined();
+    store.close();
+  });
+
   it("publishes updates in the same transaction as the run projection", async () => {
     const databasePath = await makeStateDatabasePath("run-updates");
     const executor = new ScriptedExecutor().respond("reply", async (request) => {

--- a/test/telegram-decision-channel.test.ts
+++ b/test/telegram-decision-channel.test.ts
@@ -524,6 +524,19 @@ describe("TelegramDecisionChannel SQLite", () => {
     store.close();
   });
 
+  it("does not reacquire or rewrite a healthy lease on every poll", async () => {
+    const bot = fakeBot();
+    const { store, channel } = await fixture({ fetchFn: bot.fetchFn });
+    await waitUntil(() => bot.calls.filter((call) => call.method === "getUpdates").length >= 5);
+    expect(
+      store.state.connection
+        .prepare("SELECT count(*) AS count FROM events WHERE event_type = 'channel.lease_acquired'")
+        .get(),
+    ).toEqual({ count: 1 });
+    await channel.stop();
+    store.close();
+  });
+
   it("settles confirmed messages after another channel wins", async () => {
     const bot = fakeBot();
     const { request, store, channel } = await fixture({ fetchFn: bot.fetchFn });

--- a/tui/src/ui/conversation.rs
+++ b/tui/src/ui/conversation.rs
@@ -568,7 +568,7 @@ mod tests {
         let settled = rendered(None);
         assert!(settled.contains("assistant: settled"));
         assert!(settled.contains("plan hello"));
-        assert!(settled.contains("tool read [finished] · 1 update"));
+        assert!(settled.contains("tool read [finished] · 0 updates"));
         assert!(settled.contains("args: {\"path\":\"README.md\"}"));
         assert!(settled.contains("result: {\"content\":\"ok\"}"));
         assert!(!settled.contains("more session events"));


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Replace the Pi Workflows state contract in place so large prompts, outputs, and errors are not copied into repeated run snapshots and trace records.

## What changed

- Normalize run steps in `run_steps` and reconstruct the existing public `v1` run shape when reading.
- Store prompts, outputs, errors, and include exit values once instead of copying them through run state.
- Remove duplicate large values from trace payloads.
- Keep settled lifecycle events and omit streaming deltas, incremental tool updates, and generic flush events.
- Reduce Telegram lease writes and contain SQLite busy errors.
- Use one canonical workflow definition digest in the extension and engine.
- Update TUI fixtures and assertions for the compact event stream.

## Testing

- `npm run check`: 1,030 tests passed, coverage passed.
- `npm run test:e2e`: 20 tests passed.
- `npx slophammer-ts dry .`: no candidates.
- `cargo test` in `tui`: 45 tests passed.
- `git diff --check`: passed.
- Pi Reviewer: no P0 or P1 findings.

## Risk

This is a hard cutover. An old Workflows database is rejected with a reset instruction. The code does not migrate, read, or delete old state automatically.