### PR TITLE
fix(test): remove temporary workflow fixtures

### DIFF
--- a/test/builtin-autoimplement.test.ts
+++ b/test/builtin-autoimplement.test.ts
@@ -1,6 +1,5 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -306,7 +305,7 @@ function addRedesignResponses(executor: ScriptedExecutor, plans: unknown[]): Scr
 
 beforeEach(async () => {
   originalPath = process.env.PATH ?? "";
-  commandDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-workflows-commands-"));
+  commandDir = await makeTempDir("pi-workflows-commands");
   repository = await makeTempDir("pi-workflows-autoimplement-repo");
   await git(repository, ["init", "-b", "main"]);
   await git(repository, ["config", "user.name", "Test"]);

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const TEST_TEMP_ROOT_ENV = "PI_WORKFLOWS_TEST_TEMP_ROOT";
+
+let ownedRoot: string | undefined;
+let previousRoot: string | undefined;
+
+export function setup(): void {
+  previousRoot = process.env[TEST_TEMP_ROOT_ENV];
+  if (previousRoot !== undefined) return;
+
+  ownedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pi-workflows-tests-"));
+  process.env[TEST_TEMP_ROOT_ENV] = ownedRoot;
+}
+
+export function teardown(): void {
+  if (ownedRoot !== undefined) {
+    fs.rmSync(ownedRoot, { force: true, recursive: true });
+    ownedRoot = undefined;
+  }
+  if (previousRoot === undefined) delete process.env[TEST_TEMP_ROOT_ENV];
+  else process.env[TEST_TEMP_ROOT_ENV] = previousRoot;
+  previousRoot = undefined;
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { canonicalJson } from "../src/state/json.js";
 import { resourceIdFor } from "../src/state/mutation.js";
@@ -13,9 +12,18 @@ import type {
   HumanDecisionPrompt,
   HumanDecisionRequest,
 } from "../src/workflows/types.js";
+import { TEST_TEMP_ROOT_ENV } from "./global-setup.js";
 
 export async function makeTempDir(prefix: string): Promise<string> {
-  return await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  const root = process.env[TEST_TEMP_ROOT_ENV];
+  if (root === undefined) {
+    throw new Error(`Test temporary root is not configured: ${TEST_TEMP_ROOT_ENV}`);
+  }
+  if (path.basename(prefix) !== prefix) {
+    throw new Error(`Test temporary directory prefix must be one path segment: ${prefix}`);
+  }
+  await fs.mkdir(root, { recursive: true });
+  return await fs.mkdtemp(path.join(root, `${prefix}-`));
 }
 
 export async function makeStateDatabasePath(prefix: string): Promise<string> {

--- a/test/monitor-human-approval.test.ts
+++ b/test/monitor-human-approval.test.ts
@@ -1,6 +1,5 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -324,7 +323,7 @@ beforeEach(async () => {
   await execFileAsync("git", ["add", "README.md"], { cwd: repository });
   await execFileAsync("git", ["commit", "-m", "fixture"], { cwd: repository });
   await execFileAsync("git", ["switch", "-c", "feat/repair"], { cwd: repository });
-  const commands = await fs.mkdtemp(path.join(os.tmpdir(), "monitor-approval-commands-"));
+  const commands = await makeTempDir("monitor-approval-commands");
   await fs.writeFile(path.join(commands, "pi-reviewer"), "#!/bin/sh\necho clean\n", {
     mode: 0o755,
   });

--- a/test/monitor-repair.test.ts
+++ b/test/monitor-repair.test.ts
@@ -1,6 +1,5 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -253,7 +252,7 @@ function repairExecutor(secondObservation: unknown): ScriptedExecutor {
 
 beforeEach(async () => {
   originalPath = process.env.PATH ?? "";
-  const commandDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-workflows-monitor-commands-"));
+  const commandDir = await makeTempDir("pi-workflows-monitor-commands");
   repository = await makeTempDir("pi-workflows-monitor-repo");
   await execFileAsync("git", ["init", "-b", "main"], { cwd: repository });
   await execFileAsync("git", ["config", "user.name", "Test"], { cwd: repository });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     ],
   },
   test: {
+    globalSetup: ["./test/global-setup.ts"],
     testTimeout: 15_000,
     include: ["test/**/*.test.ts"],
     exclude: ["test/e2e/**", "node_modules/**"],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     },
   },
   test: {
+    globalSetup: ["./test/global-setup.ts"],
     include: ["test/e2e/**/*.e2e.test.ts"],
     testTimeout: 120_000,
     hookTimeout: 60_000,


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Every test run left hundreds of workflow fixture directories in `/tmp`.
Repeated local and CI-style runs accumulated more than 32,000 stale directories and contributed to disk exhaustion.
This change puts helper-created fixtures under one suite directory and removes that directory after the suite finishes.

## What Changed

The leak was in the shared test helper, not the production workflow host or Pi sessions.
The test helper created a new top-level directory for each fixture and had no matching cleanup.

- Added one temporary root for each unit or E2E Vitest suite.
- Added global teardown that recursively removes the suite root.
- Made `makeTempDir()` require and use the managed suite root.
- Converted three direct command fixture directories to use the managed helper.
- Kept the direct temporary directories that already have explicit `finally` or `afterEach` cleanup unchanged.

## Testing

The full unit and E2E suites pass and no new top-level workflow fixture directory remains after either command.
The pre-existing directory count stayed at 365 before and after each full run, and the managed suite-root count returned to zero.

- `npm run check` — 85 files and 1,068 tests passed.
- `npm run test:e2e` — 3 files and 9 tests passed.
- `npx slophammer-ts@latest dry .` — 0 candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — no findings.
- `git diff --check` — passed.

## Risks

The change affects test fixtures only.
Vitest global teardown runs after file-level teardown, so temporary workflow hosts can stop before their files are removed.
An operating-system kill that prevents all process cleanup can still leave one suite root, but a normal run no longer leaves hundreds of directories.
