### PR TITLE
fix: harden live model release checks

### DIFF
--- a/scripts/live-e2e.d.mts
+++ b/scripts/live-e2e.d.mts
@@ -1,3 +1,5 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
 export type LiveE2eOptions = {
   help?: boolean;
   keep: boolean;
@@ -7,6 +9,11 @@ export type LiveE2eOptions = {
   provider?: string;
   runtimeOnly: boolean;
 };
+
+export class RpcSession {
+  constructor(child: ChildProcessWithoutNullStreams, context: { profile?: string; root: string });
+  assertNoExtensionError(): void;
+}
 
 export function parseArgs(argv: string[]): LiveE2eOptions;
 export function assertSafeTempRoot(root: string, temporaryDirectory?: string): string;

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -7,6 +7,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const TEMP_PREFIX = "pi-workflows-live-e2e-";
@@ -177,7 +178,7 @@ async function runProcess(executable, args, options) {
   return { stdout, stderr };
 }
 
-class RpcSession {
+export class RpcSession {
   constructor(child, context) {
     this.child = child;
     this.context = context;
@@ -187,6 +188,7 @@ class RpcSession {
     this.stdoutBuffer = "";
     this.parseError = undefined;
     this.exited = false;
+    this.exitError = undefined;
     child.stdout.on("data", (chunk) => this.onStdout(chunk));
     child.stderr.on("data", (chunk) => {
       this.stderr += chunk.toString("utf8");
@@ -196,6 +198,7 @@ class RpcSession {
       const error = new Error(
         `Pi RPC exited with code ${String(code)} and signal ${String(signal)}\n${this.diagnostic()}`,
       );
+      this.exitError = error;
       for (const pending of this.pending.values()) pending.reject(error);
       this.pending.clear();
     });
@@ -258,6 +261,7 @@ class RpcSession {
   }
 
   assertNoExtensionError() {
+    if (this.exitError !== undefined) throw this.exitError;
     const failure = this.events.find((event) => event.type === "extension_error");
     if (failure !== undefined) {
       throw new Error(
@@ -617,7 +621,7 @@ async function runRuntimeWorkflow(context, rpc, client, piwBinary) {
   );
   const completed = await waitForRunDisplay(client, runId, "completed", RUNTIME_TIMEOUT_MS, rpc);
   const state = requireObject(completed.state, "runtime workflow state");
-  if (JSON.stringify(state.finalOutput) !== JSON.stringify({ smoke: "runtime-passed" })) {
+  if (!isDeepStrictEqual(state.finalOutput, { smoke: "runtime-passed" })) {
     throw new Error(
       `Runtime workflow returned the wrong output: ${JSON.stringify(state.finalOutput)}`,
     );
@@ -699,7 +703,7 @@ async function runModelWorkflow(context, rpc, client, api) {
   const completed = await waitForRunDisplay(client, run.runId, "completed", MODEL_TIMEOUT_MS, rpc);
   const state = requireObject(completed.state, "model workflow state");
   const expected = { smoke: "model-passed", nonce: "pi-workflows-live-e2e" };
-  if (JSON.stringify(state.finalOutput) !== JSON.stringify(expected)) {
+  if (!isDeepStrictEqual(state.finalOutput, expected)) {
     throw new Error(
       `Model workflow returned the wrong output: ${JSON.stringify(state.finalOutput)}`,
     );
@@ -729,6 +733,12 @@ async function runModelWorkflow(context, rpc, client, api) {
       `Workflow delivery does not match the accepted attempt: ${JSON.stringify(details)}`,
     );
   }
+  const costUsd = entriesData.entries.reduce((total, entry) => {
+    const value = entry?.message?.usage?.cost?.total;
+    return typeof value === "number" && Number.isFinite(value) && value >= 0
+      ? total + value
+      : total;
+  }, 0);
   assertExactModel(
     await rpc.request("get_state"),
     context.options.provider,
@@ -736,7 +746,7 @@ async function runModelWorkflow(context, rpc, client, api) {
     api,
   );
   rpc.assertNoExtensionError();
-  return run.runId;
+  return { costUsd, runId: run.runId };
 }
 
 async function waitForEndpointClosed(endpoint) {
@@ -872,10 +882,13 @@ async function execute(root, options) {
 
     const runtimeRunId = await runRuntimeWorkflow(context, rpc, client, piwBinary);
     let modelRunId;
+    let modelCostUsd;
     let api;
     if (!options.runtimeOnly) {
       api = await preflightModel(context, rpc);
-      modelRunId = await runModelWorkflow(context, rpc, client, api);
+      const modelResult = await runModelWorkflow(context, rpc, client, api);
+      modelRunId = modelResult.runId;
+      modelCostUsd = modelResult.costUsd;
     }
 
     const hostStatus = requireAccepted(
@@ -892,6 +905,7 @@ async function execute(root, options) {
         api: api ?? null,
         mode: options.runtimeOnly ? "runtime-only" : "real-model",
         model: options.model ?? null,
+        modelCostUsd: modelCostUsd ?? null,
         modelRunId: modelRunId ?? null,
         packageVersion: packageJson.version,
         piVersion,

--- a/test/fixtures/live-e2e/model.workflow.ts
+++ b/test/fixtures/live-e2e/model.workflow.ts
@@ -6,7 +6,7 @@ export default defineWorkflow({
   nodes: {
     submit: agent({
       prompt: () =>
-        'Call the workflow tool exactly once. Submit this object: { "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }.',
+        'Call the workflow tool exactly once. Before the call, compare the step and attempt arguments character-for-character with the appended workflow step contract. Submit this object: { "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }.',
       expectedOutput: '{ "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }',
     }),
   },

--- a/test/live-e2e-script.test.ts
+++ b/test/live-e2e-script.test.ts
@@ -1,8 +1,15 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { assertSafeTempRoot, parseArgs, withTemporaryRoot } from "../scripts/live-e2e.mjs";
+import {
+  assertSafeTempRoot,
+  parseArgs,
+  RpcSession,
+  withTemporaryRoot,
+} from "../scripts/live-e2e.mjs";
 
 describe("installed live E2E script", () => {
   it("keeps provider and model as separate exact values", () => {
@@ -26,6 +33,18 @@ describe("installed live E2E script", () => {
     expect(assertSafeTempRoot("/tmp/pi-workflows-live-e2e-example", "/tmp")).toBe(
       "/tmp/pi-workflows-live-e2e-example",
     );
+  });
+
+  it("reports an unexpected Pi RPC exit immediately", async () => {
+    const child = spawn(process.execPath, ["-e", "process.exit(7)"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const rpc = new RpcSession(child, {
+      root: "/tmp/pi-workflows-live-e2e-rpc-exit",
+    });
+    await once(child, "close");
+
+    expect(() => rpc.assertNoExtensionError()).toThrow("Pi RPC exited with code 7");
   });
 
   it("cleans the guarded root when the operation fails", async () => {


### PR DESCRIPTION
## Summary

The new release check found two test-runner defects during its first real Luna runs.
The runner could wait for ten minutes after Pi exited, and it compared valid JSON objects by key order.
This change makes failed runs stop immediately, compares workflow output structurally, and records the observed model cost in the final receipt.

## What Changed

The release check now handles real provider behavior without hiding workflow failures.
The model fixture also tells the model to verify the exact durable step and attempt identifiers before its one tool call.

- Retain and report an unexpected Pi RPC process exit from every polling path.
- Compare fixed workflow outputs with structural equality instead of serialized key order.
- Include `modelCostUsd` in successful real-model receipts.
- Add a regression test for immediate Pi RPC exit reporting.

## Testing

The complete packed-package test passed with the exact `openai/gpt-5.6-luna` pair.
It used Pi 0.84.2, package 0.15.3, Rust 1.98.0, and the `openai-responses` API.
The successful model turn cost $0.0002908.

- `npm run check` — 91 files and 1,130 tests passed.
- `npm run test:e2e` — 3 files and 9 tests passed.
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna` — passed.
- `cargo test --manifest-path tui/Cargo.toml` — passed.
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --manifest-path tui/Cargo.toml --check` — passed.
- Both required Slophammer checks — passed.
- `npm pack --dry-run` and `git diff --check` — passed.

SimpleDoc reports only the same nine old naming and frontmatter problems.

## Risks

The changes affect only the repository-owned live release runner and its fixture.
They do not change workflow runtime, protocol, state, Pi session, or provider behavior.
