### PR TITLE
feat(state): preserve pre-viewer runs

### DIFF
--- a/docs/SQLITE_STATE.md
+++ b/docs/SQLITE_STATE.md
@@ -18,7 +18,11 @@ The store retains 256 presentation revisions. A reader with an older cursor must
 
 `session_entries` and `session_events` have run-wide sequence numbers and indexed `(run_id, run_seq)` ranges. Step, trace, entry, and event reads contain at most 256 rows. Run-list queries read metadata, status, lease facts, and the presentation revision. They do not read payload bodies.
 
-This is an in-place alpha schema change. The schema name and version remain `pi-workflows-state` version 1. The DDL digest and exact shape changed. An older alpha database fails with the standard reset instruction and remains untouched. There is no compatibility reader, migration shim, dual path, feature flag, alias, or `v2` schema.
+This is an in-place alpha schema change. The schema name and version remain `pi-workflows-state` version 1. The DDL digest and exact shape changed.
+
+The exact schema used by Pi Workflows 0.14.0 can take one explicit preservation upgrade. The upgrade first requires all workflow runs and hosts to stop. It checkpoints the WAL, holds an exclusive lock, writes a byte-identical backup, verifies that backup, and then changes the source database in one transaction. It rebuilds `session_entries` and `session_events` with run-wide sequence numbers, adds the viewer tables, gives every existing run presentation revision 1, and writes a bounded replay checkpoint at each complete 256-event boundary. It verifies existing session row content, the final schema shape, integrity, and foreign keys before commit. An error rolls back the source database and keeps a completed backup.
+
+This is one exact upgrade, not a general compatibility layer. Normal readers and writers support only the current schema. Unknown alpha schemas still fail with the standard reset instruction and remain untouched. There is no dual path, feature flag, alias, or `v2` schema.
 
 ## Storage boundary
 
@@ -258,6 +262,7 @@ Supported commands are:
 pi-workflows state status
 pi-workflows state verify
 pi-workflows state backup /absolute/path/to/state-backup.sqlite
+pi-workflows state upgrade --backup /absolute/path/to/state-before-viewer.sqlite --apply
 pi-workflows state prune --before 2026-08-01T00:00:00Z --dry-run
 pi-workflows state prune --before 2026-08-01T00:00:00Z --backup /absolute/path/to/before-prune.sqlite --apply
 ```
@@ -265,10 +270,14 @@ pi-workflows state prune --before 2026-08-01T00:00:00Z --backup /absolute/path/t
 `status` reports only safe counts, file size, active leases, and unsettled effects.
 It does not print actor IDs, channel references, payloads, or credentials.
 
+`upgrade` is the only supported way to preserve a database from the exact pre-viewer schema. Stop every Pi Workflows run and host first. The command refuses active leases, an existing backup destination, a relative backup path, the current schema, and every unknown schema. Pi Workflows never runs this upgrade at startup.
+
 `prune --dry-run` reports complete terminal run trees older than the cutoff and the trees that safety checks block. It does not change the database. `prune --apply` requires a new absolute backup path. It verifies the backup, locks maintenance, rechecks the same selection in an exclusive transaction, and refuses trees with live queues, active leases, unsettled effects, controller references, channel references, or step links from runs outside the tree. It deletes the safe aggregates, removes blobs with no remaining foreign-key reference, checkpoints the WAL, vacuums the file, and runs integrity and foreign-key checks. Pi Workflows never runs prune at startup.
 
 ## Alpha cutover
 
-This is a hard cut. Pi Workflows has no normal reader or writer for older live storage. It does not use dual reads, dual writes, aliases, versioned state roots, or automatic import.
+Normal runtime access remains a hard cut. Pi Workflows has no normal reader or writer for older live storage. It does not use dual reads, dual writes, aliases, versioned state roots, or automatic import.
 
-Older state remains untouched. If it is present when a new database would be created, Pi Workflows fails with a clear instruction instead of guessing or deleting data.
+The explicit pre-viewer upgrade is a bounded exception requested to preserve existing runs. It accepts only the known prior digest and exact changed table shapes. It does not make old state readable at runtime.
+
+Other older state remains untouched. If it is present when a new database would be created, Pi Workflows fails with a clear instruction instead of guessing or deleting data.

--- a/docs/plans/2026-08-28-piw-incremental-viewer-plan.md
+++ b/docs/plans/2026-08-28-piw-incremental-viewer-plan.md
@@ -272,11 +272,25 @@ Boxed cards use a content width from 20 through 28 cells, which gives an outer w
 
 The generated scale fixture is 98,242,560 bytes and contains 44 runs, 17,820 run events, 9,284 session entries, and 48,620 session events. Five release-mode runs of 1,000 idle checks each loaded one selected window with 723 payload rows. They performed one run-index read, no later payload loads, and used 9,388 KiB peak RSS, or 9.61 MB. Total time was 1,291 through 2,331 microseconds per 1,000 checks. Median checks took 1 through 2 microseconds, p99 checks took 1 through 2 microseconds, and the maximum was 9 through 27 microseconds. Compared with the measured 370 MB baseline, peak memory fell by about 360.39 MB, or 97.4%. This is much larger than the registered 50% memory reduction gate. A separate run of 1,000,000 unchanged checks used 0.63 CPU seconds in user code and 0.65 CPU seconds in system calls. Its p99 check took 2 microseconds. The deterministic structural gate also passed: idle checks performed zero payload reads after the first bounded selected window.
 
+## Preserving pre-viewer runs
+
+The implementation changed the exact SQLite shape. It added the viewer projection tables and added run-wide sequence fields to session entries and events. Onur explicitly requires the runs stored by the immediately previous schema to remain available for testing and adoption.
+
+One explicit maintenance command upgrades only that exact prior schema. It requires a new absolute backup path and `--apply`, refuses active leases, checkpoints the WAL, takes an exclusive lock, and writes a byte-identical verified backup before it changes the source. In one transaction it rebuilds the two session tables with stable chronological run sequence numbers, adds the viewer tables, gives each old run presentation revision 1, and backfills bounded replay checkpoints. It compares existing session content before and after, validates the exact current schema, and runs integrity and foreign-key checks before commit. A failure rolls back the source and keeps a completed backup.
+
+This bounded exception does not add a runtime compatibility reader, dual reads, dual writes, a new schema version, automatic startup migration, or support for an unknown alpha schema. The normal runtime still accepts only the current exact schema.
+
 ## Rollout
 
-The implementation is one hard replacement. State writers, projection readers, local viewer, replay server, replay client, and protocol must agree before release.
+State writers, projection readers, local viewer, replay server, replay client, and protocol must agree before release.
 
-If the new presentation revision or delta records make the existing alpha database incompatible, startup must stop with the standard clear reset instruction. It must not modify or delete the old database.
+Before adoption on a pre-viewer database, stop all Pi Workflows runs and hosts and run:
+
+```bash
+pi-workflows state upgrade --backup /absolute/path/to/state-before-viewer.sqlite --apply
+```
+
+Test the command and a source-built `piw` against a copied database first. Do not modify the live database for that test.
 
 Release publication and installation of the matching npm and crates.io packages are separate work. Existing installed viewers keep their current behavior until they are replaced.
 

--- a/src/state/database.ts
+++ b/src/state/database.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { canonicalJson, parseJson, type JsonValue } from "./json.js";
 import {
+  PRE_VIEWER_STATE_SCHEMA_DIGEST,
   STATE_APPLICATION_ID,
   STATE_APP_VERSION,
   STATE_SCHEMA_DIGEST,
@@ -18,6 +19,8 @@ const BUSY_TIMEOUT_MS = 5_000;
 const JOURNAL_SIZE_LIMIT = 64 * 1024 * 1024;
 const RESET_INSTRUCTION =
   "Pi Workflows durable state is incompatible. Move or remove the old workflow state, then create a new state.sqlite database.";
+const UPGRADE_INSTRUCTION =
+  "Pi Workflows durable state needs the viewer schema upgrade. Stop Pi Workflows, then run `pi-workflows state upgrade --backup <absolute-path> --apply`.";
 
 export type StateDatabaseMode = "read-write" | "read-only";
 
@@ -278,6 +281,15 @@ export class StateDatabase {
          FROM schema_meta WHERE id = 1`,
       )
       .get();
+    if (
+      isSchemaMetaRow(row) &&
+      row.schemaName === STATE_SCHEMA_NAME &&
+      row.schemaVersion === STATE_SCHEMA_VERSION &&
+      row.appVersion === STATE_APP_VERSION &&
+      row.schemaDigest.equals(PRE_VIEWER_STATE_SCHEMA_DIGEST)
+    ) {
+      throw new Error(UPGRADE_INSTRUCTION);
+    }
     if (
       !isSchemaMetaRow(row) ||
       row.schemaName !== STATE_SCHEMA_NAME ||

--- a/src/state/schema.ts
+++ b/src/state/schema.ts
@@ -4,6 +4,10 @@ export const STATE_APPLICATION_ID = 0x50495746;
 export const STATE_SCHEMA_NAME = "pi-workflows-state";
 export const STATE_SCHEMA_VERSION = 1;
 export const STATE_APP_VERSION = "0.13.3";
+export const PRE_VIEWER_STATE_SCHEMA_DIGEST = Buffer.from(
+  "466ddbae921f2619ff81db56739518e7ef68fa0a23bff80df0296b3afd01c856",
+  "hex",
+);
 
 export const STATE_SCHEMA_SQL = String.raw`
 CREATE TABLE schema_meta (

--- a/src/viewer/cli.ts
+++ b/src/viewer/cli.ts
@@ -7,6 +7,7 @@ import { syncHerdrPlugin } from "../herdr/setup.js";
 import { sanitizeText } from "../render/ansi.js";
 import { StateDatabase } from "../state/database.js";
 import { pruneState } from "../state/prune.js";
+import { upgradePreViewerStateDatabase } from "../workflows/state-upgrade.js";
 import { WorkflowRunStore, workflowStateDatabasePath } from "../workflows/store.js";
 import {
   formatDuration,
@@ -26,6 +27,7 @@ Usage:
   pi-workflows controller <controller> <key>
   pi-workflows state status|verify
   pi-workflows state backup <destination>
+  pi-workflows state upgrade --backup <absolute-path> --apply
   pi-workflows state prune --before <timestamp> --dry-run
   pi-workflows state prune --before <timestamp> --backup <absolute-path> --apply
   pi-workflows host [--project <dir>] [-- <extra pi args>]
@@ -41,7 +43,7 @@ export type CliArgs = {
   controllerName?: string;
   resourceKey?: string;
   herdrAction?: string;
-  stateAction?: "status" | "verify" | "backup" | "prune";
+  stateAction?: "status" | "verify" | "backup" | "upgrade" | "prune";
   backupDestination?: string;
   pruneBefore?: string;
   pruneApply?: boolean;
@@ -93,8 +95,14 @@ export function parseCliArgs(argv: string[]): CliArgs {
   }
   if (command === "state") {
     const action = positionals[0];
-    if (action !== "status" && action !== "verify" && action !== "backup" && action !== "prune") {
-      throw new Error("state requires status, verify, backup, or prune");
+    if (
+      action !== "status" &&
+      action !== "verify" &&
+      action !== "backup" &&
+      action !== "upgrade" &&
+      action !== "prune"
+    ) {
+      throw new Error("state requires status, verify, backup, upgrade, or prune");
     }
     if (action === "prune") {
       if (positionals.length !== 1) throw new Error("state prune accepts no positional arguments");
@@ -124,6 +132,21 @@ export function parseCliArgs(argv: string[]): CliArgs {
         command,
         stateAction: action,
         backupDestination: positionals[1] as string,
+        once,
+        json,
+      };
+    }
+    if (action === "upgrade") {
+      if (positionals.length !== 1)
+        throw new Error("state upgrade accepts no positional arguments");
+      if (!pruneApply || backupDestination === undefined || pruneDryRun) {
+        throw new Error("state upgrade requires --backup <absolute-path> --apply");
+      }
+      return {
+        command,
+        stateAction: action,
+        backupDestination,
+        pruneApply,
         once,
         json,
       };
@@ -286,6 +309,11 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
 }
 
 async function runStateCommand(databasePath: string, args: CliArgs): Promise<void> {
+  if (args.stateAction === "upgrade") {
+    const report = upgradePreViewerStateDatabase(databasePath, args.backupDestination as string);
+    process.stdout.write(`${JSON.stringify(report)}\n`);
+    return;
+  }
   if (args.stateAction === "prune") {
     const report = await pruneState(databasePath, {
       before: args.pruneBefore as string,

--- a/src/workflows/session-reducer.ts
+++ b/src/workflows/session-reducer.ts
@@ -277,9 +277,24 @@ export function reduceSessionEventsFromCheckpoint(
   return foldSessionEvents(entries, events, throughSeq, checkpoint);
 }
 
+/** Keep only state that a later bounded replay page can continue. */
+export function boundedTemporalCheckpoint(state: TemporalSessionState): TemporalSessionState {
+  const messages = state.messages.filter((message) => message.status === "streaming");
+  const activeMessages = new Set(messages.map((message) => message.messageId));
+  return {
+    ...state,
+    messages,
+    tools: state.tools.filter(
+      (tool) => tool.status === "running" && activeMessages.has(tool.messageId),
+    ),
+    settledEntryIds: [],
+    diagnostics: ["earlier session messages are outside this page"],
+  };
+}
+
 /**
- * In-memory seek index. Checkpoints are viewer-only cache state and are never
- * persisted into a SQLite run state.
+ * In-memory seek index. Durable viewers use the persisted SQLite replay
+ * checkpoints; this index remains for complete in-memory session projections.
  */
 export class SessionReplayIndex {
   private readonly entries: WorkflowSessionEntryRecord[];

--- a/src/workflows/state-upgrade.ts
+++ b/src/workflows/state-upgrade.ts
@@ -1,0 +1,710 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { canonicalJson, parseJson } from "../state/json.js";
+import {
+  PRE_VIEWER_STATE_SCHEMA_DIGEST,
+  STATE_APPLICATION_ID,
+  STATE_APP_VERSION,
+  STATE_SCHEMA_DIGEST,
+  STATE_SCHEMA_NAME,
+  STATE_SCHEMA_SQL,
+  STATE_SCHEMA_VERSION,
+} from "../state/schema.js";
+import { VIEWER_PAGE_SIZE } from "../state/viewer.js";
+import {
+  boundedTemporalCheckpoint,
+  reduceSessionEvents,
+  reduceSessionEventsFromCheckpoint,
+  type TemporalSessionState,
+} from "./session-reducer.js";
+import type { WorkflowSessionEventRecord, WorkflowSessionEventType } from "./types.js";
+
+const BUSY_TIMEOUT_MS = 5_000;
+const PRE_VIEWER_STATE_SCHEMA_SHAPE =
+  "f0f415da472883fe413850009adcde85bc74d7223d6323c11e55f0260c05e138";
+const UPGRADE_SQL = String.raw`
+CREATE TEMP TABLE state_upgrade_session_entries AS
+SELECT e.segment_id, s.run_id, e.entry_seq,
+       row_number() OVER (
+         PARTITION BY s.run_id
+         ORDER BY e.recorded_at, e.segment_id, e.entry_seq
+       ) AS run_seq,
+       e.entry_id, e.entry_hash, e.recorded_at
+FROM session_entries e
+JOIN session_segments s ON s.segment_id = e.segment_id;
+
+DROP TABLE session_entries;
+
+CREATE TABLE session_entries (
+  segment_id TEXT NOT NULL REFERENCES session_segments(segment_id) ON DELETE CASCADE,
+  run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+  entry_seq INTEGER NOT NULL CHECK (entry_seq > 0),
+  run_seq INTEGER NOT NULL CHECK (run_seq > 0),
+  entry_id TEXT NOT NULL,
+  entry_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (segment_id, entry_seq),
+  UNIQUE (segment_id, entry_id),
+  UNIQUE (run_id, run_seq)
+) STRICT;
+
+CREATE INDEX session_entries_run_idx ON session_entries(run_id, run_seq);
+
+INSERT INTO session_entries(
+  segment_id, run_id, entry_seq, run_seq, entry_id, entry_hash, recorded_at
+)
+SELECT segment_id, run_id, entry_seq, run_seq, entry_id, entry_hash, recorded_at
+FROM state_upgrade_session_entries;
+
+DROP TABLE state_upgrade_session_entries;
+
+CREATE TEMP TABLE state_upgrade_session_events AS
+SELECT e.segment_id, s.run_id, e.event_seq,
+       row_number() OVER (
+         PARTITION BY s.run_id
+         ORDER BY e.recorded_at, e.segment_id, e.event_seq
+       ) AS run_seq,
+       e.event_type, e.node_id, e.attempt_id, e.turn_id, e.message_id,
+       e.tool_call_id, e.payload_hash, e.recorded_at
+FROM session_events e
+JOIN session_segments s ON s.segment_id = e.segment_id;
+
+DROP TABLE session_events;
+
+CREATE TABLE session_events (
+  segment_id TEXT NOT NULL REFERENCES session_segments(segment_id) ON DELETE CASCADE,
+  run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+  event_seq INTEGER NOT NULL CHECK (event_seq > 0),
+  run_seq INTEGER NOT NULL CHECK (run_seq > 0),
+  event_type TEXT NOT NULL,
+  node_id TEXT,
+  attempt_id TEXT,
+  turn_id TEXT,
+  message_id TEXT,
+  tool_call_id TEXT,
+  payload_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (segment_id, event_seq),
+  UNIQUE (run_id, run_seq)
+) STRICT;
+
+CREATE INDEX session_events_run_idx ON session_events(run_id, run_seq);
+
+INSERT INTO session_events(
+  segment_id, run_id, event_seq, run_seq, event_type, node_id, attempt_id,
+  turn_id, message_id, tool_call_id, payload_hash, recorded_at
+)
+SELECT segment_id, run_id, event_seq, run_seq, event_type, node_id, attempt_id,
+       turn_id, message_id, tool_call_id, payload_hash, recorded_at
+FROM state_upgrade_session_events;
+
+DROP TABLE state_upgrade_session_events;
+
+CREATE TABLE viewer_runs (
+  run_id TEXT PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE,
+  presentation_revision INTEGER NOT NULL CHECK (presentation_revision >= 1),
+  retained_from_revision INTEGER NOT NULL CHECK (
+    retained_from_revision >= 1 AND retained_from_revision <= presentation_revision
+  ),
+  updated_at INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE viewer_deltas (
+  run_id TEXT NOT NULL REFERENCES viewer_runs(run_id) ON DELETE CASCADE,
+  presentation_revision INTEGER NOT NULL CHECK (presentation_revision >= 1),
+  delta_index INTEGER NOT NULL CHECK (delta_index >= 0),
+  target_type TEXT NOT NULL CHECK (target_type IN (
+    'summary', 'graph', 'replay', 'timeline', 'conversation', 'inspector'
+  )),
+  target_key TEXT NOT NULL,
+  patch_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (run_id, presentation_revision, delta_index)
+) STRICT;
+
+CREATE INDEX viewer_deltas_resume_idx
+  ON viewer_deltas(run_id, presentation_revision, delta_index);
+
+CREATE TABLE viewer_session_checkpoints (
+  run_id TEXT NOT NULL REFERENCES viewer_runs(run_id) ON DELETE CASCADE,
+  event_seq INTEGER NOT NULL CHECK (event_seq > 0),
+  state_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (run_id, event_seq)
+) STRICT;
+`;
+
+const LEGACY_ENTRY_DIGEST_SQL = `
+  SELECT segment_id AS segmentId, entry_seq AS entrySeq, entry_id AS entryId,
+         hex(entry_hash) AS entryHash, recorded_at AS recordedAt
+  FROM session_entries ORDER BY segment_id, entry_seq
+`;
+const LEGACY_EVENT_DIGEST_SQL = `
+  SELECT segment_id AS segmentId, event_seq AS eventSeq, event_type AS eventType,
+         node_id AS nodeId, attempt_id AS attemptId, turn_id AS turnId,
+         message_id AS messageId, tool_call_id AS toolCallId,
+         hex(payload_hash) AS payloadHash, recorded_at AS recordedAt
+  FROM session_events ORDER BY segment_id, event_seq
+`;
+
+export type StateUpgradeReport = {
+  backupPath: string;
+  backupSha256: string;
+  sourceSchemaDigest: string;
+  targetSchemaDigest: string;
+  runs: number;
+  sessionEntries: number;
+  sessionEvents: number;
+  replayCheckpoints: number;
+};
+
+type SchemaMetaRow = {
+  schemaName: string;
+  schemaVersion: number;
+  schemaDigest: Buffer;
+  appVersion: string;
+};
+
+type CountRow = { count: number };
+
+type RunIdRow = { runId: string };
+
+type SessionEventUpgradeRow = {
+  runId: string;
+  runSeq: number;
+  eventType: string;
+  nodeId: string;
+  attemptId: string;
+  turnId: string | null;
+  messageId: string | null;
+  toolCallId: string | null;
+  payloadContent: Buffer;
+  payloadMediaType: string;
+  recordedAt: number;
+};
+
+type BlobRow = {
+  mediaType: string;
+  byteLength: number;
+  content: Buffer;
+};
+
+type SchemaObjectRow = {
+  type: string;
+  name: string;
+  tableName: string;
+  sql: string;
+};
+
+let expectedShape: string | undefined;
+
+/** Upgrade only the exact pre-viewer alpha schema after making a stable backup. */
+export function upgradePreViewerStateDatabase(
+  databasePath: string,
+  backupPath: string,
+): StateUpgradeReport {
+  const source = path.resolve(databasePath);
+  if (!path.isAbsolute(backupPath)) {
+    throw new Error("State upgrade backup path must be absolute");
+  }
+  const backup = path.resolve(backupPath);
+  if (source === backup) {
+    throw new Error("State upgrade backup must differ from the live database");
+  }
+  if (!fs.existsSync(source)) {
+    throw new Error(`Pi Workflows state database does not exist: ${source}`);
+  }
+  if (fs.existsSync(backup)) {
+    throw new Error(`State upgrade backup already exists: ${backup}`);
+  }
+
+  const database = new Database(source, { timeout: BUSY_TIMEOUT_MS });
+  let backupComplete = false;
+  try {
+    database.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    database.pragma("synchronous = FULL");
+    database.pragma("foreign_keys = ON");
+    verifyPreViewerSchema(database);
+    verifyIntegrity(database);
+    assertNoActiveLeases(database);
+    checkpointWal(database);
+
+    database.pragma("foreign_keys = OFF");
+    database.exec("BEGIN EXCLUSIVE");
+    try {
+      verifyPreViewerSchema(database);
+      assertNoActiveLeases(database);
+      const sourceEntries = tableDigest(database, LEGACY_ENTRY_DIGEST_SQL);
+      const sourceEvents = tableDigest(database, LEGACY_EVENT_DIGEST_SQL);
+      const runs = rowCount(database, "runs");
+      const sessionEntries = rowCount(database, "session_entries");
+      const sessionEvents = rowCount(database, "session_events");
+
+      backupComplete = copyAndVerifyBackup(database, source, backup);
+      database.exec(UPGRADE_SQL);
+      database
+        .prepare(
+          `INSERT INTO viewer_runs(
+             run_id, presentation_revision, retained_from_revision, updated_at
+           )
+           SELECT run_id, 1, 1, updated_at FROM runs`,
+        )
+        .run();
+      const replayCheckpoints = backfillReplayCheckpoints(database);
+      database
+        .prepare(
+          `UPDATE schema_meta
+           SET schema_digest = ?, app_version = ?, updated_at = ?
+           WHERE id = 1`,
+        )
+        .run(STATE_SCHEMA_DIGEST, STATE_APP_VERSION, Date.now());
+
+      if (rowCount(database, "runs") !== runs || rowCount(database, "viewer_runs") !== runs) {
+        throw new Error("State upgrade did not preserve every workflow run");
+      }
+      if (rowCount(database, "session_entries") !== sessionEntries) {
+        throw new Error("State upgrade changed the session entry count");
+      }
+      if (rowCount(database, "session_events") !== sessionEvents) {
+        throw new Error("State upgrade changed the session event count");
+      }
+      if (tableDigest(database, LEGACY_ENTRY_DIGEST_SQL) !== sourceEntries) {
+        throw new Error("State upgrade changed existing session entry data");
+      }
+      if (tableDigest(database, LEGACY_EVENT_DIGEST_SQL) !== sourceEvents) {
+        throw new Error("State upgrade changed existing session event data");
+      }
+      verifyCurrentSchema(database);
+      verifyIntegrity(database);
+      database.exec("COMMIT");
+      database.pragma("foreign_keys = ON");
+      verifyCurrentSchema(database);
+      verifyIntegrity(database);
+
+      return {
+        backupPath: backup,
+        backupSha256: fileSha256(backup),
+        sourceSchemaDigest: PRE_VIEWER_STATE_SCHEMA_DIGEST.toString("hex"),
+        targetSchemaDigest: STATE_SCHEMA_DIGEST.toString("hex"),
+        runs,
+        sessionEntries,
+        sessionEvents,
+        replayCheckpoints,
+      };
+    } catch (error) {
+      if (database.inTransaction) database.exec("ROLLBACK");
+      database.pragma("foreign_keys = ON");
+      throw error;
+    }
+  } catch (error) {
+    if (!backupComplete && fs.existsSync(backup)) fs.rmSync(backup);
+    throw error;
+  } finally {
+    database.close();
+  }
+}
+
+function verifyPreViewerSchema(database: Database.Database): void {
+  const applicationId = database.pragma("application_id", { simple: true });
+  const userVersion = database.pragma("user_version", { simple: true });
+  const row = readSchemaMeta(database);
+  if (
+    applicationId !== STATE_APPLICATION_ID ||
+    userVersion !== STATE_SCHEMA_VERSION ||
+    row.schemaName !== STATE_SCHEMA_NAME ||
+    row.schemaVersion !== STATE_SCHEMA_VERSION ||
+    row.appVersion !== STATE_APP_VERSION ||
+    !row.schemaDigest.equals(PRE_VIEWER_STATE_SCHEMA_DIGEST)
+  ) {
+    if (row.schemaDigest.equals(STATE_SCHEMA_DIGEST)) {
+      throw new Error("Pi Workflows state already uses the current viewer schema");
+    }
+    throw new Error("Pi Workflows state is not the exact supported pre-viewer alpha schema");
+  }
+  assertTableColumns(database, "session_entries", [
+    "segment_id",
+    "entry_seq",
+    "entry_id",
+    "entry_hash",
+    "recorded_at",
+  ]);
+  assertTableColumns(database, "session_events", [
+    "segment_id",
+    "event_seq",
+    "event_type",
+    "node_id",
+    "attempt_id",
+    "turn_id",
+    "message_id",
+    "tool_call_id",
+    "payload_hash",
+    "recorded_at",
+  ]);
+  for (const table of ["viewer_runs", "viewer_deltas", "viewer_session_checkpoints"]) {
+    if (tableExists(database, table)) {
+      throw new Error(`Pre-viewer state unexpectedly contains ${table}`);
+    }
+  }
+  if (schemaShape(database) !== PRE_VIEWER_STATE_SCHEMA_SHAPE) {
+    throw new Error("Pi Workflows state is not the exact supported pre-viewer alpha schema");
+  }
+}
+
+function verifyCurrentSchema(database: Database.Database): void {
+  const row = readSchemaMeta(database);
+  if (
+    row.schemaName !== STATE_SCHEMA_NAME ||
+    row.schemaVersion !== STATE_SCHEMA_VERSION ||
+    row.appVersion !== STATE_APP_VERSION ||
+    !row.schemaDigest.equals(STATE_SCHEMA_DIGEST) ||
+    schemaShape(database) !== expectedSchemaShape()
+  ) {
+    throw new Error("State upgrade did not produce the exact current Pi Workflows schema");
+  }
+}
+
+function readSchemaMeta(database: Database.Database): SchemaMetaRow {
+  const row = database
+    .prepare(
+      `SELECT schema_name AS schemaName, schema_version AS schemaVersion,
+              schema_digest AS schemaDigest, app_version AS appVersion
+       FROM schema_meta WHERE id = 1`,
+    )
+    .get();
+  if (!isSchemaMetaRow(row)) {
+    throw new Error("Pi Workflows state schema metadata is invalid");
+  }
+  return row;
+}
+
+function assertNoActiveLeases(database: Database.Database): void {
+  const row = database
+    .prepare(
+      `SELECT count(*) AS count FROM leases
+       WHERE owner_id IS NOT NULL AND expires_at > ?`,
+    )
+    .get(Date.now());
+  if (!isCountRow(row)) throw new Error("Pi Workflows active lease count is invalid");
+  if (row.count !== 0) {
+    throw new Error("Stop all active Pi Workflows runs and hosts before upgrading state");
+  }
+}
+
+function checkpointWal(database: Database.Database): void {
+  const rows = database.pragma("wal_checkpoint(TRUNCATE)");
+  if (!Array.isArray(rows) || rows.length !== 1 || !isCheckpointResult(rows[0])) {
+    throw new Error("Pi Workflows state WAL checkpoint returned an invalid result");
+  }
+  if (rows[0].busy !== 0 || rows[0].log !== rows[0].checkpointed) {
+    throw new Error("Pi Workflows state is busy; stop its writers and retry the upgrade");
+  }
+}
+
+function copyAndVerifyBackup(
+  sourceDatabase: Database.Database,
+  sourcePath: string,
+  backupPath: string,
+): boolean {
+  fs.mkdirSync(path.dirname(backupPath), { recursive: true, mode: 0o700 });
+  fs.copyFileSync(sourcePath, backupPath, fs.constants.COPYFILE_EXCL);
+  fs.chmodSync(backupPath, 0o600);
+  if (fileSha256(sourcePath) !== fileSha256(backupPath)) {
+    throw new Error("State upgrade backup does not match the stable source database");
+  }
+  const backup = new Database(backupPath, { readonly: true, fileMustExist: true });
+  try {
+    backup.pragma("foreign_keys = ON");
+    verifyPreViewerSchema(backup);
+    verifyIntegrity(backup);
+  } finally {
+    backup.close();
+  }
+  verifyPreViewerSchema(sourceDatabase);
+  return true;
+}
+
+function backfillReplayCheckpoints(database: Database.Database): number {
+  const runRows = database
+    .prepare("SELECT DISTINCT run_id AS runId FROM session_events ORDER BY run_id")
+    .all();
+  const pageStatement = database.prepare(
+    `SELECT e.run_id AS runId, e.run_seq AS runSeq, e.event_type AS eventType,
+            e.node_id AS nodeId, e.attempt_id AS attemptId, e.turn_id AS turnId,
+            e.message_id AS messageId, e.tool_call_id AS toolCallId,
+            b.content AS payloadContent, b.media_type AS payloadMediaType,
+            e.recorded_at AS recordedAt
+     FROM session_events e
+     JOIN blobs b ON b.blob_hash = e.payload_hash
+     WHERE e.run_id = ? AND e.run_seq > ?
+     ORDER BY e.run_seq LIMIT ?`,
+  );
+  let checkpointCount = 0;
+  for (const runValue of runRows) {
+    if (!isRunIdRow(runValue)) throw new Error("State upgrade found an invalid run row");
+    let checkpoint: TemporalSessionState = reduceSessionEvents([], [], 0);
+    let afterSequence = 0;
+    while (true) {
+      const values = pageStatement.all(runValue.runId, afterSequence, VIEWER_PAGE_SIZE);
+      if (values.length < VIEWER_PAGE_SIZE) break;
+      const page = values.map(sessionEventUpgradeRecord);
+      const last = page.at(-1);
+      if (last === undefined) throw new Error("State upgrade found an empty replay page");
+      checkpoint = reduceSessionEventsFromCheckpoint([], page, last.seq, checkpoint);
+      checkpoint = boundedTemporalCheckpoint(checkpoint);
+      const recordedAt = Date.parse(last.at);
+      if (!Number.isFinite(recordedAt)) {
+        throw new Error("State upgrade found an invalid session event timestamp");
+      }
+      putReplayCheckpoint(database, runValue.runId, last.seq, checkpoint, recordedAt);
+      checkpointCount += 1;
+      afterSequence = last.seq;
+    }
+  }
+  return checkpointCount;
+}
+
+function sessionEventUpgradeRecord(value: unknown): WorkflowSessionEventRecord {
+  if (!isSessionEventUpgradeRow(value)) {
+    throw new Error("State upgrade found an invalid session event row");
+  }
+  if (value.payloadMediaType !== "application/json") {
+    throw new Error("State upgrade found a session event payload with the wrong media type");
+  }
+  const payload = parseJson(value.payloadContent.toString("utf8"));
+  if (!isRecord(payload)) {
+    throw new Error("State upgrade found a session event payload that is not an object");
+  }
+  return {
+    seq: value.runSeq,
+    at: new Date(value.recordedAt).toISOString(),
+    nodeId: value.nodeId,
+    attemptId: value.attemptId,
+    ...(value.turnId === null ? {} : { turnId: value.turnId }),
+    ...(value.messageId === null ? {} : { messageId: value.messageId }),
+    ...(value.toolCallId === null ? {} : { toolCallId: value.toolCallId }),
+    type: sessionEventType(value.eventType),
+    payload,
+  };
+}
+
+function putReplayCheckpoint(
+  database: Database.Database,
+  runId: string,
+  eventSequence: number,
+  checkpoint: TemporalSessionState,
+  recordedAt: number,
+): void {
+  const content = Buffer.from(canonicalJson(checkpoint), "utf8");
+  const hash = createHash("sha256").update(content).digest();
+  database
+    .prepare(
+      `INSERT INTO blobs(blob_hash, media_type, byte_length, content, created_at)
+       VALUES (?, 'application/json', ?, ?, ?)
+       ON CONFLICT(blob_hash) DO NOTHING`,
+    )
+    .run(hash, content.byteLength, content, recordedAt);
+  const row = database
+    .prepare(
+      `SELECT media_type AS mediaType, byte_length AS byteLength, content
+       FROM blobs WHERE blob_hash = ?`,
+    )
+    .get(hash);
+  if (
+    !isBlobRow(row) ||
+    row.mediaType !== "application/json" ||
+    row.byteLength !== content.byteLength ||
+    !row.content.equals(content)
+  ) {
+    throw new Error("State upgrade found a replay checkpoint blob conflict");
+  }
+  database
+    .prepare(
+      `INSERT INTO viewer_session_checkpoints(run_id, event_seq, state_hash, recorded_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(runId, eventSequence, hash, recordedAt);
+}
+
+function verifyIntegrity(database: Database.Database): void {
+  const integrity = database.pragma("integrity_check", { simple: true });
+  if (integrity !== "ok") throw new Error("Pi Workflows SQLite integrity check failed");
+  const foreignKeys = database.pragma("foreign_key_check");
+  if (!Array.isArray(foreignKeys) || foreignKeys.length !== 0) {
+    throw new Error("Pi Workflows SQLite foreign-key check failed");
+  }
+}
+
+function rowCount(database: Database.Database, table: string): number {
+  if (!/^[a-z_]+$/.test(table)) throw new Error("Invalid state table name");
+  const row = database.prepare(`SELECT count(*) AS count FROM ${table}`).get();
+  if (!isCountRow(row)) throw new Error(`State upgrade count is invalid for ${table}`);
+  return row.count;
+}
+
+function tableDigest(database: Database.Database, sql: string): string {
+  const hash = createHash("sha256");
+  for (const row of database.prepare(sql).iterate()) {
+    hash.update(canonicalJson(row));
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
+function fileSha256(filePath: string): string {
+  const descriptor = fs.openSync(filePath, "r");
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    let bytesRead = 0;
+    do {
+      bytesRead = fs.readSync(descriptor, buffer, 0, buffer.byteLength, null);
+      if (bytesRead > 0) hash.update(buffer.subarray(0, bytesRead));
+    } while (bytesRead > 0);
+    return hash.digest("hex");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function tableExists(database: Database.Database, table: string): boolean {
+  return (
+    database.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?").get(table) !==
+    undefined
+  );
+}
+
+function assertTableColumns(
+  database: Database.Database,
+  table: string,
+  expected: readonly string[],
+): void {
+  const columns = database.pragma(`table_info(${table})`);
+  if (!Array.isArray(columns)) throw new Error(`State upgrade cannot inspect ${table}`);
+  const names = columns.map((value) => {
+    if (!isRecord(value) || typeof value.name !== "string") {
+      throw new Error(`State upgrade found an invalid ${table} column`);
+    }
+    return value.name;
+  });
+  if (canonicalJson(names) !== canonicalJson(expected)) {
+    throw new Error(`State upgrade found an unsupported ${table} shape`);
+  }
+}
+
+function expectedSchemaShape(): string {
+  if (expectedShape !== undefined) return expectedShape;
+  const database = new Database(":memory:");
+  try {
+    database.pragma("foreign_keys = ON");
+    database.exec(STATE_SCHEMA_SQL);
+    expectedShape = schemaShape(database);
+    return expectedShape;
+  } finally {
+    database.close();
+  }
+}
+
+function schemaShape(database: Database.Database): string {
+  const rows = database
+    .prepare(
+      `SELECT type, name, tbl_name AS tableName, sql
+       FROM sqlite_schema
+       WHERE name NOT LIKE 'sqlite_%'
+       ORDER BY type, name`,
+    )
+    .all();
+  const normalized: SchemaObjectRow[] = [];
+  for (const row of rows) {
+    if (!isSchemaObjectRow(row)) {
+      throw new Error("Pi Workflows database contains an invalid schema object");
+    }
+    normalized.push(row);
+  }
+  return createHash("sha256").update(canonicalJson(normalized)).digest("hex");
+}
+
+function sessionEventType(value: string): WorkflowSessionEventType {
+  switch (value) {
+    case "turn_started":
+    case "turn_finished":
+    case "message_started":
+    case "assistant_event":
+    case "message_finished":
+    case "tool_execution_started":
+    case "tool_execution_finished":
+      return value;
+    default:
+      throw new Error(`State upgrade found an unknown session event type: ${value}`);
+  }
+}
+
+function isSchemaMetaRow(value: unknown): value is SchemaMetaRow {
+  return (
+    isRecord(value) &&
+    typeof value.schemaName === "string" &&
+    typeof value.schemaVersion === "number" &&
+    Buffer.isBuffer(value.schemaDigest) &&
+    typeof value.appVersion === "string"
+  );
+}
+
+function isCountRow(value: unknown): value is CountRow {
+  return isRecord(value) && typeof value.count === "number";
+}
+
+function isCheckpointResult(
+  value: unknown,
+): value is { busy: number; log: number; checkpointed: number } {
+  return (
+    isRecord(value) &&
+    typeof value.busy === "number" &&
+    typeof value.log === "number" &&
+    typeof value.checkpointed === "number"
+  );
+}
+
+function isRunIdRow(value: unknown): value is RunIdRow {
+  return isRecord(value) && typeof value.runId === "string";
+}
+
+function isSessionEventUpgradeRow(value: unknown): value is SessionEventUpgradeRow {
+  return (
+    isRecord(value) &&
+    typeof value.runId === "string" &&
+    typeof value.runSeq === "number" &&
+    typeof value.eventType === "string" &&
+    typeof value.nodeId === "string" &&
+    typeof value.attemptId === "string" &&
+    (typeof value.turnId === "string" || value.turnId === null) &&
+    (typeof value.messageId === "string" || value.messageId === null) &&
+    (typeof value.toolCallId === "string" || value.toolCallId === null) &&
+    Buffer.isBuffer(value.payloadContent) &&
+    typeof value.payloadMediaType === "string" &&
+    typeof value.recordedAt === "number"
+  );
+}
+
+function isBlobRow(value: unknown): value is BlobRow {
+  return (
+    isRecord(value) &&
+    typeof value.mediaType === "string" &&
+    typeof value.byteLength === "number" &&
+    Buffer.isBuffer(value.content)
+  );
+}
+
+function isSchemaObjectRow(value: unknown): value is SchemaObjectRow {
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    typeof value.name === "string" &&
+    typeof value.tableName === "string" &&
+    typeof value.sql === "string"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -21,6 +21,7 @@ import {
 import { compositionMetadata } from "./composition.js";
 import { applyJsonPatch, validateJsonPatch } from "./json-patch.js";
 import {
+  boundedTemporalCheckpoint,
   reduceSessionEvents,
   reduceSessionEventsFromCheckpoint,
   type TemporalSessionState,
@@ -4119,20 +4120,6 @@ function isTemporalSessionState(value: unknown): value is TemporalSessionState {
     Array.isArray(value.diagnostics) &&
     value.diagnostics.every((item) => typeof item === "string")
   );
-}
-
-function boundedTemporalCheckpoint(state: TemporalSessionState): TemporalSessionState {
-  const messages = state.messages.filter((message) => message.status === "streaming");
-  const activeMessages = new Set(messages.map((message) => message.messageId));
-  return {
-    ...state,
-    messages,
-    tools: state.tools.filter(
-      (tool) => tool.status === "running" && activeMessages.has(tool.messageId),
-    ),
-    settledEntryIds: [],
-    diagnostics: ["earlier session messages are outside this page"],
-  };
 }
 
 function assertValidRunId(runId: string): void {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -32,6 +32,15 @@ describe("pi-workflows CLI", () => {
       backupDestination: "/tmp/state-backup.sqlite",
     });
     expect(
+      parseCliArgs(["state", "upgrade", "--backup", "/tmp/state-before-viewer.sqlite", "--apply"]),
+    ).toMatchObject({
+      command: "state",
+      stateAction: "upgrade",
+      backupDestination: "/tmp/state-before-viewer.sqlite",
+      pruneApply: true,
+    });
+    expect(() => parseCliArgs(["state", "upgrade", "--apply"])).toThrow(/requires --backup/);
+    expect(
       parseCliArgs([
         "state",
         "prune",

--- a/test/state-upgrade.test.ts
+++ b/test/state-upgrade.test.ts
@@ -1,0 +1,339 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import workflow from "../examples/workflows/echo.workflow.js";
+import { StateDatabase } from "../src/state/database.js";
+import { PRE_VIEWER_STATE_SCHEMA_DIGEST } from "../src/state/schema.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
+import { upgradePreViewerStateDatabase } from "../src/workflows/state-upgrade.js";
+import {
+  SESSION_BINDING_SCHEMA,
+  SESSION_CAPTURE_SCHEMA,
+  SESSION_EVENT_SCHEMA,
+  WorkflowRunStore,
+} from "../src/workflows/store.js";
+import { ScriptedExecutor, makeStateDatabasePath } from "./helpers.js";
+
+const OLD_SESSION_SCHEMA_SQL = String.raw`
+CREATE TEMP TABLE state_test_session_entries AS
+SELECT segment_id, entry_seq, entry_id, entry_hash, recorded_at FROM session_entries;
+DROP TABLE session_entries;
+CREATE TABLE session_entries (
+  segment_id TEXT NOT NULL REFERENCES session_segments(segment_id) ON DELETE CASCADE,
+  entry_seq INTEGER NOT NULL CHECK (entry_seq > 0),
+  entry_id TEXT NOT NULL,
+  entry_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (segment_id, entry_seq),
+  UNIQUE (segment_id, entry_id)
+) STRICT;
+INSERT INTO session_entries(segment_id, entry_seq, entry_id, entry_hash, recorded_at)
+SELECT segment_id, entry_seq, entry_id, entry_hash, recorded_at
+FROM state_test_session_entries;
+DROP TABLE state_test_session_entries;
+
+CREATE TEMP TABLE state_test_session_events AS
+SELECT segment_id, event_seq, event_type, node_id, attempt_id, turn_id,
+       message_id, tool_call_id, payload_hash, recorded_at FROM session_events;
+DROP TABLE session_events;
+CREATE TABLE session_events (
+  segment_id TEXT NOT NULL REFERENCES session_segments(segment_id) ON DELETE CASCADE,
+  event_seq INTEGER NOT NULL CHECK (event_seq > 0),
+  event_type TEXT NOT NULL,
+  node_id TEXT,
+  attempt_id TEXT,
+  turn_id TEXT,
+  message_id TEXT,
+  tool_call_id TEXT,
+  payload_hash BLOB NOT NULL REFERENCES blobs(blob_hash),
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (segment_id, event_seq)
+) STRICT;
+INSERT INTO session_events(
+  segment_id, event_seq, event_type, node_id, attempt_id, turn_id,
+  message_id, tool_call_id, payload_hash, recorded_at
+)
+SELECT segment_id, event_seq, event_type, node_id, attempt_id, turn_id,
+       message_id, tool_call_id, payload_hash, recorded_at
+FROM state_test_session_events;
+DROP TABLE state_test_session_events;
+`;
+
+async function makePreViewerDatabase(label: string): Promise<string> {
+  const databasePath = await makeStateDatabasePath(label);
+  const result = await new WorkflowEngine({
+    databasePath,
+    executor: new ScriptedExecutor().respond("reply", { output: { reply: "done" } }),
+  }).run(workflow, { task: "preserve" });
+  const attemptId = result.state.steps[0]?.attemptId;
+  if (attemptId === undefined) throw new Error("test workflow attempt is missing");
+  const store = new WorkflowRunStore(databasePath);
+  const binding = {
+    schema: SESSION_BINDING_SCHEMA,
+    runId: result.runId,
+    piSessionId: "preserved-session",
+    cwd: "/tmp/preserved-project",
+    boundAt: "2026-08-28T00:00:00.000Z",
+  } as const;
+  await store.writeSessionBinding(result.runId, binding);
+  await store.appendSessionEntry(result.runId, { id: "preserved-entry", type: "message" });
+  await store.appendSessionEventBatch(
+    result.runId,
+    Array.from({ length: 300 }, (_, index) => ({
+      seq: index + 1,
+      at: new Date(Date.parse("2026-08-28T00:00:01.000Z") + index).toISOString(),
+      nodeId: "reply",
+      attemptId,
+      turnId: `turn-${index + 1}`,
+      type: "turn_started" as const,
+      payload: { turnIndex: index + 1 },
+    })),
+  );
+  await store.writeSessionCapture(result.runId, {
+    schema: SESSION_CAPTURE_SCHEMA,
+    eventSchema: SESSION_EVENT_SCHEMA,
+    status: "complete",
+    eventCount: 300,
+    entryCount: 1,
+    lastEventSeq: 300,
+  });
+  await store.writeSessionBinding(
+    result.runId,
+    {
+      ...binding,
+      piSessionId: "preserved-attempt-session",
+      boundAt: "2026-08-28T00:00:02.000Z",
+    },
+    attemptId,
+  );
+  await store.appendSessionEntry(
+    result.runId,
+    { id: "preserved-attempt-entry", type: "message" },
+    attemptId,
+  );
+  await store.appendSessionEventBatch(
+    result.runId,
+    [
+      {
+        seq: 1,
+        at: "2026-08-28T00:00:03.000Z",
+        nodeId: "reply",
+        attemptId,
+        turnId: "attempt-turn",
+        type: "turn_finished",
+        payload: { turnIndex: 301 },
+      },
+    ],
+    attemptId,
+  );
+  await store.writeSessionCapture(
+    result.runId,
+    {
+      schema: SESSION_CAPTURE_SCHEMA,
+      eventSchema: SESSION_EVENT_SCHEMA,
+      status: "complete",
+      eventCount: 1,
+      entryCount: 1,
+      lastEventSeq: 1,
+    },
+    attemptId,
+  );
+  store.state.connection
+    .prepare(
+      `INSERT INTO attempt_entries(attempt_id, role, segment_id, entry_id)
+       SELECT ?, 'prompt', segment_id, 'preserved-attempt-entry'
+       FROM session_entries WHERE entry_id = 'preserved-attempt-entry'`,
+    )
+    .run(attemptId);
+  store.close();
+
+  const database = new Database(databasePath);
+  try {
+    database.pragma("foreign_keys = OFF");
+    database.exec("BEGIN EXCLUSIVE");
+    database.exec(
+      "DROP TABLE viewer_session_checkpoints; DROP TABLE viewer_deltas; DROP TABLE viewer_runs;",
+    );
+    database.exec(OLD_SESSION_SCHEMA_SQL);
+    database
+      .prepare("UPDATE schema_meta SET schema_digest = ? WHERE id = 1")
+      .run(PRE_VIEWER_STATE_SCHEMA_DIGEST);
+    database.exec("COMMIT");
+    database.pragma("foreign_keys = ON");
+    expect(database.pragma("foreign_key_check")).toEqual([]);
+  } finally {
+    database.close();
+  }
+  return databasePath;
+}
+
+function sha256(filePath: string): string {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+describe("pre-viewer state upgrade", () => {
+  it("preserves runs and session rows while backfilling bounded viewer state", async () => {
+    const databasePath = await makePreViewerDatabase("state-upgrade");
+    const backupPath = path.join(path.dirname(databasePath), "state-before-viewer.sqlite");
+
+    expect(() => new StateDatabase({ filePath: databasePath, mode: "read-only" })).toThrow(
+      /state upgrade/,
+    );
+    const report = upgradePreViewerStateDatabase(databasePath, backupPath);
+
+    expect(report).toMatchObject({
+      backupPath,
+      runs: 1,
+      sessionEntries: 2,
+      sessionEvents: 301,
+      replayCheckpoints: 1,
+    });
+    expect(report.backupSha256).toBe(sha256(backupPath));
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-only" });
+    try {
+      state.integrityCheck();
+      expect(
+        state.connection
+          .prepare(
+            `SELECT presentation_revision AS presentationRevision,
+                    retained_from_revision AS retainedFromRevision
+             FROM viewer_runs`,
+          )
+          .all(),
+      ).toEqual([{ presentationRevision: 1, retainedFromRevision: 1 }]);
+      expect(
+        state.connection
+          .prepare("SELECT min(run_seq) AS first, max(run_seq) AS last FROM session_events")
+          .get(),
+      ).toEqual({ first: 1, last: 301 });
+      expect(
+        state.connection
+          .prepare("SELECT event_seq AS eventSeq FROM viewer_session_checkpoints")
+          .all(),
+      ).toEqual([{ eventSeq: 256 }]);
+      expect(
+        state.connection
+          .prepare("SELECT entry_id AS entryId FROM attempt_entries WHERE role = 'prompt'")
+          .all(),
+      ).toEqual([{ entryId: "preserved-attempt-entry" }]);
+      expect(state.connection.prepare("SELECT count(*) AS count FROM viewer_deltas").get()).toEqual(
+        {
+          count: 0,
+        },
+      );
+    } finally {
+      state.close();
+    }
+    expect(() =>
+      upgradePreViewerStateDatabase(
+        databasePath,
+        path.join(path.dirname(databasePath), "second-backup.sqlite"),
+      ),
+    ).toThrow(/already uses/);
+    await new WorkflowEngine({
+      databasePath,
+      executor: new ScriptedExecutor().respond("reply", { output: { reply: "after upgrade" } }),
+    }).run(workflow, { task: "after upgrade" });
+    const reopened = new StateDatabase({ filePath: databasePath, mode: "read-only" });
+    try {
+      expect(reopened.connection.prepare("SELECT count(*) AS count FROM runs").get()).toEqual({
+        count: 2,
+      });
+      expect(
+        reopened.connection.prepare("SELECT count(*) AS count FROM viewer_runs").get(),
+      ).toEqual({ count: 2 });
+    } finally {
+      reopened.close();
+    }
+
+    const backup = new Database(backupPath, { readonly: true });
+    try {
+      expect(backup.prepare("SELECT count(*) AS count FROM runs").get()).toEqual({ count: 1 });
+      expect(backup.prepare("SELECT count(*) AS count FROM session_events").get()).toEqual({
+        count: 301,
+      });
+      expect(
+        backup.prepare("SELECT 1 FROM sqlite_schema WHERE name = 'viewer_runs'").get(),
+      ).toBeUndefined();
+    } finally {
+      backup.close();
+    }
+  });
+
+  it("refuses active writers before creating a backup", async () => {
+    const databasePath = await makePreViewerDatabase("state-upgrade-active");
+    const backupPath = path.join(path.dirname(databasePath), "state-before-viewer.sqlite");
+    const database = new Database(databasePath);
+    try {
+      database
+        .prepare(
+          `UPDATE leases SET generation = generation + 1, owner_type = 'host', owner_id = 'active',
+             token_hash = zeroblob(32), acquired_at = ?, heartbeat_at = ?, expires_at = ?
+           WHERE resource_id = (SELECT resource_id FROM runs LIMIT 1)`,
+        )
+        .run(Date.now(), Date.now(), Date.now() + 60_000);
+    } finally {
+      database.close();
+    }
+
+    expect(() => upgradePreViewerStateDatabase(databasePath, backupPath)).toThrow(
+      /Stop all active/,
+    );
+    expect(fs.existsSync(backupPath)).toBe(false);
+  });
+
+  it("rolls back a failed backfill and keeps its verified backup", async () => {
+    const databasePath = await makePreViewerDatabase("state-upgrade-rollback");
+    const backupPath = path.join(path.dirname(databasePath), "state-before-viewer.sqlite");
+    const database = new Database(databasePath);
+    try {
+      database
+        .prepare("UPDATE session_events SET event_type = 'unsupported' WHERE rowid = 1")
+        .run();
+    } finally {
+      database.close();
+    }
+
+    expect(() => upgradePreViewerStateDatabase(databasePath, backupPath)).toThrow(/unknown/);
+    expect(fs.existsSync(backupPath)).toBe(true);
+    const rolledBack = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        rolledBack.prepare("SELECT 1 FROM sqlite_schema WHERE name = 'viewer_runs'").get(),
+      ).toBeUndefined();
+      expect(
+        rolledBack
+          .prepare("SELECT hex(schema_digest) AS digest FROM schema_meta WHERE id = 1")
+          .get(),
+      ).toEqual({ digest: PRE_VIEWER_STATE_SCHEMA_DIGEST.toString("hex").toUpperCase() });
+    } finally {
+      rolledBack.close();
+    }
+  });
+
+  it("rejects an unsupported source shape before creating a backup", async () => {
+    const databasePath = await makePreViewerDatabase("state-upgrade-shape");
+    const backupPath = path.join(path.dirname(databasePath), "state-before-viewer.sqlite");
+    const database = new Database(databasePath);
+    try {
+      database.exec("CREATE TABLE unsupported_state(value TEXT) STRICT;");
+    } finally {
+      database.close();
+    }
+
+    expect(() => upgradePreViewerStateDatabase(databasePath, backupPath)).toThrow(
+      /exact supported/,
+    );
+    expect(fs.existsSync(backupPath)).toBe(false);
+    const rolledBack = new Database(databasePath, { readonly: true });
+    try {
+      expect(
+        rolledBack.prepare("SELECT 1 FROM sqlite_schema WHERE name = 'viewer_runs'").get(),
+      ).toBeUndefined();
+    } finally {
+      rolledBack.close();
+    }
+  });
+});


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

The incremental viewer schema initially required deleting old workflow state.
This change preserves runs from the exact Pi Workflows 0.14.0 schema through one explicit, transactional upgrade.
It makes and verifies a stable backup first, then backfills the run-wide session sequences and replay checkpoints that the new viewer needs.

## What Changed

The normal runtime still accepts only the current schema.
The new maintenance path is narrow and refuses unknown schemas or active writers.

- Added `pi-workflows state upgrade --backup <absolute-path> --apply`.
- Detects the exact pre-viewer schema by metadata digest, changed table columns, and full schema shape.
- Checkpoints the WAL, takes an exclusive lock, and writes a byte-identical verified backup before mutation.
- Rebuilds `session_entries` and `session_events` with deterministic run-wide sequence numbers.
- Adds `viewer_runs`, `viewer_deltas`, and `viewer_session_checkpoints` in one transaction.
- Gives preserved runs presentation revision 1 and backfills replay checkpoints at complete 256-event boundaries.
- Verifies session row content, counts, exact final schema, integrity, and foreign keys before commit.
- Rolls back the source database on failure and keeps a completed backup.
- Gives old-schema runtime opens a clear upgrade instruction instead of a reset-only message.

## Testing

The upgrade passed synthetic rollback, active-writer, dependent-foreign-key, replay-checkpoint, and post-upgrade writer tests.
It also upgraded an SQLite backup copy of the current live database; the live database was not written.

- Copy result: 56 runs, 16,191 session entries, 80,678 session events, and 287 replay checkpoints.
- The migrated copy passed integrity and foreign-key checks.
- The source-built `piw` loaded all 56 runs and completed a jump from live state to the start of replay.
- The verified pre-upgrade backup stayed on the old schema with all 56 runs.
- `npm run check`
- `npm run test:e2e`
- `cargo fmt --check --manifest-path tui/Cargo.toml`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml --no-fail-fast`
- `npm run fixtures` twice with no diff
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `git diff --check`

SimpleDoc still reports the repository's nine pre-existing rename and frontmatter findings.

## Risks

The command changes durable state, so it requires an explicit backup path and `--apply`.
It refuses active leases and every schema except the exact supported predecessor.
The upgrade is not automatic and does not add runtime compatibility reads or dual writes.
