### PR TITLE
chore: release 0.16.0

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -159,7 +159,8 @@ workflow stores a long-lived registry token:
 For later versions:
 
 1. Update `version` in `package.json`, `package-lock.json`, `tui/Cargo.toml`,
-   and `tui/Cargo.lock`, then merge that change into the default branch.
+   `tui/Cargo.lock`, and `herdr-plugin.toml`, then merge that change into the
+   default branch.
 2. Publish a GitHub Release whose tag is `v<version>`, such as `v0.2.0`.
 3. Wait for the **Publish npm package** and **Publish crates.io package**
    workflows to finish.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "osolmaz.pi-workflows"
 name = "pi-workflows"
-version = "0.15.3"
+version = "0.16.0"
 min_herdr_version = "0.7.0"
 description = "Open the active pi-workflows run in piw from a managed Herdr pane."
 platforms = ["linux", "macos"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@osolmaz/pi-workflows",
-      "version": "0.15.3",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osolmaz/pi-workflows",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "Workflow and controller runtime with a live terminal viewer for the pi coding agent",
   "keywords": [
     "pi-package"

--- a/tui/Cargo.lock
+++ b/tui/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "pi-workflows"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-workflows"
-version = "0.15.3"
+version = "0.16.0"
 edition = "2021"
 description = "Terminal client and live relay for hosted pi-workflows state"
 license = "MIT"


### PR DESCRIPTION
## Summary

This prepares Pi Workflows `0.16.0` for publication.
The minor release includes the out-of-process workflow host, the unified workflow client and session delivery controls, installed-package release checks, and the new `piw <runId> --once` interface.
All npm, Rust, and Herdr package versions now match.

## What Changed

The release metadata now identifies one exact version across every published artifact and packaged plugin.
The release guide also lists the Herdr manifest as a required version source.

- Set `package.json` and `package-lock.json` to `0.16.0`.
- Set `tui/Cargo.toml` and `tui/Cargo.lock` to `0.16.0`.
- Set `herdr-plugin.toml` to `0.16.0`.
- Updated the release checklist in `docs/development.md`.

## Testing

The exact `0.16.0` package passed the complete release gate.
The real-model check used `openai/gpt-5.6-luna`, the `openai-responses` API, and cost $0.000299.

- `npm run check` — 91 files and 1,130 tests passed.
- `npm run test:e2e` — 3 files and 9 tests passed.
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna` — passed.
- Rust test, Clippy, and format gates — passed.
- Both required Slophammer gates — passed.
- `npm pack --dry-run` produced `osolmaz-pi-workflows-0.16.0.tgz`.
- `git diff --check` — passed.

SimpleDoc reports only the same nine old naming and frontmatter problems.

## Risks

This change only updates release metadata and the release checklist.
Publishing remains controlled by the existing GitHub Release workflows, which verify the tag, default-branch ancestry, package versions, and registry state before publishing.
