### PR TITLE
fix(workflows): adopt concurrent decision continuations

### DIFF
--- a/docs/HUMAN_DECISIONS.md
+++ b/docs/HUMAN_DECISIONS.md
@@ -322,19 +322,23 @@ Recovery follows these rules:
 
 A required decision with no available channel remains waiting and reports the configuration problem. An automatic decision does not need a channel to apply its saved response after the deadline. A skipped plan policy creates no decision.
 
+Direct answer handling and recovery can notice the same accepted decision at the same time. Both paths use one continuation coordinator. The coordinator prepares the deterministic continuation through the existing durable run queue. The first caller creates and claims the queue row. Only that caller receives the claim token and starts the engine. A compatible later caller adopts the existing row without starting another engine.
+
+Adoption does not change the lease, claim generation, queue state, timestamps, or events. An adopter cannot renew, release, park, complete, or replace the winning claim. Reuse with a different workflow source, definition, input, launch options, parent, or owning session fails without changing the existing run. If the winning process stops after it claims the row, existing lease expiry and activation recovery can continue the prepared run.
+
 ## Compatibility
 
-This alpha change updates the current request, accepted-result, receipt, resolution, continuation, and snapshot contracts in place. Old active runs refuse resume through normal source and definition identity checks. There is no compatibility reader, migration, dual path, or new schema generation. Updated viewers label a human decision as a checkpoint, show its deadline and automatic action when present, and keep the canonical subject separate. Private channel configuration and transport identifiers remain hidden.
+This alpha change updates the current request, accepted-result, receipt, resolution, continuation, and snapshot contracts in place. Old active runs refuse resume through normal source and definition identity checks. There is no compatibility reader, migration, dual path, or new schema generation. The continuation startup fix uses existing queue and lease records. It adds no field, table, migration, or schema version. Existing compatible prepared or initialized continuations are adopted. Updated viewers label a human decision as a checkpoint, show its deadline and automatic action when present, and keep the canonical subject separate. Private channel configuration and transport identifiers remain hidden.
 
 The engine remains independent from Pi and Telegram. Core code owns decision contracts, validation, durable acceptance, and continuation. The Pi extension owns UI and channel lifecycle. The Telegram adapter owns Bot API translation. Workflow definitions own only the question, choices, audience, and routes.
 
 ## Contract impact
 
 - **Session state:** Pi records normal workflow messages and interactive decision results.
-- **Other persistent data:** decision requests and resolutions can carry a deadline, automatic response, and resolution provenance in the existing decision store. The private channel index remains rebuildable.
+- **Other persistent data:** decision requests and resolutions can carry a deadline, automatic response, and resolution provenance in the existing decision store. Continuation startup uses existing run, queue, source, binding, lease, event, continuation, and decision-effect records. It adds no new persistent shape. The private channel index remains rebuildable.
 - **Pi internals:** none.
 - **Public Pi API:** documented extension lifecycle and UI methods only.
-- **Public pi-workflows API:** typed human choices, `humanDecision().onTimeout`, `humanDecisionEdge()`, the channel interface, the plan approval policy, and the shared plan-change workflow.
+- **Public pi-workflows API:** typed human choices, `humanDecision().onTimeout`, `humanDecisionEdge()`, the channel interface, the plan approval policy, the shared plan-change workflow, and the additive queue prepare-or-adopt operation.
 
 ## Verification requirements
 
@@ -350,6 +354,10 @@ The implementation must test:
 - unauthorized users and chats;
 - stale request digests;
 - concurrent Pi and Telegram answers;
+- a direct verified answer racing recovery for the same accepted decision;
+- one claim generation, one engine start, one continuation, and one execution of each continuation node;
+- compatible continuation adoption without lease, queue, timestamp, or event mutation;
+- incompatible continuation identity reuse without mutation;
 - identical and conflicting retries;
 - crashes before and after answer acceptance and continuation creation;
 - ambiguous Telegram sends;
@@ -357,4 +365,4 @@ The implementation must test:
 - decision cancellation and expiry;
 - included `plan-approval` routes and bounded replan loops;
 - viewer redaction; and
-- real Pi execution without real Telegram credentials or network calls.
+- real Pi execution without real Telegram credentials or network calls, duplicate-start failures, revision conflicts, or a stranded running continuation.

--- a/docs/plans/2026-08-19-human-decision-gates-plan.md
+++ b/docs/plans/2026-08-19-human-decision-gates-plan.md
@@ -52,6 +52,11 @@ Pi and Telegram implement one channel interface. Workflows address a named audie
 - Accept the first valid response with a no-replace write.
 - Adopt identical retries and reject conflicting responses.
 - Derive one continuation identity from the accepted decision.
+- Prepare that continuation through one atomic queue operation.
+- Let the first caller create and claim the queue row.
+- Let compatible concurrent or repeated callers adopt the row without changing its lease, claim generation, queue state, timestamps, or events.
+- Reject incompatible workflow source, definition, input, launch options, parent, or owning session without changing the existing row.
+- Give only the winning caller a claim token and permission to start the engine.
 - Reject stale responses by decision ID and canonical request digest.
 - Rebuild the pending-decision index from immutable records.
 
@@ -83,6 +88,10 @@ Pi and Telegram implement one channel interface. Workflows address a named audie
 - Promise exactly-once Telegram message creation after an ambiguous Bot API response.
 - Add arbitrary forms in the first release. Choice buttons and one text input cover the required flows.
 - Change existing checkpoints or historical run bundles.
+- Add a database field, table, migration, schema version, compatibility reader, or dual-write path for continuation startup.
+- Coordinate continuation startup with a process-local promise map, timing guard, retry loop, or swallowed error.
+- Change general queue claim behavior for unrelated launch paths.
+- Repair an already stranded live continuation as part of this change.
 - Enable human approval by default in existing built-in workflows.
 
 ## Design decisions
@@ -107,7 +116,13 @@ The Telegram adapter accepts replan text only as a reply to the exact `ForceRepl
 
 ### Make answer acceptance exact
 
-Channel delivery can be retried or fail independently. Decision acceptance is one atomic no-replace operation. The accepted response and deterministic continuation identity prevent two channels from starting two continuations.
+Channel delivery can be retried or fail independently. Decision acceptance is one atomic no-replace operation. The accepted response and deterministic continuation identity prevent two channels from selecting different continuations.
+
+### Prepare or adopt one continuation
+
+Direct answer handling and periodic recovery can both see the accepted decision. They use one continuation coordinator and one durable queue operation. The operation creates and claims a missing queue row or returns a compatible existing row as adopted. Only a newly claimed preparation can call `WorkflowEngine.continueRun()`.
+
+An adopted result is normal success. It does not start another engine or change the winning lease, claim generation, queue state, timestamps, or events. The adopter receives no claim token, so it cannot renew, release, park, complete, or replace the winning claim. Incompatible reuse fails without mutation. Existing cleanup handles failure before run initialization, and existing lease expiry and activation recovery handle a winning process that stops after preparation.
 
 ### Handle Telegram delivery limits honestly
 
@@ -171,10 +186,17 @@ A private SQLite index may track pending decisions, channel leases, Telegram upd
 - Validate the accepted response through the node contract.
 - Preserve the parent's original workflow input.
 - Expose the response as the checkpoint output.
-- derive and adopt the continuation identity; and
-- leave the legacy checkpoint path unchanged.
+- Derive the deterministic continuation identity.
+- Add a typed atomic prepare-or-adopt operation to the existing SQLite queue store.
+- Compare the stored workflow source, definition digest, input, launch options, parent, and owning session before adoption.
+- Build one prepared continuation value in the Pi extension.
+- Route direct verified answers and recovery through one continuation coordinator.
+- Start `WorkflowEngine.continueRun()` only with the new claim token.
+- Return normal started or already-continuing success to the answer path.
+- Keep enqueue and lease behavior unchanged for other launch paths.
+- Leave legacy checkpoint continuation unchanged.
 
-Test crashes before acceptance, after acceptance, during continuation creation, and after continuation completion.
+Test crashes before acceptance, after acceptance, during continuation creation, and after continuation completion. Add a focused race test for direct answer handling and recovery. It must prove one claim generation, one engine start, one continuation, one execution of each continuation node, coherent queue and run state, and no duplicate-start or revision-conflict failure. Add a real-Pi version of the same regression with a durable barrier instead of sleep-only timing.
 
 ### Channel management
 
@@ -248,7 +270,9 @@ The setup command uses an existing mode-`0600` token file instead of collecting 
 - The workflow tool cannot answer a protected human decision.
 - Pi and Telegram can receive the same decision through one audience profile.
 - The first concurrent valid answer wins and creates one continuation.
-- An identical retry is adopted; a conflicting or stale answer is rejected.
+- Direct answer handling and recovery can race without starting it twice or replacing its lease.
+- The first queue preparation starts the engine, and a compatible repeat adopts it without mutation.
+- An incompatible continuation identity, conflicting answer, or stale answer is rejected without mutation.
 - The original workflow input survives a human-decision continuation.
 - Old checkpoints and old bundles pass their existing tests unchanged.
 - The Telegram adapter accepts text only from the bound reply and approved numeric actor.
@@ -267,6 +291,8 @@ npx vitest run test/human-decision-api.test.ts test/human-decision-store.test.ts
 npx vitest run test/human-decision-engine.test.ts test/run-resume.test.ts
 npx vitest run test/pi-decision-channel.test.ts test/telegram-decision-channel.test.ts
 npx vitest run test/plan-approval.test.ts test/composition.test.ts
+npx vitest run test/run-queue.test.ts test/extension.test.ts
+npx vitest run --config vitest.e2e.config.ts test/e2e/workflow.e2e.test.ts
 ```
 
 Run all repository gates before review:
@@ -290,7 +316,7 @@ This work adds compatible public APIs and additive persisted records. Release it
 ## Contract impact
 
 - **Session state:** normal workflow messages and interactive decision results.
-- **Other persistent data:** additive decision records, a rebuildable private channel index, and private channel configuration.
+- **Other persistent data:** additive decision records, a rebuildable private channel index, private channel configuration, and existing run queue and lease records. The continuation startup fix adds no persistent field, table, migration, or schema version.
 - **Pi internals:** none.
 - **Public Pi API:** documented extension lifecycle plus command and UI methods only.
-- **Public pi-workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, and the `plan-approval` workflow.
+- **Public pi-workflows API:** typed human choices, `humanDecision()`, `humanDecisionEdge()`, the channel interface, the `plan-approval` workflow, and an additive queue prepare-or-adopt operation.

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -24,7 +24,10 @@ export {
   SqliteControllerStore,
   type RunEventRecord,
   type WorkflowNotificationRecord,
+  type WorkflowRunClaimOptions,
+  type WorkflowRunPreparationResult,
   type WorkflowRunQueueRecord,
+  type WorkflowRunReservationOptions,
 } from "./sqlite.js";
 export {
   type ControllerStore,

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { StateDatabase, workflowStatePath } from "../state/database.js";
+import { canonicalJson } from "../state/json.js";
 import { resourceIdFor, tokenHash } from "../state/mutation.js";
 import {
   EffectRequestConflictError,
@@ -39,6 +40,26 @@ export type WorkflowRunLaunchStatus =
   | "failed"
   | "cancelled";
 
+export type WorkflowRunReservationOptions = {
+  runId: string;
+  workflowName: string;
+  workflowSourceRef: string;
+  workflowSource: unknown;
+  definitionDigest: string;
+  definitionSnapshot: unknown;
+  input: unknown;
+  launchOptions?: unknown;
+  runnerId: string;
+  originSessionId: string;
+  parentRunId?: string;
+  now?: string;
+};
+
+export type WorkflowRunClaimOptions = WorkflowRunReservationOptions & {
+  claimToken: string;
+  leaseMs: number;
+};
+
 export type WorkflowRunQueueRecord = {
   runId: string;
   workflowName: string;
@@ -63,6 +84,16 @@ export type WorkflowRunQueueRecord = {
   startedAt: string | null;
   finishedAt: string | null;
 };
+
+export type WorkflowRunPreparationResult =
+  | {
+      state: "claimed";
+      run: WorkflowRunQueueRecord & { claimToken: string };
+    }
+  | {
+      state: "adopted";
+      run: WorkflowRunQueueRecord;
+    };
 
 export type WorkflowNotificationRecord = {
   notificationId: string;
@@ -998,139 +1029,147 @@ export class SqliteControllerStore implements ControllerStore {
     }));
   }
 
-  reserveWorkflowRun(options: {
-    runId: string;
-    workflowName: string;
-    workflowSourceRef: string;
-    workflowSource: unknown;
-    definitionDigest: string;
-    definitionSnapshot: unknown;
-    input: unknown;
-    launchOptions?: unknown;
-    runnerId: string;
-    originSessionId: string;
-    parentRunId?: string;
-    now?: string;
-  }): WorkflowRunQueueRecord {
+  reserveWorkflowRun(options: WorkflowRunReservationOptions): WorkflowRunQueueRecord {
     validateRunId(options.runId);
     const now = epoch(validTimestamp(options.now));
     const definitionDigest = digestBuffer(options.definitionDigest);
-    return this.state.transaction(() => {
-      if (this.getWorkflowRun(options.runId) !== undefined) {
-        throw new Error(`Workflow run already reserved: ${options.runId}`);
+    return this.state.transaction(() =>
+      this.reserveWorkflowRunInTransaction(options, now, definitionDigest),
+    );
+  }
+
+  private reserveWorkflowRunInTransaction(
+    options: WorkflowRunReservationOptions,
+    now: number,
+    definitionDigest: Buffer,
+  ): WorkflowRunQueueRecord {
+    if (this.getWorkflowRun(options.runId) !== undefined) {
+      throw new Error(`Workflow run already reserved: ${options.runId}`);
+    }
+    if (options.parentRunId !== undefined) {
+      const parent = this.requireWorkflowRunRow(options.parentRunId);
+      if (parent.originSessionId !== options.originSessionId) {
+        throw new Error("Continuation parent belongs to another Pi session");
       }
-      if (options.parentRunId !== undefined) {
-        const parent = this.requireWorkflowRunRow(options.parentRunId);
-        if (parent.originSessionId !== options.originSessionId) {
-          throw new Error("Continuation parent belongs to another Pi session");
+      if (parent.status === "parked") {
+        const parentLease = this.requireLease(parent.resourceId);
+        if (parentLease.ownerId !== null) {
+          throw new Error("Continuation parent still has an active owner");
         }
-        if (parent.status === "parked") {
-          const parentLease = this.requireLease(parent.resourceId);
-          if (parentLease.ownerId !== null) {
-            throw new Error("Continuation parent still has an active owner");
-          }
-          this.state.connection
-            .prepare(
-              `UPDATE run_queue
+        this.state.connection
+          .prepare(
+            `UPDATE run_queue
                SET status = 'done', updated_at = ?, finished_at = ?
                WHERE run_id = ? AND status = 'parked'`,
-            )
-            .run(now, now, parent.runId);
-          const parentRevision = this.resourceRevision(parent.resourceId);
-          this.bumpResource(parent.resourceId, parentRevision, now);
-          this.insertEvent(
-            parent.resourceId,
-            parentRevision + 1,
-            "run.queue_done_for_continuation",
-            "session",
-            options.originSessionId,
-            { continuationRunId: options.runId },
-            now,
-          );
-        } else if (parent.status === "done") {
-          throw new Error("Continuation parent already has a reserved continuation");
-        } else {
-          throw new Error(`Continuation parent queue is ${parent.status}`);
-        }
+          )
+          .run(now, now, parent.runId);
+        const parentRevision = this.resourceRevision(parent.resourceId);
+        this.bumpResource(parent.resourceId, parentRevision, now);
+        this.insertEvent(
+          parent.resourceId,
+          parentRevision + 1,
+          "run.queue_done_for_continuation",
+          "session",
+          options.originSessionId,
+          { continuationRunId: options.runId },
+          now,
+        );
+      } else if (parent.status === "done") {
+        throw new Error("Continuation parent already has a reserved continuation");
+      } else {
+        throw new Error(`Continuation parent queue is ${parent.status}`);
       }
-      const resourceId = resourceIdFor("run", options.runId);
-      const definitionHash = this.state.putJson(options.definitionSnapshot, now);
-      const queuedSource = queuedWorkflowSource(options.workflowSource);
-      const inputHash = this.state.putJson(options.input ?? null, now);
-      const launchHash = this.state.putJson(options.launchOptions ?? {}, now);
-      this.state.connection
-        .prepare(
-          `INSERT INTO workflow_definitions(
+    }
+    const resourceId = resourceIdFor("run", options.runId);
+    const definitionHash = this.state.putJson(options.definitionSnapshot, now);
+    const queuedSource = queuedWorkflowSource(options.workflowSource);
+    const inputHash = this.state.putJson(options.input ?? null, now);
+    const launchHash = this.state.putJson(options.launchOptions ?? {}, now);
+    this.state.connection
+      .prepare(
+        `INSERT INTO workflow_definitions(
              definition_digest, workflow_name, definition_hash, created_at
            ) VALUES (?, ?, ?, ?)
            ON CONFLICT(definition_digest) DO NOTHING`,
-        )
-        .run(definitionDigest, options.workflowName, definitionHash, now);
-      this.state.connection
-        .prepare(
-          `INSERT INTO resources(resource_id, resource_type, aggregate_key, revision, created_at, updated_at)
+      )
+      .run(definitionDigest, options.workflowName, definitionHash, now);
+    this.state.connection
+      .prepare(
+        `INSERT INTO resources(resource_id, resource_type, aggregate_key, revision, created_at, updated_at)
            VALUES (?, 'run', ?, 1, ?, ?)`,
-        )
-        .run(resourceId, options.runId, now, now);
-      this.state.connection
-        .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
-        .run(resourceId);
-      this.state.connection
-        .prepare(
-          `INSERT INTO runs(
+      )
+      .run(resourceId, options.runId, now, now);
+    this.state.connection
+      .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
+      .run(resourceId);
+    this.state.connection
+      .prepare(
+        `INSERT INTO runs(
              run_id, resource_id, project_id, parent_run_id, definition_digest,
              workflow_ref, launch_options_hash, status, paused,
              input_hash, created_at, updated_at
            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 0, ?, ?, ?)`,
-        )
-        .run(
-          options.runId,
-          resourceId,
-          this.requireProjectId(),
-          options.parentRunId ?? null,
-          definitionDigest,
-          options.workflowSourceRef,
-          launchHash,
-          inputHash,
-          now,
-          now,
-        );
-      insertQueuedRunSources(this.state, options.runId, queuedSource);
-      this.state.connection
-        .prepare(
-          `INSERT INTO run_bindings(run_id, origin_session_id, execution_mode, created_at)
+      )
+      .run(
+        options.runId,
+        resourceId,
+        this.requireProjectId(),
+        options.parentRunId ?? null,
+        definitionDigest,
+        options.workflowSourceRef,
+        launchHash,
+        inputHash,
+        now,
+        now,
+      );
+    insertQueuedRunSources(this.state, options.runId, queuedSource);
+    this.state.connection
+      .prepare(
+        `INSERT INTO run_bindings(run_id, origin_session_id, execution_mode, created_at)
            VALUES (?, ?, 'interactive', ?)`,
-        )
-        .run(options.runId, options.originSessionId, now);
-      this.state.connection
-        .prepare(
-          `INSERT INTO run_queue(
+      )
+      .run(options.runId, options.originSessionId, now);
+    this.state.connection
+      .prepare(
+        `INSERT INTO run_queue(
              run_id, status, available_at, affinity_runner_id, origin_session_id,
              consecutive_errors, created_at, updated_at
            ) VALUES (?, 'queued', ?, ?, ?, 0, ?, ?)`,
-        )
-        .run(options.runId, now, options.runnerId, options.originSessionId, now, now);
-      this.insertEvent(resourceId, 1, "run.queued", "session", options.originSessionId, {}, now);
-      return this.requireWorkflowRun(options.runId);
+      )
+      .run(options.runId, now, options.runnerId, options.originSessionId, now, now);
+    this.insertEvent(resourceId, 1, "run.queued", "session", options.originSessionId, {}, now);
+    return this.requireWorkflowRun(options.runId);
+  }
+
+  prepareOrAdoptWorkflowRun(options: WorkflowRunClaimOptions): WorkflowRunPreparationResult {
+    validateRunId(options.runId);
+    const now = epoch(validTimestamp(options.now));
+    const definitionDigest = digestBuffer(options.definitionDigest);
+    return this.state.transaction(() => {
+      const existing = this.workflowRunRow(options.runId);
+      if (existing !== undefined) {
+        this.assertWorkflowRunPreparationCompatible(existing, options, definitionDigest);
+        return { state: "adopted", run: this.mapWorkflowRun(existing) };
+      }
+      this.reserveWorkflowRunInTransaction(options, now, definitionDigest);
+      const claimed = this.claimRunInTransaction(
+        options.runId,
+        options.runnerId,
+        options.claimToken,
+        options.leaseMs,
+        now,
+      );
+      if (claimed === undefined) {
+        throw new Error(`Workflow run could not be claimed: ${options.runId}`);
+      }
+      return {
+        state: "claimed",
+        run: claimed as WorkflowRunQueueRecord & { claimToken: string },
+      };
     });
   }
 
-  enqueueWorkflowRun(options: {
-    runId: string;
-    workflowName: string;
-    workflowSourceRef: string;
-    workflowSource: unknown;
-    definitionDigest: string;
-    definitionSnapshot: unknown;
-    input: unknown;
-    launchOptions?: unknown;
-    runnerId: string;
-    claimToken: string;
-    leaseMs: number;
-    originSessionId: string;
-    parentRunId?: string;
-    now?: string;
-  }): WorkflowRunQueueRecord {
+  enqueueWorkflowRun(options: WorkflowRunClaimOptions): WorkflowRunQueueRecord {
     if (this.getWorkflowRun(options.runId) === undefined) {
       this.reserveWorkflowRun({
         runId: options.runId,
@@ -2230,6 +2269,27 @@ export class SqliteControllerStore implements ControllerStore {
     return this.mapWorkflowRun(this.requireWorkflowRunRow(runId));
   }
 
+  private assertWorkflowRunPreparationCompatible(
+    row: RunRow,
+    options: WorkflowRunReservationOptions,
+    definitionDigest: Buffer,
+  ): void {
+    const compatible =
+      row.workflowName === options.workflowName &&
+      row.workflowRef === options.workflowSourceRef &&
+      row.definitionDigest.equals(definitionDigest) &&
+      canonicalJson(readQueuedRunSources(this.state, row)) ===
+        canonicalJson(queuedWorkflowSource(options.workflowSource)) &&
+      canonicalJson(this.state.readJson(row.inputHash)) === canonicalJson(options.input ?? null) &&
+      canonicalJson(this.state.readJson(row.launchOptionsHash)) ===
+        canonicalJson(options.launchOptions ?? {}) &&
+      row.originSessionId === options.originSessionId &&
+      row.parentRunId === (options.parentRunId ?? null);
+    if (!compatible) {
+      throw new Error(`Workflow run preparation conflicts: ${options.runId}`);
+    }
+  }
+
   /* istanbul ignore next -- pure projection covered by integration tests */
   private mapWorkflowRun(row: RunRow): WorkflowRunQueueRecord {
     return {
@@ -2269,56 +2329,65 @@ export class SqliteControllerStore implements ControllerStore {
     leaseMs: number,
     now: number,
   ): WorkflowRunQueueRecord | undefined {
-    return this.state.transaction(() => {
-      const row = this.workflowRunRow(runId);
-      if (row === undefined || ["done", "failed", "cancelled"].includes(row.status))
-        return undefined;
-      const lease = this.requireLease(row.resourceId);
-      if (
-        lease.ownerId !== null &&
-        lease.expiresAt !== null &&
-        lease.expiresAt > now &&
-        lease.ownerId !== runnerId
-      )
-        return undefined;
-      const generation = lease.generation + 1;
-      const expiresAt = now + leaseMs;
-      const result = this.state.connection
-        .prepare(
-          `UPDATE leases SET generation = ?, owner_type = ?, owner_id = ?, token_hash = ?,
+    return this.state.transaction(() =>
+      this.claimRunInTransaction(runId, runnerId, claimToken, leaseMs, now),
+    );
+  }
+
+  private claimRunInTransaction(
+    runId: string,
+    runnerId: string,
+    claimToken: string,
+    leaseMs: number,
+    now: number,
+  ): WorkflowRunQueueRecord | undefined {
+    const row = this.workflowRunRow(runId);
+    if (row === undefined || ["done", "failed", "cancelled"].includes(row.status)) return undefined;
+    const lease = this.requireLease(row.resourceId);
+    if (
+      lease.ownerId !== null &&
+      lease.expiresAt !== null &&
+      lease.expiresAt > now &&
+      lease.ownerId !== runnerId
+    )
+      return undefined;
+    const generation = lease.generation + 1;
+    const expiresAt = now + leaseMs;
+    const result = this.state.connection
+      .prepare(
+        `UPDATE leases SET generation = ?, owner_type = ?, owner_id = ?, token_hash = ?,
                   acquired_at = ?, heartbeat_at = ?, expires_at = ?
            WHERE resource_id = ? AND generation = ?`,
-        )
-        .run(
-          generation,
-          runnerId.startsWith("host-") ? "host" : "session",
-          runnerId,
-          tokenHash(claimToken),
-          now,
-          now,
-          expiresAt,
-          row.resourceId,
-          lease.generation,
-        );
-      /* istanbul ignore if -- impossible after exact schema and transaction checks */
-      if (result.changes !== 1) return undefined;
-      this.state.connection
-        .prepare("UPDATE run_queue SET status = 'starting', updated_at = ? WHERE run_id = ?")
-        .run(now, runId);
-      const revision = this.resourceRevision(row.resourceId);
-      this.bumpResource(row.resourceId, revision, now);
-      this.insertEvent(
-        row.resourceId,
-        revision + 1,
-        "lease.claimed",
+      )
+      .run(
+        generation,
         runnerId.startsWith("host-") ? "host" : "session",
         runnerId,
-        { expiresAt },
+        tokenHash(claimToken),
         now,
-        generation,
+        now,
+        expiresAt,
+        row.resourceId,
+        lease.generation,
       );
-      return { ...this.requireWorkflowRun(runId), claimToken };
-    });
+    /* istanbul ignore if -- impossible after exact schema and transaction checks */
+    if (result.changes !== 1) return undefined;
+    this.state.connection
+      .prepare("UPDATE run_queue SET status = 'starting', updated_at = ? WHERE run_id = ?")
+      .run(now, runId);
+    const revision = this.resourceRevision(row.resourceId);
+    this.bumpResource(row.resourceId, revision, now);
+    this.insertEvent(
+      row.resourceId,
+      revision + 1,
+      "lease.claimed",
+      runnerId.startsWith("host-") ? "host" : "session",
+      runnerId,
+      { expiresAt },
+      now,
+      generation,
+    );
+    return { ...this.requireWorkflowRun(runId), claimToken };
   }
 
   private updateClaimedRunStatus(

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -248,6 +248,16 @@ type StartRunOptions = {
   claimToken?: string;
 };
 
+type PreparedRunLaunch = {
+  ref: string;
+  input: unknown;
+  options: StartRunOptions;
+  workflow: WorkflowDefinition;
+  snapshot: WorkflowDefinitionSnapshot;
+  workflowSource: WorkflowSource;
+  runId: string;
+};
+
 function definitionDigest(snapshot: WorkflowDefinitionSnapshot): string {
   return `sha256:${createHash("sha256").update(canonicalJson(snapshot)).digest("hex")}`;
 }
@@ -1611,37 +1621,15 @@ export default function piWorkflows(pi: ExtensionAPI) {
     }
   };
 
-  const startRun = async (
+  const prepareRunLaunch = async (
     ctx: ExtensionContext,
     ref: string,
     input: unknown,
     options: StartRunOptions = {},
-  ): Promise<string | undefined> => {
+  ): Promise<PreparedRunLaunch> => {
     if (options.signal?.aborted) {
       throw options.signal.reason ?? new Error("Workflow startup aborted");
     }
-    ensureFollowUpDelivery();
-    if (activeRun) {
-      if (!options.quiet) {
-        notify(
-          ctx,
-          `A workflow is already running: ${activeRun.workflowName}. Use /workflow cancel first.`,
-          "error",
-        );
-      }
-      return undefined;
-    }
-    if (presentationPending !== null) {
-      if (!options.quiet) {
-        notify(
-          ctx,
-          "The previous workflow result is still being presented. Wait for it to finish.",
-        );
-      }
-      return undefined;
-    }
-    supersedePresentation();
-    const generation = runGeneration;
     const resolved = await resolveWorkflowRef(ref, { cwd: ctx.cwd }, builtinWorkflowCatalog);
     const workflow = resolved.definition;
     if (options.signal?.aborted) {
@@ -1669,6 +1657,46 @@ export default function piWorkflows(pi: ExtensionAPI) {
           workflowSource,
         );
       }
+    }
+    return { ref, input, options, workflow, snapshot, workflowSource, runId };
+  };
+
+  const beginRunStart = (ctx: ExtensionContext, options: StartRunOptions): number | undefined => {
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? new Error("Workflow startup aborted");
+    }
+    ensureFollowUpDelivery();
+    if (activeRun) {
+      if (!options.quiet) {
+        notify(
+          ctx,
+          `A workflow is already running: ${activeRun.workflowName}. Use /workflow cancel first.`,
+          "error",
+        );
+      }
+      return undefined;
+    }
+    if (presentationPending !== null) {
+      if (!options.quiet) {
+        notify(
+          ctx,
+          "The previous workflow result is still being presented. Wait for it to finish.",
+        );
+      }
+      return undefined;
+    }
+    supersedePresentation();
+    return runGeneration;
+  };
+
+  const startPreparedRun = async (
+    ctx: ExtensionContext,
+    launch: PreparedRunLaunch,
+    generation: number,
+  ): Promise<string | undefined> => {
+    const { ref, input, options, workflow, snapshot, workflowSource, runId } = launch;
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? new Error("Workflow startup aborted");
     }
 
     // Interactive runs are queued and claimed atomically, so this session
@@ -1998,6 +2026,21 @@ export default function piWorkflows(pi: ExtensionAPI) {
         notify(ctx, `Workflow ${workflow.name} crashed: ${message}`, "error");
       });
     return runId;
+  };
+
+  const startRun = async (
+    ctx: ExtensionContext,
+    ref: string,
+    input: unknown,
+    options: StartRunOptions = {},
+  ): Promise<string | undefined> => {
+    const generation = beginRunStart(ctx, options);
+    if (generation === undefined) return undefined;
+    return await startPreparedRun(
+      ctx,
+      await prepareRunLaunch(ctx, ref, input, options),
+      generation,
+    );
   };
 
   // Reclaim and resume a parked run when this session opens without an
@@ -2743,6 +2786,100 @@ export default function piWorkflows(pi: ExtensionAPI) {
     };
   };
 
+  type HumanDecisionContinuationOutcome = {
+    runId: string;
+    started: boolean;
+    queueStatus: WorkflowRunQueueRecord["status"];
+  };
+
+  const continueAcceptedHumanDecision = async (
+    ctx: ExtensionContext,
+    options: {
+      parentRunId: string;
+      workflowRef: string;
+      input: unknown;
+      request: HumanDecisionRequest;
+      resolved: ResolvedHumanDecision;
+      quiet: boolean;
+    },
+  ): Promise<HumanDecisionContinuationOutcome> => {
+    const runId = `continuation-${options.request.decisionId.slice("decision-".length)}`;
+    const launch = await prepareRunLaunch(ctx, options.workflowRef, options.input, {
+      parentRunId: options.parentRunId,
+      humanDecision: options.resolved,
+      runId,
+      quiet: options.quiet,
+    });
+    const queue = ensureRunQueueStore(ctx.cwd);
+    const claimToken = randomUUID();
+    const preparation = queue.prepareOrAdoptWorkflowRun({
+      runId,
+      workflowName: launch.workflow.name,
+      workflowSourceRef:
+        launch.workflowSource.kind === "builtin"
+          ? `builtin:${launch.workflowSource.id}`
+          : launch.workflowSource.path,
+      workflowSource: launchSourceIdentity(launch.workflow, launch.workflowSource),
+      definitionDigest: definitionDigest(launch.snapshot),
+      definitionSnapshot: launch.snapshot,
+      input: launch.input,
+      launchOptions: preparedLaunchOptions(launch.options),
+      runnerId,
+      claimToken,
+      leaseMs: RUN_CLAIM_LEASE_MS,
+      originSessionId: ctx.sessionManager.getSessionId(),
+      parentRunId: options.parentRunId,
+    });
+
+    let started = false;
+    if (preparation.state === "claimed") {
+      recordRunEvent({
+        runId,
+        workflowRef: options.workflowRef,
+        type: "queued",
+        payload: { parentRunId: options.parentRunId },
+      });
+      const claimedLaunch = {
+        ...launch,
+        options: { ...launch.options, claimToken: preparation.run.claimToken },
+      };
+      const generation = beginRunStart(ctx, claimedLaunch.options);
+      const startedRunId =
+        generation === undefined
+          ? undefined
+          : await startPreparedRun(ctx, claimedLaunch, generation);
+      if (startedRunId === undefined) {
+        queue.parkWorkflowRun({ runId, claimToken: preparation.run.claimToken });
+      } else {
+        started = true;
+      }
+    } else {
+      const bundle = readWorkflowRun(runId);
+      if (
+        ["done", "failed", "cancelled"].includes(preparation.run.status) &&
+        (bundle === null || bundle.state.status === "running")
+      ) {
+        throw new Error(`Workflow continuation ${runId} has inconsistent durable state`);
+      }
+    }
+
+    const continuation = {
+      schema: "pi-workflows.human-decision-continuation.v1" as const,
+      decisionId: options.request.decisionId,
+      requestDigest: options.request.requestDigest,
+      provenance: options.resolved.provenance,
+      parentRunId: options.parentRunId,
+      runId,
+      createdAt: options.resolved.acceptedAt,
+    };
+    const decisionStore = humanDecisionStore(ctx.cwd);
+    await decisionStore.recordContinuation(options.request.decisionId, continuation);
+    decisionStore.markEffectApplied(options.request.decisionId, "decision.continue");
+    await settleHumanDecisionChannels(options.resolved);
+    decisionStore.markEffectApplied(options.request.decisionId, "decision.settle_presentations");
+    return { runId, started, queueStatus: preparation.run.status };
+  };
+
   const answerWorkflowControl = async (
     ctx: ExtensionContext,
     input: unknown,
@@ -2755,7 +2892,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
     const request = humanDecisionRequest(parent.state.finalOutput);
     let accepted: AcceptedHumanDecision | undefined;
     let continuationInput = input;
-    let continuationRunId: string | undefined;
     if (request !== null) {
       if (
         verified !== undefined &&
@@ -2783,7 +2919,6 @@ export default function piWorkflows(pi: ExtensionAPI) {
       }
       accepted = acceptance.decision;
       continuationInput = parent.state.input;
-      continuationRunId = `continuation-${request.decisionId.slice("decision-".length)}`;
     }
     if (request !== null && accepted !== undefined && verified !== undefined) {
       const queueRecord = ensureRunQueueStore(ctx.cwd).getWorkflowRun(waiting.parentRunId);
@@ -2804,44 +2939,41 @@ export default function piWorkflows(pi: ExtensionAPI) {
         };
       }
     }
-    const decisionStore = humanDecisionStore(ctx.cwd);
-    if (continuationRunId !== undefined) {
-      const existingContinuation = readWorkflowRun(continuationRunId);
-      if (existingContinuation !== null) {
-        if (accepted !== undefined) await settleHumanDecisionChannels(accepted);
-        lastWaitingRunId = null;
-        return {
-          message: `Human decision already continued as ${continuationRunId}.`,
-          details: {
-            action: "answer",
-            parentRunId: waiting.parentRunId,
-            runId: continuationRunId,
-            adopted: true,
-          },
-        };
-      }
+    if (request !== null && accepted !== undefined) {
+      const outcome = await continueAcceptedHumanDecision(ctx, {
+        parentRunId: waiting.parentRunId,
+        workflowRef: waiting.workflowRef,
+        input: continuationInput,
+        request,
+        resolved: accepted,
+        quiet: false,
+      });
+      lastWaitingRunId = null;
+      return outcome.started
+        ? {
+            message: `Answered checkpoint ${waiting.parentRunId}; continuation ${outcome.runId} started.`,
+            details: {
+              action: "answer",
+              parentRunId: waiting.parentRunId,
+              runId: outcome.runId,
+            },
+          }
+        : {
+            message: `Human decision already continuing as ${outcome.runId}.`,
+            details: {
+              action: "answer",
+              parentRunId: waiting.parentRunId,
+              runId: outcome.runId,
+              adopted: true,
+              status: outcome.queueStatus,
+            },
+          };
     }
     const continued = await startRun(ctx, waiting.workflowRef, continuationInput, {
       parentRunId: waiting.parentRunId,
-      ...(accepted !== undefined ? { humanDecision: accepted } : {}),
-      ...(continuationRunId !== undefined ? { runId: continuationRunId } : {}),
     });
     if (continued === undefined) {
       throw new Error("Could not start the checkpoint continuation.");
-    }
-    if (request !== null && accepted !== undefined) {
-      await decisionStore.recordContinuation(request.decisionId, {
-        schema: "pi-workflows.human-decision-continuation.v1",
-        decisionId: request.decisionId,
-        requestDigest: request.requestDigest,
-        provenance: accepted.provenance,
-        parentRunId: waiting.parentRunId,
-        runId: continued,
-        createdAt: accepted.acceptedAt,
-      });
-      decisionStore.markEffectApplied(request.decisionId, "decision.continue");
-      await settleHumanDecisionChannels(accepted);
-      decisionStore.markEffectApplied(request.decisionId, "decision.settle_presentations");
     }
     lastWaitingRunId = null;
     return {
@@ -2929,14 +3061,40 @@ export default function piWorkflows(pi: ExtensionAPI) {
       ) {
         continue;
       }
-      const queueRecord = ensureRunQueueStore(ctx.cwd).getWorkflowRun(request.runId);
+      const recoveryQueue = ensureRunQueueStore(ctx.cwd);
+      const queueRecord = recoveryQueue.getWorkflowRun(request.runId);
       const ownedBySession =
         queueRecord !== undefined &&
         (queueRecord.originSessionId === null ||
           queueRecord.originSessionId === ctx.sessionManager.getSessionId());
       if (!ownedBySession) continue;
+      if (
+        queueRecord.status === "done" &&
+        (await store.readContinuation(request.decisionId)) !== null
+      ) {
+        continue;
+      }
+
+      let resolved = await store.readResolved(request.decisionId);
+      if (resolved !== null) {
+        if (parent.state.workflowSource === undefined) continue;
+        const workflowRef =
+          parent.state.workflowSource.kind === "builtin"
+            ? `builtin:${parent.state.workflowSource.id}`
+            : parent.state.workflowSource.path;
+        await continueAcceptedHumanDecision(ctx, {
+          parentRunId: request.runId,
+          workflowRef,
+          input: parent.state.input,
+          request,
+          resolved,
+          quiet: true,
+        });
+        if (activeRun !== null) break;
+        continue;
+      }
+
       const recoveryToken = randomUUID();
-      const recoveryQueue = ensureRunQueueStore(ctx.cwd);
       const claimed = recoveryQueue.claimWorkflowRun({
         runId: request.runId,
         runnerId: ctx.sessionManager.getSessionId(),
@@ -2947,97 +3105,73 @@ export default function piWorkflows(pi: ExtensionAPI) {
       const ownerStore = humanDecisionStore(ctx.cwd, () =>
         recoveryQueue.workflowRunAuthority(request.runId, recoveryToken),
       );
-      let resolved = await store.readResolved(request.decisionId);
+      resolved = await store.readResolved(request.decisionId);
+      let cancellation = await store.readCancellation(request.decisionId);
+      const expired =
+        request.expiresAt !== undefined && Date.parse(request.expiresAt) <= Date.now();
+      if (resolved === null && cancellation === null && expired) {
+        if (request.defaultResponse === undefined) {
+          await ownerStore.cancel(request, "expired");
+          cancellation = await ownerStore.readCancellation(request.decisionId);
+        } else {
+          try {
+            resolved = (await ownerStore.resolveTimeout(request)).decision;
+          } catch {
+            cancellation = await store.readCancellation(request.decisionId);
+            resolved = await store.readResolved(request.decisionId);
+          }
+        }
+      }
+      if (cancellation !== null) {
+        recoveryQueue.completeWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
+        ownerStore.markEffectApplied(request.decisionId, "decision.cancel_parent");
+        await settleHumanDecisionChannels(cancellation);
+        ownerStore.markEffectApplied(request.decisionId, "decision.settle_presentations");
+        ownerStore.close();
+        continue;
+      }
       if (resolved === null) {
-        let cancellation = await store.readCancellation(request.decisionId);
-        const expired =
-          request.expiresAt !== undefined && Date.parse(request.expiresAt) <= Date.now();
-        if (cancellation === null && expired) {
-          if (request.defaultResponse === undefined) {
-            await ownerStore.cancel(request, "expired");
-            cancellation = await ownerStore.readCancellation(request.decisionId);
-          } else {
-            try {
-              resolved = (await ownerStore.resolveTimeout(request)).decision;
-            } catch {
-              cancellation = await store.readCancellation(request.decisionId);
-              resolved = await store.readResolved(request.decisionId);
-            }
-          }
-        }
-        if (cancellation !== null) {
-          recoveryQueue.completeWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
-          ownerStore.markEffectApplied(request.decisionId, "decision.cancel_parent");
-          await settleHumanDecisionChannels(cancellation);
-          ownerStore.markEffectApplied(request.decisionId, "decision.settle_presentations");
-          ownerStore.close();
-          continue;
-        }
-        if (resolved === null) {
-          if (!deliverPending) {
-            recoveryQueue.parkWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
-            ownerStore.close();
-            continue;
-          }
-          const channels = audienceChannels(decisionChannelConfig, request.audience);
-          for (const channelId of channels) {
-            const channel = telegramDecisionChannels.get(channelId);
-            if (channel !== undefined) await channel.deliver(humanDecisionChannelRequest(request));
-          }
-          if (ctx.mode === "tui" && channels.includes("pi") && lastWaitingRunId === null) {
-            lastWaitingRunId = request.runId;
-            queueMicrotask(() => void promptHumanDecision(ctx, request));
-          }
+        if (!deliverPending) {
           recoveryQueue.parkWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
           ownerStore.close();
           continue;
         }
-      }
-
-      const currentParent = runStore.readRun(request.runId);
-      if (currentParent === null || currentParent.state.status !== "waiting") {
+        const channels = audienceChannels(decisionChannelConfig, request.audience);
+        for (const channelId of channels) {
+          const channel = telegramDecisionChannels.get(channelId);
+          if (channel !== undefined) await channel.deliver(humanDecisionChannelRequest(request));
+        }
+        if (ctx.mode === "tui" && channels.includes("pi") && lastWaitingRunId === null) {
+          lastWaitingRunId = request.runId;
+          queueMicrotask(() => void promptHumanDecision(ctx, request));
+        }
         recoveryQueue.parkWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
         ownerStore.close();
         continue;
       }
-      const runId = `continuation-${request.decisionId.slice("decision-".length)}`;
-      const continuation = (await store.readContinuation(request.decisionId)) ?? {
-        schema: "pi-workflows.human-decision-continuation.v1" as const,
-        decisionId: request.decisionId,
-        requestDigest: request.requestDigest,
-        provenance: resolved.provenance,
-        parentRunId: request.runId,
-        runId,
-        createdAt: resolved.acceptedAt,
-      };
-      recoveryQueue.parkWorkflowRun({
-        runId: request.runId,
-        claimToken: recoveryToken,
-      });
-      const existing = runStore.readRun(continuation.runId);
-      if (existing === null && activeRun === null) {
-        if (currentParent.state.workflowSource === undefined) {
-          ownerStore.close();
-          continue;
-        }
-        const workflowRef =
-          currentParent.state.workflowSource.kind === "builtin"
-            ? `builtin:${currentParent.state.workflowSource.id}`
-            : currentParent.state.workflowSource.path;
-        await startRun(ctx, workflowRef, currentParent.state.input, {
-          parentRunId: request.runId,
-          humanDecision: resolved,
-          runId: continuation.runId,
-          quiet: true,
-        });
-      }
-      if (runStore.readRun(continuation.runId) !== null) {
-        await ownerStore.recordContinuation(request.decisionId, continuation);
-        ownerStore.markEffectApplied(request.decisionId, "decision.continue");
-      }
-      await settleHumanDecisionChannels(resolved);
-      ownerStore.markEffectApplied(request.decisionId, "decision.settle_presentations");
+
+      const currentParent = runStore.readRun(request.runId);
+      recoveryQueue.parkWorkflowRun({ runId: request.runId, claimToken: recoveryToken });
       ownerStore.close();
+      if (
+        currentParent === null ||
+        currentParent.state.status !== "waiting" ||
+        currentParent.state.workflowSource === undefined
+      ) {
+        continue;
+      }
+      const workflowRef =
+        currentParent.state.workflowSource.kind === "builtin"
+          ? `builtin:${currentParent.state.workflowSource.id}`
+          : currentParent.state.workflowSource.path;
+      await continueAcceptedHumanDecision(ctx, {
+        parentRunId: request.runId,
+        workflowRef,
+        input: currentParent.state.input,
+        request,
+        resolved,
+        quiet: true,
+      });
       if (activeRun !== null) break;
     }
   };

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -2848,9 +2848,10 @@ export default function piWorkflows(pi: ExtensionAPI) {
         generation === undefined
           ? undefined
           : await startPreparedRun(ctx, claimedLaunch, generation);
-      if (startedRunId === undefined) {
-        queue.parkWorkflowRun({ runId, claimToken: preparation.run.claimToken });
-      } else {
+      // A temporary active-run or presentation guard must not park this
+      // continuation. Keep it prepared so normal activation recovery starts it
+      // as soon as the session is idle.
+      if (startedRunId !== undefined) {
         started = true;
       }
     } else {

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -320,6 +320,41 @@ export default defineWorkflow({
 });
 `;
 
+const HUMAN_DECISION_RACE_E2E_WORKFLOW = `import fs from "node:fs/promises";
+import path from "node:path";
+import { choice, compute, defineHumanChoices, defineWorkflow, humanDecision, humanDecisionEdge } from "@osolmaz/pi-workflows";
+
+const barrierDir = process.env.PI_WORKFLOWS_E2E_RACE_DIR;
+if (barrierDir === undefined) throw new Error("PI_WORKFLOWS_E2E_RACE_DIR is required");
+const enteredPath = path.join(barrierDir, "human-decision-race-loads");
+const releasePath = path.join(barrierDir, "human-decision-race-release");
+let previousLoads = "";
+try { previousLoads = await fs.readFile(enteredPath, "utf8"); } catch {}
+await fs.appendFile(enteredPath, "load\\n");
+if (previousLoads.length > 0) {
+  for (;;) {
+    try { await fs.access(releasePath); break; }
+    catch { await new Promise((resolve) => setTimeout(resolve, 10)); }
+  }
+}
+
+const choices = defineHumanChoices({ continue: choice({ label: "Continue" }) });
+
+export default defineWorkflow({
+  name: "human-decision-race-e2e",
+  startAt: "approve",
+  nodes: {
+    approve: humanDecision({
+      audience: "operator",
+      choices,
+      request: ({ input }) => ({ title: "Approve", subject: input, presentation: { schema: "pi-workflows.decision-presentation.v1", summary: "Review this decision.", blocks: [] } }),
+    }),
+    continued: compute({ run: ({ input, outputs }) => ({ input, answer: outputs.approve }) }),
+  },
+  edges: [humanDecisionEdge({ from: "approve", choices, cases: { continue: "continued" } })],
+});
+`;
+
 const HUMAN_TIMEOUT_E2E_WORKFLOW = `import { choice, compute, defineHumanChoices, defineWorkflow, humanDecision, humanDecisionEdge } from "@osolmaz/pi-workflows";
 
 const choices = defineHumanChoices({ continue: choice({ label: "Continue" }) });
@@ -1249,6 +1284,11 @@ describe.sequential("pi-workflows end to end", () => {
       "utf8",
     );
     await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "human-decision-race-e2e.workflow.ts"),
+      HUMAN_DECISION_RACE_E2E_WORKFLOW,
+      "utf8",
+    );
+    await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "composed-child.workflow.ts"),
       COMPOSED_CHILD_WORKFLOW,
       "utf8",
@@ -1376,6 +1416,7 @@ describe.sequential("pi-workflows end to end", () => {
         PI_CODING_AGENT_DIR: agentDir,
         PI_AGENT_FIXTURE_BASE_URL: mock.baseUrl,
         PI_AGENT_FIXTURE_API_KEY: "e2e-provider-key",
+        PI_WORKFLOWS_E2E_RACE_DIR: agentDir,
         PATH: `${commandDir}:${process.env.PATH ?? ""}`,
       },
     });
@@ -2141,6 +2182,86 @@ describe.sequential("pi-workflows end to end", () => {
     );
     await waitForPiIdle(pi);
   });
+
+  it("starts one continuation when a direct answer races recovery", async () => {
+    const outputOffset = pi.stdoutLines.length;
+    pi.send({
+      id: "human-decision-race-1",
+      type: "prompt",
+      message: '/workflow human-decision-race-e2e --input-json {"original":true}',
+    });
+    const waiting = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "human-decision-race-e2e" && candidate.status === "waiting",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+      20_000,
+    );
+    pi.send({
+      id: "human-decision-race-2",
+      type: "prompt",
+      message: `/workflow answer ${waiting.state.runId} {"choice":"continue"}`,
+    });
+    const enteredPath = path.join(agentDir, "human-decision-race-loads");
+    await waitForCondition(
+      async () => {
+        const loads = await fs.readFile(enteredPath, "utf8").catch(() => "");
+        return loads.trim().split("\n").length >= 3;
+      },
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+      20_000,
+    );
+    await fs.writeFile(path.join(agentDir, "human-decision-race-release"), "release\n", "utf8");
+    const continued = await waitForRunState(
+      runsDir,
+      (candidate) =>
+        candidate.workflowName === "human-decision-race-e2e" &&
+        candidate.parentRunId === waiting.state.runId &&
+        candidate.status === "completed",
+      () => `${pi.stderr()}\n${pi.stdoutLines.slice(-20).join("\n")}`,
+      20_000,
+    );
+    await waitForPiIdle(pi);
+
+    const continuations = listWorkflowRuns({ databasePath: runsDir }).filter(
+      (bundle) => bundle.state.parentRunId === waiting.state.runId,
+    );
+    expect(continuations).toHaveLength(1);
+    expect(continued.state.steps.map((step) => step.nodeId)).toEqual(["approve", "continued"]);
+
+    const queue = new SqliteControllerStore(runsDir, { projectPath: projectDir });
+    expect(queue.getWorkflowRun(continued.state.runId)?.status).toBe("done");
+    expect(
+      queue.state.connection
+        .prepare(
+          `SELECT l.generation AS generation FROM leases l
+           JOIN runs r ON r.resource_id = l.resource_id WHERE r.run_id = ?`,
+        )
+        .get(continued.state.runId),
+    ).toEqual({ generation: 1 });
+    expect(
+      queue.state.connection
+        .prepare(
+          `SELECT count(*) AS starts FROM events e
+           JOIN runs r ON r.resource_id = e.resource_id
+           WHERE r.run_id = ? AND e.event_type = 'run_started'`,
+        )
+        .get(continued.state.runId),
+    ).toEqual({ starts: 1 });
+    expect(
+      queue.state.connection
+        .prepare(
+          `SELECT count(*) AS failures FROM events e
+           JOIN runs r ON r.resource_id = e.resource_id
+           WHERE r.run_id = ? AND e.event_type = 'failed'`,
+        )
+        .get(continued.state.runId),
+    ).toEqual({ failures: 0 });
+    queue.close();
+    expect(pi.stdoutLines.slice(outputOffset).join("\n")).not.toMatch(
+      /already exists|revision conflict|crashed/iu,
+    );
+  }, 30_000);
 
   it("continues a timed human decision through the real Pi recovery loop", async () => {
     pi.send({

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/extension/deferred-turn.js";
 import piWorkflows from "../src/extension/index.js";
 import type { WorkflowToolInput } from "../src/extension/workflow-tool.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
 import { createHumanDecisionRequest, HumanDecisionStore } from "../src/workflows/human-decision.js";
 import {
   listWorkflowRuns,
@@ -462,12 +463,30 @@ export default defineWorkflow({
   );
 }
 
-async function writeHumanDecisionWorkflow(cwd: string, timeoutMs?: number): Promise<void> {
+async function writeHumanDecisionWorkflow(
+  cwd: string,
+  timeoutMs?: number,
+  loadBarrier?: { enteredPath: string; releasePath: string },
+): Promise<void> {
   const dir = path.join(cwd, ".pi", "workflows");
   await fs.mkdir(dir, { recursive: true });
+  const barrierSource =
+    loadBarrier === undefined
+      ? ""
+      : `import fs from "node:fs/promises";
+let previousLoads = "";
+try { previousLoads = await fs.readFile(${JSON.stringify(loadBarrier.enteredPath)}, "utf8"); } catch {}
+await fs.appendFile(${JSON.stringify(loadBarrier.enteredPath)}, "load\\n");
+if (previousLoads.length > 0) {
+  for (;;) {
+    try { await fs.access(${JSON.stringify(loadBarrier.releasePath)}); break; }
+    catch { await new Promise((resolve) => setTimeout(resolve, 10)); }
+  }
+}`;
   await fs.writeFile(
     path.join(dir, "human.workflow.ts"),
     `import { choice, compute, defineHumanChoices, defineWorkflow, humanDecision, humanDecisionEdge, textInput } from "@osolmaz/pi-workflows";
+${barrierSource}
 const choices = defineHumanChoices({
   continue: choice({ label: "Continue" }),
   replan: choice({ label: "Replan", input: textInput({ name: "instructions", prompt: "What should change?" }) }),
@@ -749,6 +768,93 @@ describe("pi-workflows extension", () => {
       answer: { choice: "replan", input: { instructions: exact } },
     });
     expect(JSON.stringify(completed?.state.finalOutput)).not.toContain("actorId");
+  });
+
+  it("adopts one continuation when a direct answer races recovery", async () => {
+    const cwd = await makeTempDir("pi-workflows-human-race");
+    const runsDir = await makeTempDir("pi-workflows-human-race-runs");
+    vi.stubEnv("HOME", runsDir);
+    const enteredPath = path.join(cwd, ".pi", "human-decision-race-loads");
+    const releasePath = path.join(cwd, ".pi", "human-decision-race-release");
+    await writeHumanDecisionWorkflow(cwd, undefined, { enteredPath, releasePath });
+    const continueRun = vi.spyOn(WorkflowEngine.prototype, "continueRun");
+    const harness = makeHarness({
+      cwd,
+      respond: () => {},
+      select: async () => "Continue",
+    });
+
+    try {
+      await harness.emitAsync("session_start", {});
+      await harness.command.handler(
+        'human --input-json {"task":"approve","original":true}',
+        harness.ctx,
+      );
+      await waitFor(async () => {
+        const loads = await fs.readFile(enteredPath, "utf8").catch(() => "");
+        return loads.trim().split("\n").length >= 3;
+      }, 20_000);
+      await fs.writeFile(releasePath, "release\n", "utf8");
+      await waitFor(
+        async () =>
+          (await listWorkflowRuns({ databasePath: workflowStateDatabasePath(runsDir) })).some(
+            (bundle) =>
+              bundle.state.parentRunId !== undefined && bundle.state.status === "completed",
+          ),
+        20_000,
+      );
+
+      const bundles = await listWorkflowRuns({
+        databasePath: workflowStateDatabasePath(runsDir),
+      });
+      const parent = bundles.find((bundle) => bundle.state.status === "waiting");
+      const continuations = bundles.filter(
+        (bundle) => bundle.state.parentRunId === parent?.state.runId,
+      );
+      expect(continuations).toHaveLength(1);
+      expect(continuations[0]?.state.steps.map((step) => step.nodeId)).toEqual([
+        "approve",
+        "continued",
+      ]);
+      expect(continueRun).toHaveBeenCalledTimes(1);
+      const request = parent?.state.finalOutput as HumanDecisionRequest | undefined;
+      if (request === undefined) throw new Error("missing race decision request");
+      const decisions = new HumanDecisionStore(workflowStateDatabasePath(runsDir));
+      await waitFor(async () => (await decisions.readContinuation(request.decisionId)) !== null);
+      const loadsAtCompletion = await fs.readFile(enteredPath, "utf8");
+      await new Promise((resolve) => setTimeout(resolve, 1_200));
+      expect(await fs.readFile(enteredPath, "utf8")).toBe(loadsAtCompletion);
+
+      const queue = new SqliteControllerStore(workflowStateDatabasePath(runsDir), {
+        projectPath: cwd,
+      });
+      const continuationId = continuations[0]?.state.runId ?? "";
+      expect(queue.getWorkflowRun(continuationId)?.status).toBe("done");
+      expect(
+        queue.state.connection
+          .prepare(
+            `SELECT l.generation AS generation FROM leases l
+             JOIN runs r ON r.resource_id = l.resource_id WHERE r.run_id = ?`,
+          )
+          .get(continuationId),
+      ).toEqual({ generation: 1 });
+      expect(
+        queue.state.connection
+          .prepare(
+            `SELECT count(*) AS count FROM events e
+             JOIN runs r ON r.resource_id = e.resource_id
+             WHERE r.run_id = ? AND e.event_type = 'failed'`,
+          )
+          .get(continuationId),
+      ).toEqual({ count: 0 });
+      queue.close();
+      expect(harness.notifications.join("\n")).not.toMatch(
+        /already exists|revision conflict|crashed/iu,
+      );
+    } finally {
+      continueRun.mockRestore();
+      await harness.emitAsync("session_shutdown", {});
+    }
   });
 
   it("cancels a pending human decision and rejects later acceptance", async () => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -467,6 +467,7 @@ async function writeHumanDecisionWorkflow(
   cwd: string,
   timeoutMs?: number,
   loadBarrier?: { enteredPath: string; releasePath: string },
+  presentationPrompt?: string,
 ): Promise<void> {
   const dir = path.join(cwd, ".pi", "workflows");
   await fs.mkdir(dir, { recursive: true });
@@ -493,6 +494,7 @@ const choices = defineHumanChoices({
 });
 export default defineWorkflow({
   name: "human",
+  ${presentationPrompt === undefined ? "" : `presentationPrompt: () => ${JSON.stringify(presentationPrompt)},`}
   startAt: "approve",
   nodes: {
     approve: humanDecision({ audience: "operator", choices, request: ({ input }) => ({ title: "Approve", subject: input, presentation: { schema: "pi-workflows.decision-presentation.v1", summary: "Review this decision.", blocks: [] } }), ${timeoutMs === undefined ? "" : `onTimeout: { afterMs: ${timeoutMs}, response: { choice: "continue" } },`} }),
@@ -851,6 +853,57 @@ describe("pi-workflows extension", () => {
       expect(harness.notifications.join("\n")).not.toMatch(
         /already exists|revision conflict|crashed/iu,
       );
+    } finally {
+      continueRun.mockRestore();
+      await harness.emitAsync("session_shutdown", {});
+    }
+  });
+
+  it("activates a claimed continuation after a pending presentation settles", async () => {
+    const cwd = await makeTempDir("pi-workflows-human-presentation");
+    const runsDir = await makeTempDir("pi-workflows-human-presentation-runs");
+    vi.stubEnv("HOME", runsDir);
+    await writeHumanDecisionWorkflow(cwd, undefined, undefined, "Present the decision.");
+    const continueRun = vi.spyOn(WorkflowEngine.prototype, "continueRun");
+    const harness = makeHarness({
+      cwd,
+      respond: () => {},
+      select: async () => "Continue",
+    });
+
+    try {
+      await harness.emitAsync("session_start", {});
+      await harness.command.handler("human", harness.ctx);
+      await waitFor(async () => {
+        const bundles = await listWorkflowRuns({
+          databasePath: workflowStateDatabasePath(runsDir),
+        });
+        const parent = bundles.find((bundle) => bundle.state.status === "waiting");
+        if (parent === undefined) return false;
+        const continuation = bundles.find(
+          (bundle) => bundle.state.parentRunId === parent.state.runId,
+        );
+        if (continuation === undefined) return false;
+        const queue = new SqliteControllerStore(workflowStateDatabasePath(runsDir), {
+          projectPath: cwd,
+        });
+        try {
+          return queue.getWorkflowRun(continuation.state.runId)?.status === "starting";
+        } finally {
+          queue.close();
+        }
+      });
+
+      await harness.emitAsync("agent_settled", {});
+      await waitFor(async () => {
+        const bundles = await listWorkflowRuns({
+          databasePath: workflowStateDatabasePath(runsDir),
+        });
+        return bundles.some(
+          (bundle) => bundle.state.parentRunId !== undefined && bundle.state.status === "completed",
+        );
+      });
+      expect(continueRun).toHaveBeenCalledTimes(1);
     } finally {
       continueRun.mockRestore();
       await harness.emitAsync("session_shutdown", {});

--- a/test/run-queue.test.ts
+++ b/test/run-queue.test.ts
@@ -36,6 +36,24 @@ function reserve(store: SqliteControllerStore, runId = "run-1") {
   });
 }
 
+function continuationPreparation() {
+  return {
+    runId: "continuation-1",
+    workflowName: "echo",
+    workflowSourceRef: "builtin:echo",
+    workflowSource: { kind: "builtin" as const, id: "echo", revision: "test" },
+    definitionDigest,
+    definitionSnapshot: snapshot,
+    input: { task: "hello" },
+    launchOptions: { parentRunId: "parent-1" },
+    runnerId: "runner-1",
+    claimToken: "winner-token",
+    leaseMs: 30_000,
+    originSessionId: "session-1",
+    parentRunId: "parent-1",
+  };
+}
+
 describe("workflow run queue in canonical SQLite", () => {
   it("reserves one run with its definition, input, binding, and queue row", async () => {
     const { store } = await setup();
@@ -62,6 +80,124 @@ describe("workflow run queue in canonical SQLite", () => {
     expect(store.state.connection.prepare("SELECT count(*) AS count FROM run_queue").get()).toEqual(
       { count: 1 },
     );
+    store.close();
+  });
+
+  it("atomically prepares or adopts one compatible continuation", async () => {
+    const { store } = await setup();
+    reserve(store, "parent-1");
+    const parentClaim = store.claimWorkflowRun({
+      runId: "parent-1",
+      runnerId: "runner-1",
+      claimToken: "parent-token",
+      leaseMs: 30_000,
+    });
+    expect(parentClaim).toBeDefined();
+    expect(store.parkWorkflowRun({ runId: "parent-1", claimToken: "parent-token" })).toBe(true);
+
+    const options = continuationPreparation();
+    const first = store.prepareOrAdoptWorkflowRun(options);
+    expect(first).toMatchObject({
+      state: "claimed",
+      run: {
+        runId: "continuation-1",
+        status: "starting",
+        claimToken: "winner-token",
+        claimGeneration: 1,
+      },
+    });
+    const before = store.getWorkflowRun("continuation-1");
+    const revisionBefore = store.state.connection
+      .prepare("SELECT revision FROM resources WHERE aggregate_key = ?")
+      .get("continuation-1");
+    const eventsBefore = store.state.connection
+      .prepare(
+        `SELECT count(*) AS count FROM events e
+         JOIN runs r ON r.resource_id = e.resource_id WHERE r.run_id = ?`,
+      )
+      .get("continuation-1");
+
+    const adopted = store.prepareOrAdoptWorkflowRun({ ...options, claimToken: "loser-token" });
+    expect(adopted).toMatchObject({
+      state: "adopted",
+      run: {
+        runId: "continuation-1",
+        status: "starting",
+        claimToken: null,
+        claimGeneration: 1,
+      },
+    });
+    expect(store.getWorkflowRun("continuation-1")).toEqual(before);
+    expect(
+      store.state.connection
+        .prepare("SELECT revision FROM resources WHERE aggregate_key = ?")
+        .get("continuation-1"),
+    ).toEqual(revisionBefore);
+    expect(
+      store.state.connection
+        .prepare(
+          `SELECT count(*) AS count FROM events e
+           JOIN runs r ON r.resource_id = e.resource_id WHERE r.run_id = ?`,
+        )
+        .get("continuation-1"),
+    ).toEqual(eventsBefore);
+    expect(
+      store.verifyWorkflowRunClaim({ runId: "continuation-1", claimToken: "winner-token" }),
+    ).toBe(true);
+    expect(
+      store.verifyWorkflowRunClaim({ runId: "continuation-1", claimToken: "loser-token" }),
+    ).toBe(false);
+    expect(
+      store.renewWorkflowRunClaim({
+        runId: "continuation-1",
+        claimToken: "loser-token",
+        leaseMs: 30_000,
+      }),
+    ).toBe(false);
+    expect(store.parkWorkflowRun({ runId: "continuation-1", claimToken: "loser-token" })).toBe(
+      false,
+    );
+    expect(store.completeWorkflowRun({ runId: "continuation-1", claimToken: "loser-token" })).toBe(
+      false,
+    );
+    expect(store.getWorkflowRun("continuation-1")).toEqual(before);
+    store.close();
+  });
+
+  it("rejects incompatible continuation adoption without mutation", async () => {
+    const { store } = await setup();
+    reserve(store, "parent-1");
+    const parent = store.claimWorkflowRun({
+      runId: "parent-1",
+      runnerId: "runner-1",
+      claimToken: "parent-token",
+      leaseMs: 30_000,
+    });
+    expect(parent).toBeDefined();
+    expect(store.parkWorkflowRun({ runId: "parent-1", claimToken: "parent-token" })).toBe(true);
+    const options = continuationPreparation();
+    store.prepareOrAdoptWorkflowRun(options);
+    const before = store.getWorkflowRun("continuation-1");
+    const conflicts = [
+      { workflowName: "other" },
+      { workflowSourceRef: "builtin:other" },
+      { workflowSource: { kind: "builtin" as const, id: "echo", revision: "other" } },
+      { definitionDigest: "0".repeat(64) },
+      { input: { task: "other" } },
+      { launchOptions: { parentRunId: "other" } },
+      { originSessionId: "session-2" },
+      { parentRunId: "parent-2" },
+    ];
+    for (const conflict of conflicts) {
+      expect(() =>
+        store.prepareOrAdoptWorkflowRun({
+          ...options,
+          ...conflict,
+          claimToken: "loser-token",
+        }),
+      ).toThrow(/preparation conflicts/);
+      expect(store.getWorkflowRun("continuation-1")).toEqual(before);
+    }
     store.close();
   });
 


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A verified human answer and periodic recovery could start the same workflow continuation at the same time.
The second start could replace the first lease, report a false crash, and leave the durable run and queue out of sync.
This change gives the deterministic continuation one atomic queue claim, so one path starts it and every compatible repeat adopts it.

## What Changed

Direct answers and recovery now use the same continuation coordinator.
Only the path that creates and claims the queue row can start the workflow engine.

- Added an atomic SQLite prepare-or-adopt operation for deterministic continuation launches.
- Made compatible adoption read-only for the queue row, lease, generation, timestamps, and events.
- Rejected incompatible workflow source, definition, input, launch options, parent, or session identity without mutation.
- Kept ordinary queue claims, legacy checkpoints, terminal restart, and public Pi extension APIs unchanged.
- Stopped recovery from reprocessing a completed, recorded continuation.
- Updated the canonical human-decision specification and implementation plan.

## Testing

The focused race tests prove one claim generation, one engine start, one continuation, and one execution of each continuation node.
The full repository and real-Pi suites also pass on the current `main` base.

- `npx vitest run test/run-queue.test.ts test/extension.test.ts`
- `npx vitest run --config vitest.e2e.config.ts test/e2e/workflow.e2e.test.ts -t "starts one continuation when a direct answer races recovery"`
- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`

## Risks

The change is limited to verified human-decision continuation startup.
It uses the existing queue, lease, decision, and run records, with no schema or Pi API change.

- A prepared winner that stops still relies on the existing lease-expiry and activation recovery path.
- Incompatible reuse fails clearly instead of changing an existing deterministic launch.
