### PR TITLE
feat(workflows): render deferred turn cards

### DIFF
--- a/docs/DEFERRED_TURNS.md
+++ b/docs/DEFERRED_TURNS.md
@@ -219,9 +219,20 @@ The fallback custom message uses this details object:
   "schema": "pi-workflows.deferred-turn-message.v1",
   "turnIntentId": "deferred-turn:...",
   "runId": "20260821T081731Z-autoimplement-407480dd",
-  "cause": "failed"
+  "cause": "failed",
+  "presentation": {
+    "workflowName": "autoimplement",
+    "state": "failed",
+    "reasonKind": "maxSteps",
+    "restart": {
+      "count": 0,
+      "limit": 3
+    }
+  }
 }
 ```
+
+`presentation` contains small, bounded display fields. `reasonKind` and `restart` are present only when the run records provide them. These fields do not replace or shorten the model prompt.
 
 The message type is `pi-workflows-deferred-turn`. Delivery uses:
 
@@ -232,7 +243,17 @@ The message type is `pi-workflows-deferred-turn`. Delivery uses:
 }
 ```
 
-For a terminal run, the visible content contains the workflow identity and revision, terminal run ID, exact stored input, bounded result, terminal state and reason, restart count, and earlier terminal outcomes in the chain. It tells the model to use the current conversation, prefer a safe restart for an unfinished task after a technical or temporary failure, and stop for completed work, cancellation, missing authority, a required user decision, or a repeated failure. Values from input and result are data, not instructions.
+### Compact TUI card
+
+Interactive Pi registers a custom renderer for `pi-workflows-deferred-turn`. The collapsed card shows the workflow name, state or cause, run identity, and restart count when it is available. It does not show the terminal facts JSON, exact input, result, fingerprint, or model instructions.
+
+The renderer reads only the structured message details for its compact fields. It sanitizes workflow-derived text and uses Pi's standard TUI components, theme colors, and `expanded` state. A message with missing or invalid details renders as a safe generic workflow card.
+
+Expanding the card shows the complete existing message content. The model and session history receive that same content whether the card is collapsed or expanded. Restored messages use the same renderer and do not create another entry or model turn.
+
+This display behavior uses the documented `pi.sendMessage()` and `pi.registerMessageRenderer()` APIs. It does not change headless or RPC delivery. Presentation messages that already use `display: false` stay hidden. It adds no Pi core change, private API, database table, migration, store, or external resource.
+
+For a terminal run, the complete content contains the workflow identity and revision, terminal run ID, exact stored input, bounded result, terminal state and reason, restart count, and earlier terminal outcomes in the chain. It tells the model to use the current conversation, prefer a safe restart for an unfinished task after a technical or temporary failure, and stop for completed work, cancellation, missing authority, a required user decision, or a repeated failure. Values from input and result are data, not instructions.
 
 The content comes only from existing run and queue records. Pi owns conversation history. Pi Workflows does not identify, hash, copy, or store an original user message.
 

--- a/docs/plans/2026-08-27-workflow-terminal-restart-plan.md
+++ b/docs/plans/2026-08-27-workflow-terminal-restart-plan.md
@@ -281,6 +281,45 @@ Document:
 
 No workflow definition needs an opt-in or terminal restart step.
 
+### 9. Render deferred terminal turns as compact cards
+
+**Where**
+
+- `src/extension/deferred-turn.ts`
+- `src/extension/index.ts`
+- Deferred-turn renderer unit tests
+- Real-Pi end-to-end tests
+
+**Change**
+
+Register a custom TUI message renderer for the existing `pi-workflows-deferred-turn` message type through Pi's documented `pi.registerMessageRenderer()` API.
+
+Keep the complete existing message content unchanged. The model and session history must still receive the terminal facts, exact input, bounded result, restart history, and instructions. Do not replace that content with a summary, split it into another entry, or hide the deferred fallback with `display: false`.
+
+Add small, bounded presentation fields to the existing message details. The fields cover the workflow name, terminal state or cause, run identity, terminal reason kind, and restart count and limit when available. The renderer must read those fields directly and must not parse the model prompt.
+
+The collapsed card must show a concise workflow summary. It must not show the terminal facts JSON, exact input, result, fingerprint, or full model instructions. The expanded card must show the complete existing content through Pi's standard `expanded` state, consistent with agent-step message cards.
+
+Use standard Pi TUI components and theme colors. Sanitize all workflow-derived display text. Missing or malformed details must produce a safe generic card instead of an exception.
+
+Keep the behavior workflow-agnostic. Ordinary deferred fallbacks, terminal decisions, and restored messages use the same renderer. Presentation messages that already use `display: false` stay unchanged. Headless and RPC behavior stays unchanged. Rendering must not create a duplicate session entry or model turn.
+
+This change uses only `pi.sendMessage()` and `pi.registerMessageRenderer()`. It adds no Pi core or private API use, database table, migration, store, service, controller, daemon, or external resource.
+
+**Verification**
+
+Focused tests must prove that:
+
+- collapsed output shows bounded workflow, state or cause, run, and restart fields
+- collapsed output omits the full prompt, terminal JSON, input, result, and fingerprint
+- expanded output contains the complete model-facing content
+- completed, failed, timed-out, cancelled, launch-failure, and maxSteps states render correctly
+- long or terminal-unsafe fields are safe
+- missing and malformed details do not throw
+- the renderer registers once for `pi-workflows-deferred-turn`
+- restored messages render without creating another entry or turn
+- real Pi still gives the provider the complete prompt while the session record keeps the custom message type and renderer details
+
 ## Contract changes
 
 - The workflow tool gains `restart`.
@@ -293,6 +332,9 @@ No workflow definition needs an opt-in or terminal restart step.
 - Restart lineage uses existing run launch data.
 - No new store, service, controller, or Pi API is added.
 - No original-message provenance contract is added.
+- The existing deferred-turn message details gain small, bounded presentation fields.
+- The existing deferred-turn message content remains complete and unchanged for the model and session history.
+- Interactive Pi renders deferred turns through the public message-renderer API. Headless and RPC delivery do not change.
 
 ## Test plan
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -714,6 +714,14 @@ The model uses the current Pi conversation to stop, restart safely, start
 Monitor for an authorized external wait, ask for a decision or authority, or
 take another safe authorized action.
 
+Interactive Pi shows a compact card for a factual terminal fallback. The
+collapsed card shows the workflow, state or cause, run identity, and restart
+count when available. It hides the full terminal facts, input, result,
+fingerprint, and model instructions. Expanding the card shows the complete
+model-facing content. The renderer uses structured display fields rather than
+parsing the prompt, so collapsing the card does not change session history,
+model context, replay, or recovery. Headless and RPC behavior stays unchanged.
+
 `presentationPrompt` adds workflow-specific presentation instructions to this
 shared terminal decision message for completed runs. Returning `undefined`,
 returning an empty string, omitting `presentationPrompt`, or ending in failure,

--- a/src/extension/deferred-turn.ts
+++ b/src/extension/deferred-turn.ts
@@ -1,15 +1,26 @@
 import { createHash } from "node:crypto";
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
 import type {
   WorkflowTurnIntentCause,
   WorkflowTurnIntentFacts,
   WorkflowTurnIntentRecord,
   WorkflowTurnIntentResolution,
 } from "../controllers/sqlite.js";
+import {
+  cleanSingleLine,
+  customMessageContentText,
+  paintMessageCard,
+  renderMessageCard,
+  type MessageCardColor,
+  type MessageCardView,
+} from "./message-card.js";
+import type { TerminalDecision, TerminalReason } from "./terminal-decision.js";
 
 export const DEFERRED_TURN_MESSAGE_TYPE = "pi-workflows-deferred-turn";
 export const DEFERRED_TURN_MESSAGE_SCHEMA = "pi-workflows.deferred-turn-message.v1";
 const FACTS_SCHEMA = "pi-workflows.deferred-turn-facts.v1";
 const MAX_REASON_CHARS = 8_192;
+const MAX_PRESENTATION_FIELD_CHARS = 512;
 
 export type DeferredTurnSource = {
   runId: string;
@@ -36,12 +47,30 @@ export type DeferredTurnDescriptor = {
   fallbackFacts: WorkflowTurnIntentFacts;
 };
 
+export type DeferredTurnMessagePresentation = {
+  workflowName: string;
+  state: string;
+  reasonKind?: TerminalReason["kind"];
+  restart?: {
+    count: number;
+    limit: number;
+  };
+};
+
 export type DeferredTurnMessageDetails = {
   schema: typeof DEFERRED_TURN_MESSAGE_SCHEMA;
   turnIntentId: string;
   runId: string;
   cause: WorkflowTurnIntentCause;
+  presentation?: DeferredTurnMessagePresentation;
 };
+
+type DeferredTurnMessage = {
+  content: unknown;
+  details?: unknown;
+};
+
+export type DeferredTurnMessageView = MessageCardView;
 
 export function deferredTurnSourceEventId(options: {
   runId: string;
@@ -107,12 +136,82 @@ export function deferredTurnMessageId(
 
 export function deferredTurnMessageDetails(
   intent: WorkflowTurnIntentRecord,
+  decision?: TerminalDecision | null,
 ): DeferredTurnMessageDetails {
   return {
     schema: DEFERRED_TURN_MESSAGE_SCHEMA,
     turnIntentId: intent.intentId,
     runId: intent.runId,
     cause: intent.cause,
+    presentation: {
+      workflowName: boundedPresentationField(
+        decision?.workflowName ?? intent.fallbackFacts.workflowName,
+      ),
+      state: boundedPresentationField(decision?.state ?? intent.fallbackFacts.observedState),
+      ...(decision === null || decision === undefined
+        ? {}
+        : {
+            reasonKind: decision.reason.kind,
+            restart: { count: decision.restartNumber, limit: decision.restartLimit },
+          }),
+    },
+  };
+}
+
+export function registerDeferredTurnMessageRenderer(pi: ExtensionAPI): void {
+  pi.registerMessageRenderer<DeferredTurnMessageDetails>(
+    DEFERRED_TURN_MESSAGE_TYPE,
+    (message, { expanded }, theme) =>
+      renderMessageCard(buildDeferredTurnMessageView(message, expanded, theme), theme),
+  );
+}
+
+export function buildDeferredTurnMessageView(
+  message: DeferredTurnMessage,
+  expanded: boolean,
+  theme?: Pick<Theme, "fg">,
+): DeferredTurnMessageView {
+  const details = parseMessageDetails(message.details);
+  const presentation = details?.presentation;
+  const workflowName = safeSingleLine(presentation?.workflowName, "Workflow");
+  const outcome =
+    presentation?.reasonKind ?? presentation?.state ?? details?.cause ?? "deferred turn";
+  const appearance = outcomeAppearance(outcome);
+  const title = paintMessageCard(
+    theme,
+    appearance.color,
+    `${appearance.glyph} ${workflowName} · ${outcomeLabel(outcome)}`,
+  );
+  const statusParts = [
+    ...(details === undefined ? [] : [`run ${safeSingleLine(details.runId, "unknown")}`]),
+    ...(presentation?.restart === undefined
+      ? []
+      : [`restart ${presentation.restart.count}/${presentation.restart.limit}`]),
+  ];
+  const status = statusParts.length === 0 ? undefined : statusParts.join(" · ");
+  if (!expanded) {
+    return {
+      title,
+      ...(status === undefined ? {} : { status: paintMessageCard(theme, "dim", status) }),
+    };
+  }
+
+  const metadata = [
+    `Workflow: ${workflowName}`,
+    `Run id: ${details === undefined ? "unknown" : safeSingleLine(details.runId, "unknown")}`,
+    `Cause: ${details === undefined ? "unknown" : outcomeLabel(details.cause)}`,
+    `State: ${presentation === undefined ? "unknown" : outcomeLabel(presentation.state)}`,
+    ...(presentation?.reasonKind === undefined
+      ? []
+      : [`Reason kind: ${outcomeLabel(presentation.reasonKind)}`]),
+    ...(presentation?.restart === undefined
+      ? []
+      : [`Restart: ${presentation.restart.count}/${presentation.restart.limit}`]),
+  ];
+  return {
+    title,
+    ...(status === undefined ? {} : { status: paintMessageCard(theme, "dim", status) }),
+    expandedText: `${metadata.map((line) => paintMessageCard(theme, "dim", line)).join("\n")}\n\n${customMessageContentText(message.content)}`,
   };
 }
 
@@ -152,6 +251,131 @@ export function buildDeferredTurnContent(intent: WorkflowTurnIntentRecord): stri
   ]
     .filter((part) => part.length > 0)
     .join(" ");
+}
+
+function parseMessageDetails(value: unknown): DeferredTurnMessageDetails | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const candidate = value as Partial<DeferredTurnMessageDetails>;
+  if (
+    candidate.schema !== DEFERRED_TURN_MESSAGE_SCHEMA ||
+    typeof candidate.turnIntentId !== "string" ||
+    typeof candidate.runId !== "string" ||
+    !isTurnIntentCause(candidate.cause)
+  ) {
+    return undefined;
+  }
+  const presentation = parsePresentation(candidate.presentation);
+  return {
+    schema: DEFERRED_TURN_MESSAGE_SCHEMA,
+    turnIntentId: candidate.turnIntentId,
+    runId: candidate.runId,
+    cause: candidate.cause,
+    ...(presentation === undefined ? {} : { presentation }),
+  };
+}
+
+function parsePresentation(value: unknown): DeferredTurnMessagePresentation | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const candidate = value as Partial<DeferredTurnMessagePresentation>;
+  if (typeof candidate.workflowName !== "string" || typeof candidate.state !== "string") {
+    return undefined;
+  }
+  if (candidate.reasonKind !== undefined && !isTerminalReasonKind(candidate.reasonKind)) {
+    return undefined;
+  }
+  const restart = parseRestart(candidate.restart);
+  if (candidate.restart !== undefined && restart === undefined) return undefined;
+  return {
+    workflowName: candidate.workflowName,
+    state: candidate.state,
+    ...(candidate.reasonKind === undefined ? {} : { reasonKind: candidate.reasonKind }),
+    ...(restart === undefined ? {} : { restart }),
+  };
+}
+
+function parseRestart(value: unknown): { count: number; limit: number } | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const candidate = value as { count?: unknown; limit?: unknown };
+  if (
+    typeof candidate.count !== "number" ||
+    !Number.isInteger(candidate.count) ||
+    candidate.count < 0 ||
+    typeof candidate.limit !== "number" ||
+    !Number.isInteger(candidate.limit) ||
+    candidate.limit < 0
+  ) {
+    return undefined;
+  }
+  return { count: candidate.count, limit: candidate.limit };
+}
+
+function isTurnIntentCause(value: unknown): value is WorkflowTurnIntentCause {
+  return (
+    typeof value === "string" &&
+    [
+      "agentCancelled",
+      "timedOut",
+      "failed",
+      "launchFailed",
+      "controllerInterrupted",
+      "claimLost",
+      "terminal",
+      "cancelled",
+    ].includes(value)
+  );
+}
+
+function isTerminalReasonKind(value: unknown): value is TerminalReason["kind"] {
+  return (
+    typeof value === "string" &&
+    ["completed", "failed", "timedOut", "maxSteps", "cancelled", "launchFailed"].includes(value)
+  );
+}
+
+function safeSingleLine(value: string | undefined, fallback: string): string {
+  if (value === undefined) return fallback;
+  const clean = cleanSingleLine(value).trim();
+  return clean.length === 0 ? fallback : clean;
+}
+
+function outcomeLabel(value: string): string {
+  const clean = safeSingleLine(value, "unknown");
+  const known: Readonly<Record<string, string>> = {
+    agentCancelled: "agent cancelled",
+    launchFailed: "launch failed",
+    controllerInterrupted: "controller interrupted",
+    claimLost: "claim lost",
+    timedOut: "timed out",
+    timed_out: "timed out",
+    maxSteps: "max steps",
+  };
+  return known[clean] ?? clean.replaceAll("_", " ");
+}
+
+function outcomeAppearance(value: string): { glyph: string; color: MessageCardColor } {
+  switch (value) {
+    case "completed":
+      return { glyph: "✓", color: "success" };
+    case "failed":
+    case "launchFailed":
+    case "maxSteps":
+      return { glyph: "×", color: "error" };
+    case "cancelled":
+    case "agentCancelled":
+    case "timedOut":
+    case "timed_out":
+      return { glyph: "!", color: "warning" };
+    default:
+      return { glyph: "◆", color: "accent" };
+  }
+}
+
+function boundedPresentationField(value: string): string {
+  const clean = cleanSingleLine(value);
+  return clean.length <= MAX_PRESENTATION_FIELD_CHARS
+    ? clean
+    : `${clean.slice(0, MAX_PRESENTATION_FIELD_CHARS - 1)}…`;
 }
 
 function boundedReason(value: string | null | undefined): string | null {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -75,6 +75,7 @@ import {
   deferredTurnMessageDetails,
   deferredTurnMessageId,
   deferredTurnSourceEventId,
+  registerDeferredTurnMessageRenderer,
   type DeferredTurnDescriptor,
 } from "./deferred-turn.js";
 import { ConversationStepExecutor } from "./executor.js";
@@ -546,6 +547,7 @@ type WorkflowWidgetContent = string[] | WorkflowWidgetFactory;
 
 export default function piWorkflows(pi: ExtensionAPI) {
   registerWorkflowAgentStepMessageRenderer(pi);
+  registerDeferredTurnMessageRenderer(pi);
 
   const herdrEnabled = process.env.HERDR_ENV === "1";
   const herdrViewer = new HerdrWorkflowViewer((command, args, options) =>
@@ -692,7 +694,7 @@ export default function piWorkflows(pi: ExtensionAPI) {
                     : buildTerminalDecisionContent(decision),
                 display: true,
                 details: {
-                  ...deferredTurnMessageDetails(intent),
+                  ...deferredTurnMessageDetails(intent, decision),
                   ...(decision === null
                     ? {}
                     : {

--- a/src/extension/message-card.ts
+++ b/src/extension/message-card.ts
@@ -1,0 +1,61 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Box, Text, TruncatedText } from "@earendil-works/pi-tui";
+import { sanitizeText } from "../workflows/text.js";
+
+export type MessageCardView = {
+  title: string;
+  status?: string;
+  expandedText?: string;
+};
+
+export type MessageCardColor = "accent" | "dim" | "error" | "success" | "warning";
+
+export function renderMessageCard(view: MessageCardView, theme: Theme): Box {
+  const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+  box.addChild(new TruncatedText(view.title));
+  if (view.status !== undefined) {
+    box.addChild(new TruncatedText(view.status));
+  }
+  if (view.expandedText !== undefined) {
+    box.addChild(new Text(`\n${view.expandedText}`));
+  }
+  return box;
+}
+
+export function customMessageContentText(content: unknown): string {
+  if (typeof content === "string") return cleanMultiline(content);
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (part === null || typeof part !== "object" || !("text" in part)) return "";
+      const text = (part as { text?: unknown }).text;
+      return typeof text === "string" ? cleanMultiline(text) : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function cleanOptionalSingleLine(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? cleanSingleLine(value) : undefined;
+}
+
+export function cleanSingleLine(value: string): string {
+  return sanitizeText(value);
+}
+
+export function paintMessageCard(
+  theme: Pick<Theme, "fg"> | undefined,
+  color: MessageCardColor,
+  text: string,
+): string {
+  return theme?.fg(color, text) ?? text;
+}
+
+function cleanMultiline(value: string): string {
+  return value
+    .replaceAll("\r\n", "\n")
+    .replaceAll("\r", "\n")
+    .split("\n")
+    .map((line) => sanitizeText(line))
+    .join("\n");
+}

--- a/src/extension/step-message.ts
+++ b/src/extension/step-message.ts
@@ -1,13 +1,19 @@
 import { createHash } from "node:crypto";
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
-import { Box, Text, TruncatedText } from "@earendil-works/pi-tui";
-import { sanitizeText } from "../workflows/text.js";
 import type {
   AgentStepContract,
   AgentStepPresentation,
   AgentStepSubmission,
 } from "../workflows/types.js";
 import { visibleAssistantText, type PromptDeliveryKind } from "./executor.js";
+import {
+  cleanOptionalSingleLine,
+  cleanSingleLine,
+  customMessageContentText,
+  paintMessageCard,
+  renderMessageCard,
+  type MessageCardView,
+} from "./message-card.js";
 
 export const WORKFLOW_AGENT_STEP_MESSAGE_TYPE = "pi-workflows-agent-step";
 export const WORKFLOW_AGENT_STEP_MESSAGE_SCHEMA = "pi-workflows.agent-step-message.v1";
@@ -25,27 +31,13 @@ type WorkflowAgentStepMessage = {
   details?: unknown;
 };
 
-type WorkflowAgentStepView = {
-  title: string;
-  status?: string;
-  expandedText?: string;
-};
+type WorkflowAgentStepView = MessageCardView;
 
 export function registerWorkflowAgentStepMessageRenderer(pi: ExtensionAPI): void {
   pi.registerMessageRenderer<WorkflowAgentStepMessageDetails>(
     WORKFLOW_AGENT_STEP_MESSAGE_TYPE,
-    (message, { expanded }, theme) => {
-      const view = buildWorkflowAgentStepView(message, expanded, theme);
-      const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
-      box.addChild(new TruncatedText(view.title));
-      if (view.status !== undefined) {
-        box.addChild(new TruncatedText(view.status));
-      }
-      if (view.expandedText !== undefined) {
-        box.addChild(new Text(`\n${view.expandedText}`));
-      }
-      return box;
-    },
+    (message, { expanded }, theme) =>
+      renderMessageCard(buildWorkflowAgentStepView(message, expanded, theme), theme),
   );
 }
 
@@ -65,12 +57,14 @@ export function buildWorkflowAgentStepView(
   const label = runTitle ?? workflowName;
   const suffix = kind === "step" ? "" : ` · ${kind}`;
   const glyph = kind === "step" ? "▶" : "↻";
-  const title = paint(theme, "accent", `${glyph} ${label} › ${nodeId}${suffix}`);
+  const title = paintMessageCard(theme, "accent", `${glyph} ${label} › ${nodeId}${suffix}`);
 
   if (!expanded) {
     return {
       title,
-      ...(statusDetail !== undefined ? { status: paint(theme, "dim", statusDetail) } : {}),
+      ...(statusDetail !== undefined
+        ? { status: paintMessageCard(theme, "dim", statusDetail) }
+        : {}),
     };
   }
 
@@ -88,11 +82,11 @@ export function buildWorkflowAgentStepView(
     `Completion: ${assistant ? "assistant response" : "workflow submission"}`,
     `Expected output: ${cleanSingleLine(expectedOutput)}`,
   ];
-  const prompt = contentText(message.content);
+  const prompt = customMessageContentText(message.content);
   return {
     title,
-    ...(statusDetail !== undefined ? { status: paint(theme, "dim", statusDetail) } : {}),
-    expandedText: `${metadata.map((line) => paint(theme, "dim", line)).join("\n")}\n\n${prompt}`,
+    ...(statusDetail !== undefined ? { status: paintMessageCard(theme, "dim", statusDetail) } : {}),
+    expandedText: `${metadata.map((line) => paintMessageCard(theme, "dim", line)).join("\n")}\n\n${prompt}`,
   };
 }
 
@@ -207,42 +201,4 @@ function parseDetails(value: unknown): WorkflowAgentStepMessageDetails | undefin
     return undefined;
   }
   return candidate as WorkflowAgentStepMessageDetails;
-}
-
-function contentText(content: unknown): string {
-  if (typeof content === "string") return cleanMultiline(content);
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) => {
-      if (part === null || typeof part !== "object" || !("text" in part)) return "";
-      const text = (part as { text?: unknown }).text;
-      return typeof text === "string" ? cleanMultiline(text) : "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function cleanOptionalSingleLine(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? cleanSingleLine(value) : undefined;
-}
-
-function cleanSingleLine(value: string): string {
-  return sanitizeText(value);
-}
-
-function cleanMultiline(value: string): string {
-  return value
-    .replaceAll("\r\n", "\n")
-    .replaceAll("\r", "\n")
-    .split("\n")
-    .map((line) => sanitizeText(line))
-    .join("\n");
-}
-
-function paint(
-  theme: Pick<Theme, "fg"> | undefined,
-  color: "accent" | "dim",
-  text: string,
-): string {
-  return theme?.fg(color, text) ?? text;
 }

--- a/test/deferred-turn-message.test.ts
+++ b/test/deferred-turn-message.test.ts
@@ -1,0 +1,250 @@
+import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import type { WorkflowTurnIntentRecord } from "../src/controllers/sqlite.js";
+import {
+  buildDeferredTurnMessageView,
+  DEFERRED_TURN_MESSAGE_SCHEMA,
+  DEFERRED_TURN_MESSAGE_TYPE,
+  deferredTurnMessageDetails,
+  registerDeferredTurnMessageRenderer,
+  type DeferredTurnMessageDetails,
+} from "../src/extension/deferred-turn.js";
+import type { TerminalDecision, TerminalReason } from "../src/extension/terminal-decision.js";
+
+const theme = {
+  bg: (_color: string, text: string) => text,
+  fg: (_color: string, text: string) => text,
+} as Theme;
+
+const terminalDetails: DeferredTurnMessageDetails = {
+  schema: DEFERRED_TURN_MESSAGE_SCHEMA,
+  turnIntentId: "intent-1",
+  runId: "run-1",
+  cause: "terminal",
+  presentation: {
+    workflowName: "autoimplement",
+    state: "completed",
+    reasonKind: "completed",
+    restart: { count: 0, limit: 3 },
+  },
+};
+
+function decision(reason: TerminalReason): TerminalDecision {
+  return {
+    workflowName: "autoimplement",
+    workflowSourceRef: "builtin:autoimplement",
+    workflowSource: { kind: "builtin", id: "autoimplement", revision: "test" },
+    definitionDigest: `sha256:${"a".repeat(64)}`,
+    runId: "run-1",
+    input: { task: "finish" },
+    result: { done: true },
+    state:
+      reason.kind === "completed"
+        ? "completed"
+        : reason.kind === "cancelled"
+          ? "cancelled"
+          : reason.kind === "timedOut"
+            ? "timed_out"
+            : "failed",
+    reason,
+    restartNumber: 1,
+    restartLimit: 3,
+    history: [],
+    fingerprint: `sha256:${"b".repeat(64)}`,
+  };
+}
+
+function intent(): WorkflowTurnIntentRecord {
+  return {
+    intentId: "intent-1",
+    sourceEventId: "event-1",
+    runId: "run-1",
+    workflowRef: "autoimplement",
+    targetSessionId: "session-1",
+    cause: "terminal",
+    nodeId: "$terminal",
+    attemptId: null,
+    fallbackFacts: {
+      schema: "pi-workflows.deferred-turn-facts.v1",
+      workflowName: "autoimplement",
+      runId: "run-1",
+      observedState: "completed",
+      cause: "terminal",
+      nodeId: "$terminal",
+      attemptId: null,
+      reason: null,
+      handoff: false,
+    },
+    requestedAt: "2026-08-28T00:00:00.000Z",
+    eligibleAt: "2026-08-28T00:00:00.000Z",
+    resolvedAt: null,
+    resolution: null,
+    resolutionMessageId: null,
+    deliveryClaimExpiresAt: null,
+  };
+}
+
+describe("deferred turn messages", () => {
+  it("builds a compact terminal view without the model prompt", () => {
+    const view = buildDeferredTurnMessageView(
+      {
+        content: 'Terminal facts: {"fingerprint":"secret"}\nExact workflow input: large',
+        details: terminalDetails,
+      },
+      false,
+    );
+
+    expect(view).toEqual({
+      title: "✓ autoimplement · completed",
+      status: "run run-1 · restart 0/3",
+    });
+    expect(JSON.stringify(view)).not.toContain("Terminal facts");
+    expect(JSON.stringify(view)).not.toContain("fingerprint");
+    expect(JSON.stringify(view)).not.toContain("Exact workflow input");
+  });
+
+  it("shows structured metadata and complete safe content when expanded", () => {
+    const view = buildDeferredTurnMessageView(
+      {
+        content: "Terminal facts:\n\u001b[31mfull content\u001b[0m\nWorkflow result: done",
+        details: {
+          ...terminalDetails,
+          runId: "run\nunsafe",
+          presentation: {
+            ...terminalDetails.presentation!,
+            workflowName: "auto\n\u001b[31mimplement\u001b[0m",
+            state: "timed_out",
+            reasonKind: "timedOut",
+            restart: { count: 2, limit: 3 },
+          },
+        },
+      },
+      true,
+    );
+
+    expect(view.title).toBe("! auto implement · timed out");
+    expect(view.status).toBe("run run unsafe · restart 2/3");
+    expect(view.expandedText).toContain("Workflow: auto implement");
+    expect(view.expandedText).toContain("Run id: run unsafe");
+    expect(view.expandedText).toContain("Reason kind: timed out");
+    expect(view.expandedText).toContain("Terminal facts:\nfull content\nWorkflow result: done");
+    expect(view.expandedText).not.toContain("\u001b");
+  });
+
+  it.each([
+    ["completed", "completed", "✓"],
+    ["failed", "failed", "×"],
+    ["timed_out", "timedOut", "!"],
+    ["failed", "maxSteps", "×"],
+    ["cancelled", "cancelled", "!"],
+    ["failed", "launchFailed", "×"],
+  ] as const)("renders %s with %s status", (state, reasonKind, glyph) => {
+    const view = buildDeferredTurnMessageView(
+      {
+        content: "full",
+        details: {
+          ...terminalDetails,
+          presentation: {
+            workflowName: "workflow",
+            state,
+            reasonKind,
+            restart: { count: 0, limit: 3 },
+          },
+        },
+      },
+      false,
+    );
+
+    expect(view.title.startsWith(`${glyph} workflow · `)).toBe(true);
+  });
+
+  it("renders ordinary and malformed fallback details safely", () => {
+    const ordinary = buildDeferredTurnMessageView(
+      {
+        content: "Inspect state",
+        details: {
+          schema: DEFERRED_TURN_MESSAGE_SCHEMA,
+          turnIntentId: "intent-2",
+          runId: "run-2",
+          cause: "launchFailed",
+        },
+      },
+      false,
+    );
+    expect(ordinary).toEqual({
+      title: "× Workflow · launch failed",
+      status: "run run-2",
+    });
+
+    const malformed = buildDeferredTurnMessageView(
+      { content: "Complete prompt", details: { schema: "wrong", presentation: null } },
+      true,
+    );
+    expect(malformed.title).toBe("◆ Workflow · deferred turn");
+    expect(malformed.status).toBeUndefined();
+    expect(malformed.expandedText).toContain("Run id: unknown");
+    expect(malformed.expandedText).toContain("Complete prompt");
+  });
+
+  it("builds bounded presentation details from fallback and terminal records", () => {
+    expect(deferredTurnMessageDetails(intent())).toMatchObject({
+      presentation: { workflowName: "autoimplement", state: "completed" },
+    });
+    expect(
+      deferredTurnMessageDetails(intent(), decision({ kind: "maxSteps", message: "max steps" })),
+    ).toMatchObject({
+      presentation: {
+        workflowName: "autoimplement",
+        state: "failed",
+        reasonKind: "maxSteps",
+        restart: { count: 1, limit: 3 },
+      },
+    });
+
+    const longIntent = intent();
+    longIntent.fallbackFacts.workflowName = `unsafe\n\u001b[31m${"x".repeat(1_000)}`;
+    const presentation = deferredTurnMessageDetails(longIntent).presentation;
+    expect(presentation?.workflowName).not.toContain("\u001b");
+    expect(presentation?.workflowName).not.toContain("\n");
+    expect(presentation?.workflowName).toHaveLength(512);
+    expect(presentation?.workflowName.endsWith("…")).toBe(true);
+  });
+
+  it("registers one width-safe collapsed and expanded renderer", () => {
+    let registrations = 0;
+    let renderer:
+      | ((
+          message: never,
+          options: { expanded: boolean },
+          renderTheme: Theme,
+        ) => { render(width: number): string[] })
+      | undefined;
+    const pi = {
+      registerMessageRenderer: (customType: string, candidate: typeof renderer) => {
+        expect(customType).toBe(DEFERRED_TURN_MESSAGE_TYPE);
+        registrations += 1;
+        renderer = candidate;
+      },
+    } as unknown as ExtensionAPI;
+    registerDeferredTurnMessageRenderer(pi);
+
+    const message = {
+      role: "custom",
+      customType: DEFERRED_TURN_MESSAGE_TYPE,
+      content: "Complete terminal decision content",
+      display: true,
+      details: terminalDetails,
+      timestamp: Date.now(),
+    };
+    const collapsed = renderer?.(message as never, { expanded: false }, theme).render(32) ?? [];
+    expect(registrations).toBe(1);
+    expect(collapsed.join("\n")).toContain("autoimplement");
+    expect(collapsed.join("\n")).not.toContain("Complete terminal decision content");
+    expect(collapsed.every((line) => visibleWidth(line) <= 32)).toBe(true);
+
+    const expanded = renderer?.(message as never, { expanded: true }, theme).render(40) ?? [];
+    expect(expanded.join("\n")).toContain("Complete terminal decision content");
+    expect(expanded.every((line) => visibleWidth(line) <= 40)).toBe(true);
+  });
+});

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -594,6 +594,36 @@ async function readRpcState(pi: RpcHandle): Promise<RpcState> {
   return data as RpcState;
 }
 
+async function readRpcEntries(pi: RpcHandle): Promise<
+  Array<{
+    type?: unknown;
+    customType?: unknown;
+    content?: unknown;
+    details?: unknown;
+  }>
+> {
+  const id = `e2e-entries-${++rpcStateRequest}`;
+  const start = pi.stdoutLines.length;
+  pi.send({ id, type: "get_entries" });
+  await waitForCondition(
+    () => pi.stdoutLines.slice(start).some((line) => line.includes(`"id":"${id}"`)),
+    () => `pi stderr:\n${pi.stderr()}\npi stdout tail:\n${pi.stdoutLines.slice(-15).join("\n")}`,
+  );
+  const response = pi.stdoutLines
+    .slice(start)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+    .find((value) => value.id === id);
+  const data = response?.data;
+  if (data === null || typeof data !== "object") {
+    throw new Error(`Pi RPC get_entries ${id} returned no data`);
+  }
+  const entries = (data as { entries?: unknown }).entries;
+  if (!Array.isArray(entries)) {
+    throw new Error(`Pi RPC get_entries ${id} returned no entries`);
+  }
+  return entries;
+}
+
 async function waitForPiIdle(pi: RpcHandle, timeoutMs = 30_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
@@ -1668,6 +1698,35 @@ describe.sequential("pi-workflows end to end", () => {
         );
       });
     expect(terminalDecisionRequests()).toHaveLength(2);
+
+    const terminalRuns = listWorkflowRuns({ databasePath: runsDir }).filter(
+      (candidate) => candidate.state.workflowName === "terminal-restart-e2e",
+    );
+    const terminalRunIds = new Set(terminalRuns.map((candidate) => candidate.runId));
+    const recordedTerminalMessages = (await readRpcEntries(pi)).filter((entry) => {
+      if (entry.type !== "custom_message" || entry.customType !== "pi-workflows-deferred-turn") {
+        return false;
+      }
+      const details = entry.details;
+      if (details === null || typeof details !== "object" || Array.isArray(details)) return false;
+      const runId = (details as { runId?: unknown }).runId;
+      return typeof runId === "string" && terminalRunIds.has(runId);
+    });
+    expect(recordedTerminalMessages).toHaveLength(2);
+    for (const message of recordedTerminalMessages) {
+      expect(message.details).toMatchObject({
+        schema: "pi-workflows.deferred-turn-message.v1",
+        presentation: {
+          workflowName: "terminal-restart-e2e",
+          state: "failed",
+          reasonKind: "maxSteps",
+          restart: { limit: 3 },
+        },
+        terminalDecision: { schema: "pi-workflows.terminal-decision.v1" },
+      });
+      expect(contentText(message.content)).toContain("Exact workflow input:");
+      expect(contentText(message.content)).toContain('"workflowName": "terminal-restart-e2e"');
+    }
 
     const restartCallIds = new Set<string>();
     for (const request of mock.requests.slice(requestOffset)) {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1289,6 +1289,7 @@ describe("pi-workflows extension", () => {
       });
       expect(harness.sentUserMessages).toHaveLength(0);
       expect(harness.messageRenderers.has("pi-workflows-agent-step")).toBe(true);
+      expect(harness.messageRenderers.has("pi-workflows-deferred-turn")).toBe(true);
 
       await waitFor(() => harness.notifications.some((note) => note.includes("completed")));
       await harness.emitAsync("agent_settled");
@@ -1369,6 +1370,12 @@ describe("pi-workflows extension", () => {
           content: expect.stringContaining('"terminalState": "cancelled"'),
           details: expect.objectContaining({
             cause: "agentCancelled",
+            presentation: {
+              workflowName: "mini",
+              state: "cancelled",
+              reasonKind: "cancelled",
+              restart: { count: 0, limit: 3 },
+            },
             terminalDecision: expect.objectContaining({
               schema: "pi-workflows.terminal-decision.v1",
             }),
@@ -1692,6 +1699,12 @@ export default defineWorkflow({
           content: expect.stringContaining('"terminalState": "failed"'),
           details: expect.objectContaining({
             cause: "launchFailed",
+            presentation: {
+              workflowName: "mini",
+              state: "failed",
+              reasonKind: "launchFailed",
+              restart: { count: 0, limit: 3 },
+            },
             terminalDecision: expect.objectContaining({
               schema: "pi-workflows.terminal-decision.v1",
             }),
@@ -1915,6 +1928,19 @@ export default defineWorkflow({
             entry.message.content.includes(sourceRunId),
         ),
       );
+      const sourceTerminalMessage = harness.sentMessages.find(
+        (entry) =>
+          entry.message.customType === "pi-workflows-deferred-turn" &&
+          entry.message.content.includes(sourceRunId),
+      );
+      expect(sourceTerminalMessage?.message.details).toMatchObject({
+        presentation: {
+          workflowName: "max-steps",
+          state: "failed",
+          reasonKind: "maxSteps",
+          restart: { count: 0, limit: 3 },
+        },
+      });
       const sourceBefore = readWorkflowRun(sourceRunId, {
         databasePath: workflowStateDatabasePath(runsDir),
       });


### PR DESCRIPTION
This pull request was opened on behalf of Onur Solmaz (`osolmaz`).

Deferred terminal decisions now appear as compact workflow cards in interactive Pi. Users can expand a card to see the complete existing terminal decision text, while model context, session replay, and workflow behavior stay unchanged.

## Summary

- Shows the workflow, outcome, run ID, and restart count in the collapsed card.
- Keeps exact input, results, fingerprints, and model instructions out of the collapsed view.
- Preserves the complete custom-message content for the model and durable session record.

## Technical details

- Registers a renderer for `pi-workflows-deferred-turn` through Pi's public `registerMessageRenderer` API.
- Adds bounded, sanitized presentation metadata to the existing message details and does not parse the model-facing prompt text.
- Reuses shared card rendering utilities with the existing agent-step renderer.
- Handles ordinary fallbacks, terminal decisions, restored entries, and malformed details without duplicate entries or turns.
- Adds unit, extension, and real-Pi RPC regressions.

## Risks and tradeoffs

- Expanded cards deliberately show the full existing content. This is unchanged model and session data, not a second summary entry.
- SimpleDoc still reports the repository's unchanged baseline migration set. This change does not apply unrelated document moves.

## Verification

- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`
- `npx -y @simpledoc/simpledoc check` (same pre-existing baseline findings as `main`)

Implementation and review support used an automated coding agent. Onur Solmaz remains responsible for the contribution.
