### PR TITLE
chore: release 0.13.2

### DIFF
--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "osolmaz.pi-workflows"
 name = "pi-workflows"
-version = "0.13.1"
+version = "0.13.2"
 min_herdr_version = "0.7.0"
 description = "Open the active pi-workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "Terminal viewer and live replay server for pi-workflows SQLite state"
 license = "MIT"


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Release Pi Workflows 0.13.2 with the compact state model and reliability fixes.

## What changed

- Bump the npm package to 0.13.2.
- Bump the Rust TUI crate to 0.13.2.
- Keep the Herdr plugin version in sync.

## Testing

- npm checks passed.
- End-to-end tests passed.
- Rust tests and Clippy passed.
- The crates.io package dry run passed.
- The implementation changes passed their full local suites and CI before this release bump.

## Release

After this pull request merges, publish GitHub Release v0.13.2. The release workflows will publish the npm package and Rust crate.