### PR TITLE
test: add installed package live end-to-end checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,34 @@ jobs:
       - name: End-to-end tests (mock provider, real pi runtime)
         run: npm run test:e2e
 
+  installed-e2e:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tui
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Installed-package end-to-end test
+        run: npm run test:e2e:live -- --runtime-only
+
   tui:
     runs-on: ubuntu-24.04
     permissions:

--- a/docs/2026-09-02-installed-live-e2e-plan.md
+++ b/docs/2026-09-02-installed-live-e2e-plan.md
@@ -1,0 +1,225 @@
+---
+title: Test installed workflows end to end
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-09-02
+---
+
+# Test installed workflows end to end
+
+## Goal
+
+Add one black-box test runner that starts base Pi with only the packed Pi Workflows package. The runner will execute a workflow through the package-owned host and check Pi's workflow widget throughout its lifecycle. It will also check the Rust `piw` client. A separate phase can use a real model.
+
+The runner must keep the Pi provider and model as separate exact values. It must work with Pi's built-in providers instead of containing OpenAI-specific model logic.
+
+## Provider boundary
+
+Pi has two distinct OpenAI providers.
+
+- `openai-codex` uses ChatGPT Plus or Pro subscription credentials. Its GPT-5.6 models use the `openai-codex-responses` API against the ChatGPT backend.
+- `openai` uses an OpenAI API key. Its GPT-5.6 models use the `openai-responses` API against `api.openai.com`.
+
+The current base Pi catalog includes `gpt-5.6-luna` under both providers. These are separate provider and model pairs:
+
+```text
+provider=openai-codex model=gpt-5.6-luna
+provider=openai       model=gpt-5.6-luna
+```
+
+The runner will require both `--provider` and `--model` for a real-model run. It will pass them to Pi as separate arguments and then query Pi's RPC state. The selected provider and model id must match the request. The selected API must match that exact pair. The runner will never accept Pi's model fallback.
+
+Any built-in Pi provider can be used when its normal authentication is ready and its selected model can call tools. The runner will not write a `models.json` file or register a custom provider.
+
+## Base Pi and resource isolation
+
+The runner will invoke the `@earendil-works/pi-coding-agent` package entry point directly. It will not invoke the `pi` command found in `PATH`, because that command can be a wrapper that adds personal packages or restart behavior.
+
+The default entry point will come from the repository's pinned Pi dependency. An optional `--pi-entry` argument will allow a pre-release check against another installed base Pi version.
+
+Each run will use:
+
+- one temporary home directory;
+- one temporary project;
+- one temporary session directory;
+- one temporary package installation;
+- either a temporary Pi agent directory or a dedicated user-supplied test profile.
+
+Pi will start with `--no-skills`, `--no-themes`, `--no-prompt-templates`, `--no-context-files`, and `--no-builtin-tools`. The runner must not use `--no-extensions`, because that would also disable Pi Workflows.
+
+After startup, the runner will call RPC `get_commands`. The `workflow`, `controller`, and `piw` commands must come from the packed Pi Workflows package. Any other user or project extension is a failure. Base Pi's own inline commands are allowed.
+
+## Installed package test
+
+The test must use the npm package that would be published, including its file allowlist and production dependencies.
+
+The runner will:
+
+1. Run `npm pack` into the temporary root.
+2. Install that archive into a temporary consumer project with `npm install --omit=dev`.
+3. Find the resulting `@osolmaz/pi-workflows` package directory.
+4. Run base Pi's `install` command against that installed directory.
+5. Start Pi and verify the extension command source paths point into that directory.
+
+Passing the `.tgz` file directly to `pi install` is not valid. Pi treats that file as an extension path. Pointing Pi at an extracted package before its dependencies are installed also fails because `better-sqlite3` is absent. The temporary consumer installation avoids both errors and tests the same dependency layout as a normal npm install.
+
+## Authentication
+
+The runner will let base Pi resolve credentials through Pi's documented authentication rules. It will not read, print, copy, or rewrite credential values.
+
+### Subscription profile
+
+A subscription run will use a dedicated Pi test profile supplied with `--profile`. The operator logs in to that profile once with base Pi. For ChatGPT Plus or Pro, the requested provider is `openai-codex`.
+
+The profile must be dedicated to this smoke test. The runtime resource check will reject unrelated extensions. The run uses a temporary home and temporary workflow state. Its session directory is also temporary even when the profile is reused for OAuth credentials.
+
+### API key
+
+An API-key run can use an ephemeral agent directory. Pi receives the caller's existing environment and resolves the provider's normal variable, such as `OPENAI_API_KEY` for the `openai` provider. The runner will not name, inspect, or log the variable value.
+
+Before a model call, the runner will execute Pi's documented `auth check` command for the exact provider and model. It will stop before the workflow starts when authentication or model resolution fails.
+
+## Runtime workflow
+
+The first workflow does not call a model. It has one delayed compute step and a fixed final output.
+
+The runner will start it through Pi RPC and check the following sequence:
+
+1. The package-owned host starts on demand.
+2. RPC emits `setWidget` and `setStatus` for the `pi-workflows` key with `running` state.
+3. `/workflow pause` is accepted.
+4. The widget and status change to `paused`.
+5. Host status reports one parked run and no active workflow worker.
+6. `/workflow resume` is accepted.
+7. The widget and status return to `running`.
+8. The workflow completes with the fixed output.
+9. RPC clears the widget and status after completion.
+10. No `extension_error` event appears.
+
+This run proves package loading and client-to-host startup. It also proves supervised worker control and the RPC widget contract. The complete check uses no model usage.
+
+## Real-model workflow
+
+The second workflow has one structured agent step. Its prompt asks the selected model to submit one fixed object through the `workflow` tool. Built-in tools stay disabled, so the model sees the workflow tool without file or shell mutation tools.
+
+The runner will check:
+
+- Pi still reports the requested provider and model id, while its API matches that exact pair;
+- one durable workflow step message exists in the origin session;
+- the message has one request id and one current attempt id;
+- one submission is accepted for that attempt;
+- stale or duplicate session delivery does not appear;
+- the workflow completes with the fixed output;
+- the Pi turn settles and no extension error appears.
+
+The result will not claim one upstream API request. Pi or the provider can retry a request. The test proves one accepted workflow submission and one origin-session delivery.
+
+## Headless piw check
+
+The current Rust `piw` command requires a terminal. Add one production command-line option:
+
+```bash
+piw RUN_ID --once
+```
+
+`--once` will connect through the normal Rust client and wait for one complete run view. It will render one frame with the existing `piw` renderer and a Ratatui test backend. It will then print the plain frame and exit. A missing run, connection failure, protocol error, or snapshot timeout will return a nonzero exit code.
+
+The E2E runner will install the candidate Rust binary into the temporary root with `cargo install --path tui --root ... --locked`. It will call `piw RUN_ID --once` while the runtime workflow is active and after completion. The output must contain the exact run id, workflow name, step name, and current status.
+
+This option also gives operators a normal noninteractive way to capture one viewer frame. It is not a test-only protocol.
+
+## Runner interface
+
+Add one command:
+
+```bash
+npm run test:e2e:live -- [options]
+```
+
+Supported forms:
+
+```bash
+npm run test:e2e:live -- --runtime-only
+
+npm run test:e2e:live -- \
+  --profile ~/.config/pi-workflows-e2e/openai-codex \
+  --provider openai-codex \
+  --model gpt-5.6-luna
+
+npm run test:e2e:live -- \
+  --provider openai \
+  --model gpt-5.6-luna
+
+npm run test:e2e:live -- \
+  --profile /path/to/dedicated-profile \
+  --provider anthropic \
+  --model exact-model-id
+```
+
+A real-model run requires explicit provider and model arguments. `--runtime-only` makes no model call. The runner will not choose a default provider, infer a provider from a model name, or change the model after startup.
+
+## Cleanup and failure evidence
+
+The standalone runner will own one temporary root and remove it in a `finally` path. It will:
+
+- close the Pi RPC process;
+- stop the workflow host through the installed client;
+- wait for the host endpoint to disappear;
+- stop child workers started for the smoke workflows;
+- remove the npm consumer installation, sessions, workflow state, and fixture project.
+
+A normal failure will print a small diagnostic summary before cleanup. The summary will identify the failed phase and the software versions. It will also show the exact provider, model name, run id, host status, recent RPC event types, and bounded `piw` output. It will not print credentials, arbitrary environment values, or unrelated session content.
+
+An explicit `--keep` option can preserve the one temporary root for manual debugging. Without that option, failures must not leave stale test directories.
+
+## Automated tests
+
+Add tests for:
+
+- `piw --once` argument handling and one-frame rendering;
+- timeout, missing-run, and host connection failures;
+- packed npm installation with production dependencies;
+- extension source isolation in base Pi;
+- RPC widget and status transitions;
+- pause with no active worker;
+- resume and completion;
+- exact provider and model validation;
+- model fallback rejection;
+- cleanup after success and injected failure;
+- bounded and secret-free diagnostics.
+
+The existing mock-provider E2E suite remains the deterministic origin-session and model-tool gate. CI will run the new installed-package runner in `--runtime-only` mode. Real-provider runs stay manual because provider availability, subscription usage, API cost, and model behavior are external facts.
+
+## Release use
+
+Before a release:
+
+1. Run all repository checks.
+2. Run the installed-package test in `--runtime-only` mode.
+3. Run one real-model check with an explicit provider and model.
+4. Record the exact Pi version, package version, Rust version, provider, model id, API, and run result.
+5. Do not release after fallback, ambiguous delivery, duplicate session delivery, extension error, cleanup failure, or disagreement between Pi, the host, and `piw`.
+
+The GitHub publish jobs will continue to use deterministic checks. They must not receive a personal subscription credential or a broad API key.
+
+## Files
+
+Implementation will update:
+
+- `scripts/live-e2e.mjs`;
+- `test/fixtures/live-e2e/runtime.workflow.ts`;
+- `test/fixtures/live-e2e/model.workflow.ts`;
+- `package.json`;
+- `tui/src/main.rs`;
+- `tui/src/ui/mod.rs`;
+- Rust and TypeScript E2E tests;
+- `docs/workflows.md` and `docs/tui-viewer.md`.
+
+## Contract impact
+
+The runner creates only temporary Pi sessions and workflow state. A reusable subscription test profile is operator-owned and contains its own normal Pi authentication. The script does not change Pi session schemas, Pi internals, private APIs, or another repository.
+
+The implementation uses documented Pi package installation and CLI model selection. It uses `auth check`, RPC state, RPC command discovery, and RPC extension UI events. Workflow state remains behind the existing Pi Workflows client protocol. The only new public interface is `piw RUN_ID --once`.
+
+## Completion criteria
+
+The work is complete when a clean base Pi process loads only the packed Pi Workflows package. The deterministic runtime workflow must pass every widget and lifecycle check, while `piw --once` must agree with Pi and the host. An explicitly selected built-in model must complete the structured agent workflow. Cleanup must leave no process or large temporary directory, and all repository checks must pass.

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -28,6 +28,7 @@ cargo install pi-workflows
 
 - `piw` connects to the local package-owned workflow host. If the socket is absent, it runs the installed `pi-workflows host start` command.
 - `piw <runId>` opens one host-owned run view.
+- `piw <runId> --once` waits for that run, renders one complete 120 × 40 plain-text frame, and exits. It returns a nonzero status for host, protocol, missing-run, or snapshot-timeout failures.
 - `piw serve [--bind 127.0.0.1:9377]` relays each WebSocket connection to one host socket over the [live client protocol](live-replay-protocol.md). Only loopback addresses are accepted; use an SSH tunnel for remote viewing.
 - `piw --connect ws://…` reads from another `piw serve` process.
 - `piw --theme <name>` selects a theme for this invocation.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -800,3 +800,41 @@ const engine = new WorkflowEngine({
 });
 const { state } = await engine.run(workflow, { task: "..." });
 ```
+
+## Test the installed package
+
+The installed-package end-to-end test packs this repository and installs the
+archive with production dependencies in a temporary consumer project. It then
+starts the repository-pinned base Pi with only that Pi Workflows installation.
+The test checks command isolation, host startup, widget and status changes,
+pause, resume, completion, and `piw <runId> --once` output.
+
+Run the deterministic phase without a model call:
+
+```bash
+npm run test:e2e:live -- --runtime-only
+```
+
+A real-model phase is manual. Supply the exact Pi provider and model as separate
+values. The runner does not select a default or accept model fallback:
+
+```bash
+npm run test:e2e:live -- \
+  --provider openai \
+  --model gpt-5.6-luna
+```
+
+For subscription authentication, use a dedicated Pi profile that has no other
+extensions or resources:
+
+```bash
+npm run test:e2e:live -- \
+  --profile ~/.config/pi-workflows-e2e/openai-codex \
+  --provider openai-codex \
+  --model gpt-5.6-luna
+```
+
+The profile and normal provider environment remain operator-owned. The runner
+does not read, copy, print, or save credentials. It uses one guarded temporary
+root and removes that root after success or failure. Use `--keep` only when you
+need the isolated files for diagnosis.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",
-        "jiti": "^2.7.0"
+        "jiti": "^2.7.0",
+        "tsx": "^4.23.13"
       },
       "bin": {
         "pi-workflows": "dist/viewer/cli.js"
@@ -24,7 +25,6 @@
         "@vitest/coverage-istanbul": "^4.1.10",
         "oxfmt": "^0.59.0",
         "oxlint": "^1.74.0",
-        "tsx": "^4.23.1",
         "typebox": "^1.3.6",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
@@ -2839,7 +2839,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2856,7 +2855,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2873,7 +2871,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2890,7 +2887,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2907,7 +2903,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2924,7 +2919,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2941,7 +2935,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,7 +2951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2975,7 +2967,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2992,7 +2983,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3009,7 +2999,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3026,7 +3015,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3043,7 +3031,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3060,7 +3047,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3077,7 +3063,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3094,7 +3079,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3111,7 +3095,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3128,7 +3111,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3145,7 +3127,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,7 +3143,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3179,7 +3159,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3196,7 +3175,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3213,7 +3191,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3230,7 +3207,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3247,7 +3223,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3264,7 +3239,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5279,7 +5253,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5413,7 +5386,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6511,10 +6483,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
-      "dev": true,
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"

--- a/package.json
+++ b/package.json
@@ -67,11 +67,13 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "test:e2e:live": "node scripts/live-e2e.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "better-sqlite3": "^13.0.2",
-    "jiti": "^2.7.0"
+    "jiti": "^2.7.0",
+    "tsx": "^4.23.13"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "0.84.2",
@@ -82,7 +84,6 @@
     "@vitest/coverage-istanbul": "^4.1.10",
     "oxfmt": "^0.59.0",
     "oxlint": "^1.74.0",
-    "tsx": "^4.23.1",
     "typebox": "^1.3.6",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"

--- a/scripts/live-e2e.d.mts
+++ b/scripts/live-e2e.d.mts
@@ -1,0 +1,18 @@
+export type LiveE2eOptions = {
+  help?: boolean;
+  keep: boolean;
+  model?: string;
+  piEntry: string;
+  profile?: string;
+  provider?: string;
+  runtimeOnly: boolean;
+};
+
+export function parseArgs(argv: string[]): LiveE2eOptions;
+export function assertSafeTempRoot(root: string, temporaryDirectory?: string): string;
+export function removeTemporaryRoot(root: string, temporaryDirectory?: string): Promise<void>;
+export function withTemporaryRoot<T>(
+  operation: (root: string) => Promise<T>,
+  options?: { keep?: boolean; temporaryDirectory?: string },
+): Promise<T>;
+export function main(argv?: string[]): Promise<void>;

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -1,0 +1,937 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TEMP_PREFIX = "pi-workflows-live-e2e-";
+const PROCESS_TIMEOUT_MS = 10 * 60 * 1_000;
+const RPC_TIMEOUT_MS = 30_000;
+const RUNTIME_TIMEOUT_MS = 90_000;
+const MODEL_TIMEOUT_MS = 10 * 60 * 1_000;
+const DIAGNOSTIC_CHARS = 12_000;
+
+export function parseArgs(argv) {
+  const options = {
+    keep: false,
+    model: undefined,
+    piEntry: path.join(
+      REPO_ROOT,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "cli.js",
+    ),
+    profile: undefined,
+    provider: undefined,
+    runtimeOnly: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--keep") options.keep = true;
+    else if (argument === "--runtime-only") options.runtimeOnly = true;
+    else if (["--model", "--pi-entry", "--profile", "--provider"].includes(argument)) {
+      const value = argv[index + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`${argument} requires a value`);
+      }
+      index += 1;
+      if (argument === "--model") options.model = value;
+      else if (argument === "--pi-entry") options.piEntry = path.resolve(value);
+      else if (argument === "--profile") options.profile = path.resolve(value);
+      else options.provider = value;
+    } else if (argument === "--help" || argument === "-h") {
+      return { ...options, help: true };
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+
+  const hasProvider = options.provider !== undefined;
+  const hasModel = options.model !== undefined;
+  if (hasProvider !== hasModel) {
+    throw new Error("A real-model run requires both --provider and --model");
+  }
+  if (options.runtimeOnly && (hasProvider || options.profile !== undefined)) {
+    throw new Error("--runtime-only cannot be combined with provider, model, or profile options");
+  }
+  if (!hasProvider) options.runtimeOnly = true;
+  return options;
+}
+
+export function assertSafeTempRoot(root, temporaryDirectory = os.tmpdir()) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTemporaryDirectory = path.resolve(temporaryDirectory);
+  if (
+    path.dirname(resolvedRoot) !== resolvedTemporaryDirectory ||
+    !path.basename(resolvedRoot).startsWith(TEMP_PREFIX)
+  ) {
+    throw new Error(`Refusing unsafe live E2E cleanup path: ${resolvedRoot}`);
+  }
+  return resolvedRoot;
+}
+
+export async function removeTemporaryRoot(root, temporaryDirectory = os.tmpdir()) {
+  const safeRoot = assertSafeTempRoot(root, temporaryDirectory);
+  const stat = await fs.lstat(safeRoot);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Refusing non-directory live E2E cleanup path: ${safeRoot}`);
+  }
+  await fs.rm(safeRoot, { recursive: true, force: false, maxRetries: 2, retryDelay: 100 });
+}
+
+export async function withTemporaryRoot(operation, options = {}) {
+  const temporaryDirectory = path.resolve(options.temporaryDirectory ?? os.tmpdir());
+  const root = await fs.mkdtemp(path.join(temporaryDirectory, TEMP_PREFIX));
+  try {
+    return await operation(root);
+  } finally {
+    if (options.keep === true) console.log(`Live E2E files kept at ${root}`);
+    else await removeTemporaryRoot(root, temporaryDirectory);
+  }
+}
+
+function usage() {
+  return `Usage:
+  npm run test:e2e:live -- --runtime-only
+  npm run test:e2e:live -- --provider PROVIDER --model MODEL [--profile ABSOLUTE_PATH]
+
+Options:
+  --runtime-only       Run the installed package, widget, host, pause/resume, and piw checks without a model call.
+  --provider NAME      Exact built-in Pi provider for the optional real-model phase.
+  --model ID           Exact model id for the optional real-model phase.
+  --profile PATH       Dedicated Pi agent directory that already contains subscription authentication.
+  --pi-entry PATH      Base Pi cli.js entry point. Defaults to the repository-pinned Pi dependency.
+  --keep               Keep the guarded temporary root for diagnosis.
+`;
+}
+
+function stage(message) {
+  process.stdout.write(`[live-e2e] ${message}\n`);
+}
+
+function tail(text, length = DIAGNOSTIC_CHARS) {
+  return text.length <= length ? text : text.slice(-length);
+}
+
+function cleanEnvironment(environment) {
+  return Object.fromEntries(
+    Object.entries(environment).filter((entry) => typeof entry[1] === "string"),
+  );
+}
+
+function sanitize(text, context) {
+  return text
+    .replaceAll(context.root, "<live-e2e-root>")
+    .replaceAll(context.profile ?? "\u0000", "<profile>");
+}
+
+async function runProcess(executable, args, options) {
+  const child = spawn(executable, args, {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  options.children.add(child);
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk.toString("utf8");
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString("utf8");
+  });
+
+  let timedOut = false;
+  let killTimer;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+    killTimer = setTimeout(() => child.kill("SIGKILL"), 3_000);
+  }, options.timeoutMs ?? PROCESS_TIMEOUT_MS);
+  const result = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  }).finally(() => {
+    clearTimeout(timer);
+    clearTimeout(killTimer);
+    options.children.delete(child);
+  });
+
+  if (timedOut || result.code !== 0) {
+    const reason = timedOut
+      ? `timed out after ${options.timeoutMs ?? PROCESS_TIMEOUT_MS} ms`
+      : `exited with code ${String(result.code)} and signal ${String(result.signal)}`;
+    throw new Error(
+      `${executable} ${args.join(" ")} ${reason}\nstdout:\n${tail(stdout)}\nstderr:\n${tail(stderr)}`,
+    );
+  }
+  return { stdout, stderr };
+}
+
+class RpcSession {
+  constructor(child, context) {
+    this.child = child;
+    this.context = context;
+    this.events = [];
+    this.pending = new Map();
+    this.stderr = "";
+    this.stdoutBuffer = "";
+    this.parseError = undefined;
+    this.exited = false;
+    child.stdout.on("data", (chunk) => this.onStdout(chunk));
+    child.stderr.on("data", (chunk) => {
+      this.stderr += chunk.toString("utf8");
+    });
+    child.once("close", (code, signal) => {
+      this.exited = true;
+      const error = new Error(
+        `Pi RPC exited with code ${String(code)} and signal ${String(signal)}\n${this.diagnostic()}`,
+      );
+      for (const pending of this.pending.values()) pending.reject(error);
+      this.pending.clear();
+    });
+  }
+
+  onStdout(chunk) {
+    this.stdoutBuffer += chunk.toString("utf8");
+    for (;;) {
+      const newline = this.stdoutBuffer.indexOf("\n");
+      if (newline < 0) return;
+      let line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (line.length === 0) continue;
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch (error) {
+        this.parseError = new Error(`Pi RPC emitted invalid JSONL: ${String(error)}`);
+        continue;
+      }
+      if (message.type === "response" && typeof message.id === "string") {
+        const pending = this.pending.get(message.id);
+        if (pending !== undefined) {
+          this.pending.delete(message.id);
+          clearTimeout(pending.timer);
+          if (message.success === true) pending.resolve(message.data);
+          else pending.reject(new Error(message.error ?? `Pi RPC ${message.command} failed`));
+        }
+      } else {
+        this.events.push(message);
+      }
+    }
+  }
+
+  async request(type, fields = {}, timeoutMs = RPC_TIMEOUT_MS) {
+    if (this.exited) throw new Error(`Pi RPC is not running\n${this.diagnostic()}`);
+    if (this.parseError !== undefined) throw this.parseError;
+    const id = `live-e2e-${randomUUID()}`;
+    const response = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Pi RPC ${type} timed out\n${this.diagnostic()}`));
+      }, timeoutMs);
+      this.pending.set(id, { reject, resolve, timer });
+    });
+    this.child.stdin.write(`${JSON.stringify({ id, type, ...fields })}\n`);
+    return await response;
+  }
+
+  diagnostic() {
+    const eventTail = this.events
+      .slice(-20)
+      .map((event) => JSON.stringify(event))
+      .join("\n");
+    return sanitize(
+      `Pi stderr tail:\n${tail(this.stderr)}\nPi event tail:\n${tail(eventTail)}`,
+      this.context,
+    );
+  }
+
+  assertNoExtensionError() {
+    const failure = this.events.find((event) => event.type === "extension_error");
+    if (failure !== undefined) {
+      throw new Error(
+        `Pi reported an extension error: ${JSON.stringify(failure)}\n${this.diagnostic()}`,
+      );
+    }
+    if (this.parseError !== undefined) throw this.parseError;
+  }
+
+  async stop() {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error("Pi RPC stopped"));
+    }
+    this.pending.clear();
+    if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+    this.child.stdin.end();
+    this.child.kill("SIGTERM");
+    await Promise.race([
+      new Promise((resolve) => this.child.once("close", resolve)),
+      new Promise((resolve) => setTimeout(resolve, 3_000)),
+    ]);
+    if (this.child.exitCode === null && this.child.signalCode === null) {
+      this.child.kill("SIGKILL");
+      await new Promise((resolve) => this.child.once("close", resolve));
+    }
+  }
+}
+
+async function waitFor(description, check, options) {
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    options.rpc?.assertNoExtensionError();
+    try {
+      const result = await check();
+      if (result !== false && result !== undefined && result !== null) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, options.intervalMs ?? 100));
+  }
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(
+    `Timed out waiting for ${description}${detail}\n${options.rpc?.diagnostic() ?? ""}`,
+  );
+}
+
+function requireObject(value, description) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${description} must be an object`);
+  }
+  return value;
+}
+
+function requireAccepted(response, description) {
+  const value = requireObject(response, description);
+  if (value.outcome !== "accepted" && value.outcome !== "adopted") {
+    throw new Error(`${description} was not accepted: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function extensionUiEvents(rpc, start = 0) {
+  return rpc.events.slice(start).filter((event) => event.type === "extension_ui_request");
+}
+
+function hasWorkflowUiState(rpc, workflowName, status, start = 0) {
+  const events = extensionUiEvents(rpc, start);
+  const statusSeen = events.some(
+    (event) =>
+      event.method === "setStatus" &&
+      event.statusKey === "pi-workflows" &&
+      event.statusText === `${workflowName} [${status}]`,
+  );
+  const widgetSeen = events.some(
+    (event) =>
+      event.method === "setWidget" &&
+      event.widgetKey === "pi-workflows" &&
+      Array.isArray(event.widgetLines) &&
+      event.widgetLines.join("\n").includes(workflowName) &&
+      event.widgetLines.join("\n").toLowerCase().includes(status),
+  );
+  return statusSeen && widgetSeen;
+}
+
+function hasWorkflowUiClear(rpc, start = 0) {
+  const events = extensionUiEvents(rpc, start);
+  const statusCleared = events.some(
+    (event) =>
+      event.method === "setStatus" &&
+      event.statusKey === "pi-workflows" &&
+      !("statusText" in event),
+  );
+  const widgetCleared = events.some(
+    (event) =>
+      event.method === "setWidget" &&
+      event.widgetKey === "pi-workflows" &&
+      !("widgetLines" in event),
+  );
+  return statusCleared && widgetCleared;
+}
+
+function assertExactModel(state, provider, model, expectedApi) {
+  const selected = requireObject(requireObject(state, "Pi state").model, "Pi selected model");
+  if (selected.provider !== provider || selected.id !== model || selected.api !== expectedApi) {
+    throw new Error(
+      `Pi model fallback detected: requested ${provider}/${model} (${expectedApi}), observed ${String(selected.provider)}/${String(selected.id)} (${String(selected.api)})`,
+    );
+  }
+}
+
+function validateProfile(profile) {
+  if (profile === undefined) return Promise.resolve();
+  return fs.stat(profile).then(async (stat) => {
+    if (!stat.isDirectory()) throw new Error(`Pi test profile is not a directory: ${profile}`);
+    const modelsPath = path.join(profile, "models.json");
+    try {
+      await fs.access(modelsPath);
+      throw new Error(`The dedicated test profile must not contain custom models: ${modelsPath}`);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    let settings;
+    try {
+      settings = JSON.parse(await fs.readFile(path.join(profile, "settings.json"), "utf8"));
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+    const record = requireObject(settings, "Pi test profile settings");
+    for (const key of ["packages", "extensions", "skills", "promptTemplates", "themes"]) {
+      const value = record[key];
+      if (Array.isArray(value) && value.length > 0) {
+        throw new Error(`The dedicated Pi test profile has unrelated ${key}`);
+      }
+    }
+  });
+}
+
+async function findRun(client, workflowName) {
+  return await waitFor(
+    `host run ${workflowName}`,
+    async () => {
+      const response = requireAccepted(
+        await client.request({ operation: "run.list", payload: { limit: 20 } }),
+        "run list",
+      );
+      if (!Array.isArray(response.receipt)) return false;
+      return response.receipt.find((run) => run.workflowName === workflowName) ?? false;
+    },
+    { timeoutMs: 30_000 },
+  );
+}
+
+async function waitForRunDisplay(client, runId, status, timeoutMs, rpc) {
+  return await waitFor(
+    `workflow ${runId} to become ${status}`,
+    async () => {
+      const view = await client.getRun(runId);
+      return view?.display?.status === status ? view : false;
+    },
+    { rpc, timeoutMs },
+  );
+}
+
+function assertOneFrame(output, workflowName, status) {
+  const normalized = output.toLowerCase();
+  if (!output.includes(workflowName) || !normalized.includes(status)) {
+    throw new Error(
+      `piw one-frame output did not show ${workflowName} as ${status}:\n${tail(output)}`,
+    );
+  }
+}
+
+async function installCandidate(context) {
+  stage("packing the npm package");
+  await fs.mkdir(context.packs, { recursive: true });
+  const packed = await runProcess(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    ["pack", "--silent", "--pack-destination", context.packs],
+    context.processOptions(REPO_ROOT),
+  );
+  const archiveName = packed.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".tgz"))
+    .at(-1);
+  if (archiveName === undefined) throw new Error(`npm pack returned no archive: ${packed.stdout}`);
+  const archivePath = path.join(context.packs, path.basename(archiveName));
+
+  stage("installing the packed package into an isolated consumer");
+  await fs.mkdir(context.consumer, { recursive: true });
+  await fs.writeFile(
+    path.join(context.consumer, "package.json"),
+    `${JSON.stringify({ name: "pi-workflows-live-e2e-consumer", private: true, version: "0.0.0" }, null, 2)}\n`,
+  );
+  await runProcess(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    ["install", "--omit=dev", "--no-audit", "--no-fund", archivePath],
+    context.processOptions(context.consumer),
+  );
+  const candidate = path.join(context.consumer, "node_modules", "@osolmaz", "pi-workflows");
+  await fs.access(path.join(candidate, "dist", "extension", "index.js"));
+  await fs.access(path.join(candidate, "dist", "client", "index.js"));
+
+  stage("installing the candidate package through base Pi");
+  await runProcess(
+    process.execPath,
+    [context.options.piEntry, "install", candidate, "--local", "--approve"],
+    context.processOptions(context.project),
+  );
+  return candidate;
+}
+
+async function buildPiw(context) {
+  stage("installing the piw candidate");
+  await runProcess(
+    "cargo",
+    [
+      "install",
+      "--path",
+      path.join(REPO_ROOT, "tui"),
+      "--root",
+      context.piwRoot,
+      "--locked",
+      "--force",
+    ],
+    context.processOptions(REPO_ROOT, { CARGO_TARGET_DIR: context.cargoTarget }),
+  );
+  const binary = path.join(
+    context.piwRoot,
+    "bin",
+    process.platform === "win32" ? "piw.exe" : "piw",
+  );
+  await fs.access(binary);
+  return binary;
+}
+
+async function startPi(context) {
+  const args = [
+    context.options.piEntry,
+    "--mode",
+    "rpc",
+    "--session-id",
+    randomUUID(),
+    "--session-dir",
+    context.sessions,
+    "--name",
+    "Pi Workflows installed live E2E",
+    "--no-skills",
+    "--no-themes",
+    "--no-prompt-templates",
+    "--no-context-files",
+    "--no-builtin-tools",
+    "--offline",
+    "--approve",
+  ];
+  if (!context.options.runtimeOnly) {
+    args.push("--provider", context.options.provider, "--model", context.options.model);
+  }
+  const child = spawn(process.execPath, args, {
+    cwd: context.project,
+    env: context.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+  context.children.add(child);
+  const rpc = new RpcSession(child, context);
+  await waitFor("base Pi RPC startup", async () => await rpc.request("get_state"), {
+    rpc,
+    timeoutMs: 30_000,
+  });
+  return rpc;
+}
+
+async function assertPackageIsolation(rpc, candidate) {
+  const data = requireObject(await rpc.request("get_commands"), "Pi commands response");
+  if (!Array.isArray(data.commands)) throw new Error("Pi commands response has no command list");
+  const commandPath = (command) => command.path ?? command.sourceInfo?.path;
+  for (const required of ["workflow", "controller", "piw"]) {
+    const command = data.commands.find((item) => item.name === required);
+    if (command === undefined || command.source !== "extension") {
+      throw new Error(`Installed candidate did not register /${required}`);
+    }
+    const sourcePath = commandPath(command);
+    if (
+      typeof sourcePath !== "string" ||
+      !path.resolve(sourcePath).startsWith(`${candidate}${path.sep}`)
+    ) {
+      throw new Error(
+        `/${required} did not load from the installed candidate: ${JSON.stringify(command)}`,
+      );
+    }
+  }
+  const unrelated = data.commands.filter((command) => {
+    if (command.source !== "extension") return true;
+    const sourcePath = commandPath(command);
+    if (typeof sourcePath === "string" && sourcePath.startsWith("<inline:")) return false;
+    return (
+      typeof sourcePath !== "string" ||
+      !path.resolve(sourcePath).startsWith(`${candidate}${path.sep}`)
+    );
+  });
+  if (unrelated.length > 0) {
+    throw new Error(`Base Pi loaded unrelated resources: ${JSON.stringify(unrelated)}`);
+  }
+}
+
+async function runRuntimeWorkflow(context, rpc, client, piwBinary) {
+  const workflowName = "live-runtime-e2e";
+  stage("running the model-free workflow through Pi");
+  const runningEvents = rpc.events.length;
+  await rpc.request("prompt", { message: `/workflow ${workflowName}` });
+  await waitFor(
+    "the running Pi workflow widget and status",
+    () => hasWorkflowUiState(rpc, workflowName, "running", runningEvents),
+    { rpc, timeoutMs: 30_000 },
+  );
+  const run = await findRun(client, workflowName);
+  const runId = run.runId;
+
+  const pauseEvents = rpc.events.length;
+  await rpc.request("prompt", { message: "/workflow pause" });
+  await waitFor(
+    "the paused Pi workflow widget and status",
+    () => hasWorkflowUiState(rpc, workflowName, "paused", pauseEvents),
+    { rpc, timeoutMs: 30_000 },
+  );
+  await waitForRunDisplay(client, runId, "paused", 30_000, rpc);
+  await waitFor(
+    "a parked run with no active worker",
+    async () => {
+      const response = requireAccepted(
+        await client.request({ operation: "host.status" }),
+        "host status",
+      );
+      const receipt = requireObject(response.receipt, "host status receipt");
+      return receipt.activeWorkers === 0 && receipt.parkedRuns === 1 ? receipt : false;
+    },
+    { rpc, timeoutMs: 30_000 },
+  );
+
+  const pausedFrame = await runProcess(
+    piwBinary,
+    [runId, "--once"],
+    context.processOptions(context.project),
+  );
+  assertOneFrame(pausedFrame.stdout, workflowName, "paused");
+
+  const resumeEvents = rpc.events.length;
+  await rpc.request("prompt", { message: "/workflow resume" });
+  await waitFor(
+    "the resumed Pi workflow widget and status",
+    () => hasWorkflowUiState(rpc, workflowName, "running", resumeEvents),
+    { rpc, timeoutMs: 30_000 },
+  );
+  const completed = await waitForRunDisplay(client, runId, "completed", RUNTIME_TIMEOUT_MS, rpc);
+  const state = requireObject(completed.state, "runtime workflow state");
+  if (JSON.stringify(state.finalOutput) !== JSON.stringify({ smoke: "runtime-passed" })) {
+    throw new Error(
+      `Runtime workflow returned the wrong output: ${JSON.stringify(state.finalOutput)}`,
+    );
+  }
+  await waitFor(
+    "Pi to clear the workflow widget and status",
+    () => hasWorkflowUiClear(rpc, resumeEvents),
+    { rpc, timeoutMs: 30_000 },
+  );
+
+  const completedFrame = await runProcess(
+    piwBinary,
+    [runId, "--once"],
+    context.processOptions(context.project),
+  );
+  assertOneFrame(completedFrame.stdout, workflowName, "completed");
+  rpc.assertNoExtensionError();
+  return runId;
+}
+
+async function preflightModel(context, rpc) {
+  stage(`checking authentication for ${context.options.provider}/${context.options.model}`);
+  const auth = await runProcess(
+    process.execPath,
+    [
+      context.options.piEntry,
+      "auth",
+      "check",
+      "--provider",
+      context.options.provider,
+      "--model",
+      context.options.model,
+      "--json",
+    ],
+    context.processOptions(context.project),
+  );
+  const authStatus = requireObject(JSON.parse(auth.stdout), "Pi authentication status");
+  if (authStatus.status !== "ready") {
+    throw new Error(`Pi authentication is not ready: ${JSON.stringify(authStatus)}`);
+  }
+
+  const available = requireObject(await rpc.request("get_available_models"), "Pi available models");
+  if (!Array.isArray(available.models)) throw new Error("Pi returned no available model list");
+  const model = available.models.find(
+    (candidate) =>
+      candidate.provider === context.options.provider && candidate.id === context.options.model,
+  );
+  if (model === undefined || typeof model.api !== "string") {
+    throw new Error(
+      `Pi does not expose the exact built-in model ${context.options.provider}/${context.options.model}`,
+    );
+  }
+  if (
+    context.options.provider === "openai-codex" &&
+    context.options.model === "gpt-5.6-luna" &&
+    model.api !== "openai-codex-responses"
+  ) {
+    throw new Error(`openai-codex/gpt-5.6-luna resolved to unexpected API ${model.api}`);
+  }
+  if (
+    context.options.provider === "openai" &&
+    context.options.model === "gpt-5.6-luna" &&
+    model.api !== "openai-responses"
+  ) {
+    throw new Error(`openai/gpt-5.6-luna resolved to unexpected API ${model.api}`);
+  }
+  const state = await rpc.request("get_state");
+  assertExactModel(state, context.options.provider, context.options.model, model.api);
+  return model.api;
+}
+
+async function runModelWorkflow(context, rpc, client, api) {
+  const workflowName = "live-model-e2e";
+  stage(
+    `running the real-model workflow through ${context.options.provider}/${context.options.model}`,
+  );
+  await rpc.request("prompt", { message: `/workflow ${workflowName}` });
+  const run = await findRun(client, workflowName);
+  const completed = await waitForRunDisplay(client, run.runId, "completed", MODEL_TIMEOUT_MS, rpc);
+  const state = requireObject(completed.state, "model workflow state");
+  const expected = { smoke: "model-passed", nonce: "pi-workflows-live-e2e" };
+  if (JSON.stringify(state.finalOutput) !== JSON.stringify(expected)) {
+    throw new Error(
+      `Model workflow returned the wrong output: ${JSON.stringify(state.finalOutput)}`,
+    );
+  }
+  if (!Array.isArray(state.steps) || state.steps.length !== 1) {
+    throw new Error(`Model workflow recorded ${String(state.steps?.length)} steps instead of one`);
+  }
+  const step = requireObject(state.steps[0], "model workflow step");
+  if (typeof step.attemptId !== "string" || step.outcome !== "ok") {
+    throw new Error(`Model workflow step was not accepted: ${JSON.stringify(step)}`);
+  }
+
+  const entriesData = requireObject(await rpc.request("get_entries"), "Pi entries response");
+  if (!Array.isArray(entriesData.entries)) throw new Error("Pi returned no session entries");
+  const deliveries = entriesData.entries.filter(
+    (entry) =>
+      entry.type === "custom_message" &&
+      entry.customType === "pi-workflows-agent-step" &&
+      entry.details?.contract?.runId === run.runId,
+  );
+  if (deliveries.length !== 1) {
+    throw new Error(`Expected one durable workflow step delivery, observed ${deliveries.length}`);
+  }
+  const details = requireObject(deliveries[0].details, "workflow step delivery");
+  if (typeof details.requestId !== "string" || details.contract?.attemptId !== step.attemptId) {
+    throw new Error(
+      `Workflow delivery does not match the accepted attempt: ${JSON.stringify(details)}`,
+    );
+  }
+  assertExactModel(
+    await rpc.request("get_state"),
+    context.options.provider,
+    context.options.model,
+    api,
+  );
+  rpc.assertNoExtensionError();
+  return run.runId;
+}
+
+async function waitForEndpointClosed(endpoint) {
+  await waitFor(
+    "the workflow host endpoint to close",
+    () =>
+      new Promise((resolve) => {
+        const socket = net.createConnection(endpoint);
+        socket.once("connect", () => {
+          socket.destroy();
+          resolve(false);
+        });
+        socket.once("error", () => resolve(true));
+      }),
+    { timeoutMs: 10_000 },
+  );
+}
+
+async function stopChildren(children) {
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  }
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+  }
+  children.clear();
+}
+
+async function execute(root, options) {
+  assertSafeTempRoot(root);
+  const profile = options.profile ?? path.join(root, "agent");
+  await validateProfile(options.profile);
+  const context = {
+    cargoTarget: path.join(root, "cargo-target"),
+    children: new Set(),
+    consumer: path.join(root, "consumer"),
+    home: path.join(root, "home"),
+    npmCache: path.join(root, "npm-cache"),
+    options,
+    packs: path.join(root, "packs"),
+    piwRoot: path.join(root, "piw"),
+    profile,
+    project: path.join(root, "project"),
+    root,
+    sessions: path.join(root, "sessions"),
+    temporary: path.join(root, "tmp"),
+    xdgCache: path.join(root, "xdg-cache"),
+    xdgConfig: path.join(root, "xdg-config"),
+    xdgData: path.join(root, "xdg-data"),
+  };
+  await Promise.all(
+    [
+      context.home,
+      context.profile,
+      context.project,
+      context.sessions,
+      context.temporary,
+      context.xdgCache,
+      context.xdgConfig,
+      context.xdgData,
+      path.join(context.project, ".pi", "workflows"),
+    ].map(async (directory) => await fs.mkdir(directory, { recursive: true })),
+  );
+  const operatorHome = os.homedir();
+  context.env = cleanEnvironment({
+    ...process.env,
+    CARGO_HOME: process.env.CARGO_HOME ?? path.join(operatorHome, ".cargo"),
+    CI: "1",
+    HOME: context.home,
+    NO_COLOR: "1",
+    PATH: process.env.PATH,
+    PI_CODING_AGENT_DIR: context.profile,
+    PI_CODING_AGENT_SESSION_DIR: context.sessions,
+    PI_OFFLINE: "1",
+    RUSTUP_HOME: process.env.RUSTUP_HOME ?? path.join(operatorHome, ".rustup"),
+    TMPDIR: context.temporary,
+    XDG_CACHE_HOME: context.xdgCache,
+    XDG_CONFIG_HOME: context.xdgConfig,
+    XDG_DATA_HOME: context.xdgData,
+    npm_config_cache: context.npmCache,
+  });
+  context.processOptions = (cwd, extraEnvironment = {}) => ({
+    children: context.children,
+    cwd,
+    env: cleanEnvironment({ ...context.env, ...extraEnvironment }),
+    timeoutMs: PROCESS_TIMEOUT_MS,
+  });
+
+  await Promise.all([
+    fs.copyFile(
+      path.join(REPO_ROOT, "test", "fixtures", "live-e2e", "runtime.workflow.ts"),
+      path.join(context.project, ".pi", "workflows", "live-runtime-e2e.workflow.ts"),
+    ),
+    fs.copyFile(
+      path.join(REPO_ROOT, "test", "fixtures", "live-e2e", "model.workflow.ts"),
+      path.join(context.project, ".pi", "workflows", "live-model-e2e.workflow.ts"),
+    ),
+  ]);
+
+  let rpc;
+  let client;
+  try {
+    await fs.access(options.piEntry);
+    const candidate = await installCandidate(context);
+    const piwBinary = await buildPiw(context);
+    context.env.PATH = `${path.join(context.consumer, "node_modules", ".bin")}${path.delimiter}${path.dirname(piwBinary)}${path.delimiter}${context.env.PATH}`;
+
+    const packageJson = JSON.parse(await fs.readFile(path.join(candidate, "package.json"), "utf8"));
+    const piVersion = (
+      await runProcess(
+        process.execPath,
+        [options.piEntry, "--version"],
+        context.processOptions(context.project),
+      )
+    ).stdout.trim();
+    const rustVersion = (
+      await runProcess("rustc", ["--version"], context.processOptions(context.project))
+    ).stdout.trim();
+
+    rpc = await startPi(context);
+    await assertPackageIsolation(rpc, candidate);
+    const clientModule = await import(
+      `${pathToFileURL(path.join(candidate, "dist", "client", "index.js")).href}?live=${Date.now()}`
+    );
+    const databasePath = path.join(context.home, ".pi", "agent", "workflows", "state.sqlite");
+    client = new clientModule.WorkflowClient({
+      clientId: `live-e2e-${randomUUID()}`,
+      databasePath,
+      env: context.env,
+    });
+    await client.ensureAvailable();
+
+    const runtimeRunId = await runRuntimeWorkflow(context, rpc, client, piwBinary);
+    let modelRunId;
+    let api;
+    if (!options.runtimeOnly) {
+      api = await preflightModel(context, rpc);
+      modelRunId = await runModelWorkflow(context, rpc, client, api);
+    }
+
+    const hostStatus = requireAccepted(
+      await client.request({ operation: "host.status" }),
+      "final host status",
+    );
+    const hostReceipt = requireObject(hostStatus.receipt, "final host status receipt");
+    if (hostReceipt.lifecycleContradictions !== 0 || hostReceipt.ambiguousEffects !== 0) {
+      throw new Error(`Host ended with unsafe state: ${JSON.stringify(hostReceipt)}`);
+    }
+    rpc.assertNoExtensionError();
+    process.stdout.write(
+      `${JSON.stringify({
+        api: api ?? null,
+        mode: options.runtimeOnly ? "runtime-only" : "real-model",
+        model: options.model ?? null,
+        modelRunId: modelRunId ?? null,
+        packageVersion: packageJson.version,
+        piVersion,
+        provider: options.provider ?? null,
+        result: "passed",
+        runtimeRunId,
+        rustVersion,
+      })}\n`,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+    throw new Error(sanitize(message, context));
+  } finally {
+    if (rpc !== undefined) await rpc.stop();
+    if (client !== undefined) {
+      const endpoint = client.endpoint;
+      try {
+        await client.request({ operation: "host.stop" });
+      } catch {
+        // The host is already stopped or never became available.
+      }
+      await client.close();
+      await waitForEndpointClosed(endpoint);
+    }
+    await stopChildren(context.children);
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help === true) {
+    process.stdout.write(usage());
+    return;
+  }
+  await withTemporaryRoot(async (root) => await execute(root, options), { keep: options.keep });
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/fixtures/live-e2e/model.workflow.ts
+++ b/test/fixtures/live-e2e/model.workflow.ts
@@ -1,0 +1,14 @@
+import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "live-model-e2e",
+  startAt: "submit",
+  nodes: {
+    submit: agent({
+      prompt: () =>
+        'Call the workflow tool exactly once. Submit this object: { "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }.',
+      expectedOutput: '{ "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }',
+    }),
+  },
+  edges: [],
+});

--- a/test/fixtures/live-e2e/runtime.workflow.ts
+++ b/test/fixtures/live-e2e/runtime.workflow.ts
@@ -1,0 +1,15 @@
+import { compute, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "live-runtime-e2e",
+  startAt: "hold",
+  nodes: {
+    hold: compute({
+      run: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 8_000));
+        return { smoke: "runtime-passed" };
+      },
+    }),
+  },
+  edges: [],
+});

--- a/test/live-e2e-script.test.ts
+++ b/test/live-e2e-script.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { assertSafeTempRoot, parseArgs, withTemporaryRoot } from "../scripts/live-e2e.mjs";
+
+describe("installed live E2E script", () => {
+  it("keeps provider and model as separate exact values", () => {
+    expect(parseArgs(["--provider", "openai-codex", "--model", "gpt-5.6-luna"])).toMatchObject({
+      model: "gpt-5.6-luna",
+      provider: "openai-codex",
+      runtimeOnly: false,
+    });
+    expect(parseArgs([])).toMatchObject({ runtimeOnly: true });
+    expect(() => parseArgs(["--provider", "openai"])).toThrow(
+      "requires both --provider and --model",
+    );
+  });
+
+  it("refuses cleanup outside one direct guarded temporary root", () => {
+    expect(() => assertSafeTempRoot("/", "/tmp")).toThrow("Refusing unsafe");
+    expect(() => assertSafeTempRoot(os.homedir(), "/tmp")).toThrow("Refusing unsafe");
+    expect(() => assertSafeTempRoot("/tmp/parent/pi-workflows-live-e2e-child", "/tmp")).toThrow(
+      "Refusing unsafe",
+    );
+    expect(assertSafeTempRoot("/tmp/pi-workflows-live-e2e-example", "/tmp")).toBe(
+      "/tmp/pi-workflows-live-e2e-example",
+    );
+  });
+
+  it("cleans the guarded root when the operation fails", async () => {
+    let root = "";
+    await expect(
+      withTemporaryRoot(async (temporaryRoot) => {
+        root = temporaryRoot;
+        await fs.writeFile(path.join(temporaryRoot, "proof.txt"), "temporary\n");
+        throw new Error("injected failure");
+      }),
+    ).rejects.toThrow("injected failure");
+    await expect(fs.access(root)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -22,6 +22,14 @@ struct Cli {
     #[arg(long, value_name = "NAME")]
     theme: Option<String>,
 
+    /// Render one complete view as plain text and exit.
+    #[arg(
+        long,
+        requires = "run_id",
+        conflicts_with_all = ["connect", "list_themes"]
+    )]
+    once: bool,
+
     /// Print built-in viewer theme names and exit.
     #[arg(long)]
     list_themes: bool,
@@ -99,6 +107,10 @@ async fn ensure_host(socket_path: &PathBuf) -> Result<()> {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    anyhow::ensure!(
+        !(cli.once && cli.command.is_some()),
+        "--once cannot be used with a subcommand"
+    );
     if cli.list_themes {
         for name in piw::theme::THEME_NAMES {
             println!("{name}");
@@ -121,6 +133,13 @@ fn main() -> Result<()> {
         None => {
             drop(runtime);
             match cli.run_id {
+                Some(run_id) if cli.once => {
+                    println!(
+                        "{}",
+                        ui::render_single_once(&socket_path, &run_id, cli_theme.as_deref())?
+                    );
+                    Ok(())
+                }
                 Some(run_id) => ui::run_single(&socket_path, &run_id, cli_theme.as_deref()),
                 None => ui::run_local(&socket_path, cli_theme.as_deref()),
             }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -27,14 +27,16 @@ use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
     MouseButton, MouseEvent, MouseEventKind,
 };
+use ratatui::backend::TestBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style, Stylize as _};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
-use ratatui::Frame;
+use ratatui::{Frame, Terminal};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::thread;
 use std::time::{Duration, Instant};
 
 const PLAY_STEP_INTERVAL: Duration = Duration::from_millis(700);
@@ -44,6 +46,9 @@ const MIN_SIDEBAR_WIDTH: u16 = 12;
 const MIN_MAIN_WIDTH: u16 = 24;
 const MIN_GRAPH_HEIGHT: u16 = 5;
 const MIN_INSPECTOR_HEIGHT: u16 = 5;
+const ONCE_WIDTH: u16 = 120;
+const ONCE_HEIGHT: u16 = 40;
+const ONCE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct RunSummary {
     pub run_id: String,
@@ -430,6 +435,38 @@ pub fn run_single(socket_path: &Path, run_id: &str, cli_theme: Option<&str>) -> 
     )
 }
 
+/// Render one complete run view without taking over the terminal.
+pub fn render_single_once(
+    socket_path: &Path,
+    run_id: &str,
+    cli_theme: Option<&str>,
+) -> Result<String> {
+    let mut remote = RemoteRuns::connect_local(socket_path)?;
+    remote.watch(run_id);
+    let deadline = Instant::now() + ONCE_TIMEOUT;
+    loop {
+        if remote.view(run_id).is_some() {
+            break;
+        }
+        if let Some(error) = remote.error() {
+            anyhow::bail!(error);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for workflow run {run_id}");
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let resolved_theme = theme::resolve(cli_theme);
+    let app = create_app(
+        Provider::Remote(remote),
+        false,
+        Some(run_id.to_owned()),
+        resolved_theme,
+    );
+    render_app_once(app, ONCE_WIDTH, ONCE_HEIGHT)
+}
+
 pub fn run_remote(url: &str, cli_theme: Option<&str>) -> Result<()> {
     let remote = RemoteRuns::connect(url)?;
     run_app(Provider::Remote(remote), true, None, cli_theme)
@@ -466,12 +503,53 @@ fn event_loop(
     initial_run: Option<String>,
     resolved_theme: theme::ResolvedTheme,
 ) -> Result<()> {
+    let mut app = create_app(provider, show_sidebar, initial_run, resolved_theme);
+
+    while !app.quit {
+        app.provider.tick();
+        let summaries = app.provider.summaries();
+        let selected_available = summaries
+            .iter()
+            .any(|summary| Some(&summary.run_id) == app.selected_run.as_ref());
+        app.selected_run = reconcile_selected_run(
+            app.selected_run.take(),
+            summaries.first().map(|summary| summary.run_id.as_str()),
+            selected_available,
+            app.show_sidebar,
+        );
+        if let Some(run_id) = app.selected_run.clone() {
+            app.provider.ensure_watch(&run_id);
+        }
+        app.ensure_step_window();
+        app.ensure_replay_window();
+        app.advance_playback();
+        terminal.draw(|frame| draw(frame, &mut app, &summaries))?;
+
+        if crossterm::event::poll(Duration::from_millis(120))? {
+            match crossterm::event::read()? {
+                Event::Key(key) if key.kind != KeyEventKind::Release => {
+                    handle_key(&mut app, &summaries, key);
+                }
+                Event::Mouse(mouse) => handle_mouse(&mut app, &summaries, mouse),
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn create_app(
+    provider: Provider,
+    show_sidebar: bool,
+    initial_run: Option<String>,
+    resolved_theme: theme::ResolvedTheme,
+) -> App {
     let sidebar_width = resolved_theme
         .ui
         .sidebar_width
         .unwrap_or(DEFAULT_SIDEBAR_WIDTH);
     let inspector_height = resolved_theme.ui.inspector_height;
-    let mut app = App {
+    App {
         provider,
         show_sidebar,
         sidebar_collapsed: false,
@@ -519,39 +597,35 @@ fn event_loop(
         inspector_rect: Rect::default(),
         inspector_tab_hits: Vec::new(),
         quit: false,
-    };
-
-    while !app.quit {
-        app.provider.tick();
-        let summaries = app.provider.summaries();
-        let selected_available = summaries
-            .iter()
-            .any(|summary| Some(&summary.run_id) == app.selected_run.as_ref());
-        app.selected_run = reconcile_selected_run(
-            app.selected_run.take(),
-            summaries.first().map(|summary| summary.run_id.as_str()),
-            selected_available,
-            app.show_sidebar,
-        );
-        if let Some(run_id) = app.selected_run.clone() {
-            app.provider.ensure_watch(&run_id);
-        }
-        app.ensure_step_window();
-        app.ensure_replay_window();
-        app.advance_playback();
-        terminal.draw(|frame| draw(frame, &mut app, &summaries))?;
-
-        if crossterm::event::poll(Duration::from_millis(120))? {
-            match crossterm::event::read()? {
-                Event::Key(key) if key.kind != KeyEventKind::Release => {
-                    handle_key(&mut app, &summaries, key);
-                }
-                Event::Mouse(mouse) => handle_mouse(&mut app, &summaries, mouse),
-                _ => {}
-            }
-        }
     }
-    Ok(())
+}
+
+fn render_app_once(mut app: App, width: u16, height: u16) -> Result<String> {
+    app.provider.tick();
+    let summaries = app.provider.summaries();
+    if let Some(run_id) = app.selected_run.clone() {
+        app.provider.ensure_watch(&run_id);
+    }
+    app.ensure_step_window();
+    app.ensure_replay_window();
+
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.draw(|frame| draw(frame, &mut app, &summaries))?;
+    let lines = terminal
+        .backend()
+        .buffer()
+        .content
+        .chunks(width as usize)
+        .map(|row| {
+            row.iter()
+                .map(|cell| cell.symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    Ok(lines.join("\n").trim_end().to_owned())
 }
 
 fn reconcile_selected_run(

--- a/tui/tests/cli.rs
+++ b/tui/tests/cli.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn piw() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_piw"))
+}
+
+#[test]
+fn once_requires_a_run_id() {
+    let output = piw().arg("--once").output().expect("piw should start");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("required arguments were not provided"));
+    assert!(stderr.contains("<RUN_ID>"));
+}
+
+#[test]
+fn help_describes_one_frame_rendering() {
+    let output = piw().arg("--help").output().expect("piw should start");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("--once"));
+    assert!(stdout.contains("Render one complete view as plain text and exit"));
+}


### PR DESCRIPTION
## Summary

The release checks did not prove that the packed package worked in a clean Pi installation.
This change adds a black-box test that installs the package with production dependencies, starts base Pi with no other extensions, runs a real hosted workflow, checks the Pi widget, and checks the Rust viewer.
It also adds a manual real-model phase that keeps the provider and model exact and rejects fallback.

## What Changed

The new runner tests the same npm contents and runtime dependency layout that users install.
It uses one guarded temporary root and removes it after success or failure.

- Added `npm run test:e2e:live -- --runtime-only` and a CI job for the deterministic installed-package check.
- Added isolated model-free and optional model workflow fixtures.
- Added `piw <runId> --once` for one complete plain-text viewer frame.
- Verified command isolation, host startup, widget and status transitions, pause, parked-worker state, resume, completion, and cleanup.
- Moved `tsx` to production dependencies after the packed-package test found that the host needs it to load packaged TypeScript source.
- Documented runtime-only, API-key, subscription-profile, and exact provider/model usage.

## Testing

The deterministic installed-package run passed against Pi 0.84.2 and Rust 1.98.0.
The optional paid or subscription-backed real-model phase was not run.

- `npm run check`
- `npm run test:e2e`
- `npm run test:e2e:live -- --runtime-only`
- `cargo test --manifest-path tui/Cargo.toml`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path tui/Cargo.toml --check`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `npm pack --dry-run`
- `git diff --check`

SimpleDoc still reports the same nine old documentation naming and frontmatter problems. This change adds no new SimpleDoc problem.

## Risks

The deterministic path has low risk because it runs with no model and only temporary state.
The manual real-model phase still depends on external authentication, provider availability, and model behavior.

- The test proves one accepted workflow delivery and result. It does not claim one upstream API request.
- CI runs only the model-free phase and receives no personal subscription credential or broad API key.
