### PR TITLE
fix: restore workflow session recovery

### DIFF
--- a/docs/2026-08-18-herdr-piw-plan.md
+++ b/docs/2026-08-18-herdr-piw-plan.md
@@ -26,7 +26,7 @@ When pi-workflows runs inside Herdr, show a shortcut that opens the current run 
 
 ### One package with two host entry points
 
-The package root will contain `herdr-plugin.toml`. Pi loads the existing extension entry point. Herdr loads a `piw` pane entry point from the same package root. A small checked-in JavaScript launcher validates `PI_WORKFLOWS_RUN_DIR` and starts `piw` with an argv array.
+The package root will contain `herdr-plugin.toml`. Pi loads the existing extension entry point. Herdr loads a `piw` pane entry point from the same package root. A small checked-in JavaScript launcher validates the workflow run ID and starts `piw` with an argv array. It uses Herdr's configured executable path when that path works. If Herdr replaced its executable after the server started and the configured path no longer exists, the launcher retries the pane label command through `PATH`.
 
 `pi-workflows herdr setup` explicitly links the current package root with `herdr plugin link`. It is idempotent and never changes plugin registration during normal Pi startup.
 
@@ -58,6 +58,7 @@ Herdr's public snapshot does not expose plugin metadata tokens. The launcher wil
 - All six placements work and preserve the calling pane unless the user selects a focused viewer.
 - Repeated opens and Pi reloads focus the existing run viewer.
 - Failures produce bounded, useful messages and leave no empty tab or workspace.
+- A viewer still opens when the Herdr server supplies a replaced executable path and the current `herdr` command is in `PATH`.
 - The package tarball contains the Herdr manifest and launcher.
 - `osolmaz/pi-workflows` is public, has a root `herdr-plugin.toml`, and has the `herdr-plugin` GitHub topic.
 

--- a/docs/2026-09-02-installed-live-e2e-plan.md
+++ b/docs/2026-09-02-installed-live-e2e-plan.md
@@ -78,6 +78,14 @@ An API-key run can use an ephemeral agent directory. Pi receives the caller's ex
 
 Before a model call, the runner will execute Pi's documented `auth check` command for the exact provider and model. It will stop before the workflow starts when authentication or model resolution fails.
 
+## Startup recovery
+
+Before Pi starts, the runner creates an incompatible state fixture inside the guarded temporary home. It then starts Pi and waits for the extension's one bounded host-unavailable warning. The runner moves the fixture intact, as the alpha reset instruction requires, and starts the host through the installed client.
+
+The same Pi process must establish its origin-session subscription without a restart. An observer subscription verifies that the host has a coordinator epoch for that session. More polling must not produce a second host-unavailable warning. The normal runtime workflow then proves that the recovered session receives live widget updates.
+
+This check reproduces the case where Pi starts before the host can open durable state. It changes no operator database or Pi session.
+
 ## Runtime workflow
 
 The first workflow does not call a model. It has one delayed compute step and a fixed final output.
@@ -179,8 +187,14 @@ Add tests for:
 - timeout, missing-run, and host connection failures;
 - packed npm installation with production dependencies;
 - extension source isolation in base Pi;
+- origin-session reconnection after initial host startup fails;
+- one warning during the simulated outage;
 - RPC widget and status transitions;
 - pause with no active worker;
+- abort of an active origin-session model turn;
+- one new resumed step message and one fresh model turn after resume;
+- protected decision revision stability across pause and resume;
+- a complete session capture with no false host-interruption diagnostic;
 - resume and completion;
 - exact provider and model validation;
 - model fallback rejection;
@@ -222,4 +236,4 @@ The implementation uses documented Pi package installation and CLI model selecti
 
 ## Completion criteria
 
-The work is complete when a clean base Pi process loads only the packed Pi Workflows package. The deterministic runtime workflow must pass every widget and lifecycle check, while `piw --once` must agree with Pi and the host. An explicitly selected built-in model must complete the structured agent workflow. Cleanup must leave no process or large temporary directory, and all repository checks must pass.
+The work is complete when a clean base Pi process loads only the packed Pi Workflows package. The same Pi process must recover after the temporary incompatible-state gate is removed. The deterministic runtime workflow must pass every widget and lifecycle check, while `piw --once` must agree with Pi and the host. The full Pi mock-provider test must abort an active origin-session workflow turn, resume it through a distinct resumed step message, complete through one fresh model turn, and leave a complete session capture. The installed real-model check must reject a false host-interruption diagnostic. An explicitly selected built-in model must complete the structured agent workflow. Cleanup must leave no process or large temporary directory, and all repository checks must pass.

--- a/docs/WORKFLOW_HOST.md
+++ b/docs/WORKFLOW_HOST.md
@@ -267,7 +267,7 @@ Each report names the sent workflow message, workflow turn ID, run, and origin s
 
 At `agent_end`, the extension derives `completed`, `aborted`, or `error` from the documented assistant messages. It reads response-entry evidence from `ctx.sessionManager.getBranch()`; the entry ID can be null. The host applies the end, activity update, pause, unproductive-turn counter, and pending step-message cancellation in one transaction. A repeated report adopts that result. A stale turn ID cannot clear newer activity.
 
-An aborted turn sets the run pause, cancels pending step messages, and does not increment `unproductiveTurnEnds`. The interaction derives its paused state from the run. A completed, recoverably failed, or proved-lost turn increments the counter only when the submitted-output step remains pending, not paused, and has no accepted or validating submission. Values one and two create one step message with reason `reminder`; a value above two fails the attempt. At most one pending reminder-reason step exists. Acceptance, pause, cancellation, timeout, and branch re-presentation cancel pending step messages.
+An aborted turn sets the run pause, cancels pending step messages, and does not increment `unproductiveTurnEnds`. The interaction derives its paused state from the run. Resuming that submitted-output step atomically clears the pause, increments the interaction revision, and creates one step message with reason `resumed`. Pi starts a fresh model turn from that message. A protected decision does not start a model turn, so pause and resume do not change its interaction revision or create another decision message. A completed, recoverably failed, or proved-lost turn increments the counter only when the submitted-output step remains pending, not paused, and has no accepted or validating submission. Values one and two create one step message with reason `reminder`; a value above two fails the attempt. At most one pending reminder-reason step exists. Acceptance, pause, cancellation, timeout, and branch re-presentation cancel pending step messages.
 
 The process-local coordinator epoch ends on client disconnect, but an open reported workflow turn does not end. Host startup does not close Pi turns. On `session_start`, `workflowMessage.reportBranch` closes an unended open message as `lost` only when Pi is idle. A busy Pi session re-reports the same started turn. A lost step follows the unproductive-turn rule. A lost terminal or follow-up closes after its first turn. Follow-up activity controls ordering but does not show the completed workflow as `running`. Activity cannot grant workflow authority or settle a workflow request.
 
@@ -357,7 +357,7 @@ Agent and assistant-message steps for an interactive run execute in the origin P
 
 The worker commits the node's resolved wall-clock deadline before it proposes `interaction.requested`. The host commits the request, changes the node attempt to waiting, parks the queue row, releases the claim, and acknowledges the worker. The worker then exits. The host continues to enforce the durable deadline while no worker exists. If the deadline passes, one control claim atomically closes the stale request and schedules a supervised timeout-resume child. The child preserves the same attempt and deadline, records `timed_out`, and follows any `$result.outcome` edge. A run with no timeout recovery edge becomes terminal and releases its session reservation. Restart recovery starts this timeout path before it schedules other work.
 
-The extension finds eligible workflow messages during `session_start`, after model turns settle, and once per second while the session is open. One `WorkflowMessageCoordinator` handles every message kind. After every host connection, it waits for the complete origin-session view and reports the active branch before it sends a workflow message or reports a model turn. The host view names the next eligible pending message only to the active coordinator epoch.
+The extension finds eligible workflow messages during `session_start`, after model turns settle, and once per second while the session is open. The same poll also establishes the one session subscription when initial host startup or connection fails. It keeps at most one connection attempt and one active subscription, so the open Pi session recovers without a restart and without duplicate coordinators. One `WorkflowMessageCoordinator` handles every message kind. After every host connection, it waits for the complete origin-session view and reports the active branch before it sends a workflow message or reports a model turn. The host view names the next eligible pending message only to the active coordinator epoch.
 
 The coordinator waits until Pi is idle and has no queued user input, keeps the message ID in its in-memory queued map, and searches the active branch for that hidden ID. It reports a matching entry before any send. Otherwise, it rechecks synchronously that Pi is idle, has no pending input, the message is absent, and its connection still owns the active epoch. It calls documented `pi.sendMessage()` with no `await` between the final check and call. A poll can discover work, but it cannot send an ID already in the queued map.
 
@@ -371,7 +371,7 @@ A tool update or submission goes to the host. It includes the exact request, nod
 
 An ordinary checkpoint accepts the model-facing `answer` action and starts a continuation run. A protected human decision never accepts that tool action. The extension displays the decision without starting a model turn, and a person answers it with `/workflow answer` through `decision.answer`. When a protected decision reaches its saved `onTimeout` deadline, the host takes a control claim on the waiting parent, atomically records the validated default, closes the pending interaction, releases the parent claim, and reserves the continuation. A human answer cannot win after that deadline.
 
-The session keeps normal Pi entries for prompts, tools, and replies. Pi Workflows stores the public session entry ID used for presentation adoption. It does not edit the Pi session file or schema.
+The session keeps normal Pi entries for prompts, tools, and replies. Pi Workflows stores the public session entry ID used for presentation adoption. It does not edit the Pi session file or schema. A normal worker continuation leaves an active session capture open until the matching Pi turn ends. Only proved interruption can fail that capture; worker handoff alone cannot report that the host stopped.
 
 One session sends one workflow message at a time. Messages keep acceptance order, but an earlier ineligible or cancelled message does not block unrelated eligible work. Source state and message kind decide eligibility. A reload clears only process-local queued state. `workflowMessage.reportBranch` adopts existing entries and closes lost turns. When a pending source has no entry on the active branch, it creates one message of that source's own kind: a step with reason `resumed` for an interaction, or a decision for a protected decision. Repeating a report or returning to a branch that already contains that source creates no new message.
 
@@ -492,6 +492,7 @@ The implementation conforms when:
 - an expired or replaced owner cannot write;
 - a blocked worker cannot stop host renewal;
 - Pi can restart while work computes or waits;
+- an open Pi session reconnects after initial host startup or connection fails;
 - the host can restart and recover from committed state;
 - run, queue, attempt, decision, lease, event, and viewer projections remain consistent after injected crashes;
 - an expired running row can be resumed or cancelled safely;
@@ -509,6 +510,8 @@ The implementation conforms when:
 - a branch change creates at most one source-kind message when that source has no entry on the active branch;
 - a partial unique index allows at most one pending step message for each interactive request;
 - pause is stored once on the run and derived for its interaction;
+- resuming an aborted submitted-output step creates one new resumed message and one fresh origin-session model turn;
+- pausing and resuming a protected decision does not invalidate its answer revision or create a duplicate decision message;
 - follow-ups wait for the final continuation outcome, its terminal turn, earlier follow-ups, and release of the origin-session reservation;
 - only the final leaf in a checkpoint continuation chain receives a terminal workflow message;
 - effects are deduplicated or marked ambiguous;
@@ -522,6 +525,7 @@ The implementation conforms when:
 - the host is the only production process that opens live SQLite state;
 - the widget, status line, Herdr actions, CLI, and `piw` render the same host-produced status and controls;
 - a busy origin session displays `running` for the full exact workflow turn, including a terminal or pausing turn, and a stale turn-end report cannot clear newer activity;
+- normal worker continuation does not fail an active Pi session capture or report a false host interruption;
 - `paused` appears only after a durable pause and matching turn end;
 - a terminal run remains in the origin-session view while its terminal message is pending or its first turn is open, and then for 60 seconds after that turn ends, without retaining execution authority;
 - a TypeScript-created live database is viewable by the matching Rust `piw` through the client protocol without a duplicated SQLite digest;

--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -151,9 +151,9 @@ A start against a closed message is rejected. Follow-up turns are reported for o
 
 The extension creates one workflow turn ID at `agent_start` and keeps it through the matching `agent_end` and host reconnect. It buffers starts and ends until the session view and message receipt are ready.
 
-At `agent_end`, it derives `completed`, `aborted`, or `error` from the documented assistant messages. It reads response-entry evidence from `ctx.sessionManager.getBranch()`; the entry ID can be null. The host saves one immutable end result. A repeated report adopts it, and a stale turn ID cannot clear newer activity.
+At `agent_end`, it derives `completed`, `aborted`, or `error` from the documented assistant messages. It reads response-entry evidence from `ctx.sessionManager.getBranch()`; the entry ID can be null. The host saves one immutable end result. A repeated report adopts it, and a stale turn ID cannot clear newer activity. A supervised worker can continue after accepted tool output while that Pi turn is still open. This normal continuation leaves the session capture recording until `agent_end`; it does not mark the capture as interrupted.
 
-The host applies the end and its workflow consequence in one transaction. An aborted turn sets the run pause and cancels the request's pending step messages; the interaction derives its paused state from the run. A completed, recoverably failed, or proved-lost turn increments `unproductiveTurnEnds` only when the submitted-output step is pending, not paused, and has no accepted or validating submission. Values one and two create one step message with reason `reminder`; a value above two fails the attempt. A partial unique index enforces at most one pending step message for the request, regardless of reason. Acceptance, pause, cancel, timeout, and branch re-presentation cancel all pending step messages. A cancelled message did not start a turn and does not increment the counter.
+The host applies the end and its workflow consequence in one transaction. An aborted turn sets the run pause and cancels the request's pending step messages; the interaction derives its paused state from the run. Resuming that submitted-output step atomically clears the pause, increments the interaction revision, and creates one new step message with reason `resumed`. That message starts a fresh Pi model turn. A protected decision does not start a model turn, so its revision and decision message do not change when its run resumes. A completed, recoverably failed, or proved-lost turn increments `unproductiveTurnEnds` only when the submitted-output step is pending, not paused, and has no accepted or validating submission. Values one and two create one step message with reason `reminder`; a value above two fails the attempt. A partial unique index enforces at most one pending step message for the request, regardless of reason. Acceptance, pause, cancel, timeout, and branch re-presentation cancel all pending step messages. A cancelled message did not start a turn and does not increment the counter.
 
 There is no activity heartbeat, refresh lease, or sequence counter. The host shows `running` from the matching start until the matching end. Host startup never marks a Pi turn lost. On `session_start`, only an idle-session branch report can close an open sent message with synthetic stop reason `lost`. Polling and time alone cannot create a reminder.
 
@@ -214,10 +214,13 @@ Tests must prove:
 - messages remain in saved order without message-pointer deadlocks;
 - an early `agent_start` and `agent_end` wait for the message receipt and session view, then apply in order;
 - every matching model turn shows `running` for its full duration;
+- normal worker continuation leaves the active session capture open until the matching turn ends;
 - stale turn-end reports and starts against closed messages are rejected;
 - a manual turn cancels pending step messages that it supersedes;
 - a turn cannot bind to an interaction whose run is paused;
 - aborted turns pause without incrementing the unproductive-turn counter;
+- resuming an aborted step creates one new resumed message and one fresh model turn;
+- resuming a protected decision keeps its answer revision and does not create a duplicate decision message;
 - host restart does not close a live Pi turn, while an idle-session branch report can close an unended turn as lost;
 - two reminder-reason steps are sent at most once and the next unproductive turn fails;
 - initial, reminder, and resumed prompts use the same step kind and differ only by reason;

--- a/plugins/herdr/viewer.mjs
+++ b/plugins/herdr/viewer.mjs
@@ -12,12 +12,14 @@ if (!/^[A-Za-z0-9]+:p[A-Za-z0-9]+$/u.test(paneId)) {
   fail("HERDR_PANE_ID is missing or invalid.");
 }
 
-const herdr = process.env.HERDR_BIN_PATH ?? "herdr";
+const configuredHerdr = process.env.HERDR_BIN_PATH ?? "herdr";
 const label = `piw · ${runId}`;
-const labeled = spawnSync(herdr, ["pane", "rename", paneId, label], {
-  encoding: "utf8",
-  stdio: ["ignore", "ignore", "pipe"],
-});
+let herdr = configuredHerdr;
+let labeled = renamePane(herdr, paneId, label);
+if (labeled.error?.code === "ENOENT" && herdr !== "herdr") {
+  herdr = "herdr";
+  labeled = renamePane(herdr, paneId, label);
+}
 if (labeled.error) fail(`Could not label the Herdr viewer pane: ${labeled.error.message}`);
 if (labeled.status !== 0) {
   fail(`Could not label the Herdr viewer pane: ${bounded(labeled.stderr) || "unknown error"}`);
@@ -31,6 +33,13 @@ viewer.on("error", (error) => fail(`Could not start piw: ${error.message}`));
 viewer.on("exit", (code, signal) => {
   process.exitCode = signal ? 1 : (code ?? 1);
 });
+
+function renamePane(command, targetPaneId, targetLabel) {
+  return spawnSync(command, ["pane", "rename", targetPaneId, targetLabel], {
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+}
 
 function fail(message) {
   process.stderr.write(`${message}\n`);

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -428,6 +428,31 @@ async function waitForRunDisplay(client, runId, status, timeoutMs, rpc) {
   );
 }
 
+async function waitForPiIdle(rpc, timeoutMs = 30_000) {
+  return await waitFor(
+    "Pi to become idle",
+    async () => {
+      const state = requireObject(await rpc.request("get_state"), "Pi state");
+      return state.isStreaming === false && state.pendingMessageCount === 0;
+    },
+    { rpc, timeoutMs },
+  );
+}
+
+async function waitForCompletedSessionCapture(client, runId, rpc, timeoutMs = 30_000) {
+  return await waitFor(
+    `the completed workflow session capture for ${runId}`,
+    async () => {
+      const view = await client.getRun(runId);
+      return view?.session?.capture?.status === "complete" &&
+        view.session.integrity?.status === "complete"
+        ? view
+        : false;
+    },
+    { rpc, timeoutMs },
+  );
+}
+
 function assertOneFrame(output, workflowName, status) {
   const normalized = output.toLowerCase();
   if (!output.includes(workflowName) || !normalized.includes(status)) {
@@ -501,13 +526,80 @@ async function buildPiw(context) {
   return binary;
 }
 
+async function createIncompatibleState(candidate, databasePath) {
+  stage("creating an incompatible state fixture before Pi starts");
+  const stateModule = await import(
+    `${pathToFileURL(path.join(candidate, "dist", "state", "database.js")).href}?fixture=${Date.now()}`
+  );
+  const state = new stateModule.StateDatabase({ filePath: databasePath });
+  try {
+    state.connection
+      .prepare("UPDATE schema_meta SET app_version = ? WHERE id = 1")
+      .run("live-e2e-incompatible");
+  } finally {
+    state.close();
+  }
+}
+
+async function moveIncompatibleState(databasePath) {
+  const backupDirectory = path.join(path.dirname(databasePath), "incompatible-live-e2e");
+  await fs.mkdir(backupDirectory);
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const source = `${databasePath}${suffix}`;
+    try {
+      await fs.rename(source, path.join(backupDirectory, `state.sqlite${suffix}`));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function hasHostUnavailableNotice(rpc) {
+  return extensionUiEvents(rpc).some(
+    (event) =>
+      event.method === "notify" &&
+      event.notifyType === "warning" &&
+      typeof event.message === "string" &&
+      event.message.startsWith("Workflow host is unavailable:"),
+  );
+}
+
+async function waitForSessionCoordinator(client, sessionId, rpc) {
+  let coordinatorPresent = false;
+  const unsubscribe = await client.watchSession(sessionId, (event) => {
+    if (event.event === "session_snapshot" && typeof event.payload?.coordinatorEpoch === "string") {
+      coordinatorPresent = true;
+    }
+  });
+  try {
+    await waitFor(
+      "the existing Pi session to reconnect to the workflow host",
+      () => {
+        return coordinatorPresent;
+      },
+      { rpc, timeoutMs: 30_000 },
+    );
+  } finally {
+    await unsubscribe();
+  }
+  const notices = extensionUiEvents(rpc).filter(
+    (event) =>
+      event.method === "notify" &&
+      typeof event.message === "string" &&
+      event.message.startsWith("Workflow host is unavailable:"),
+  );
+  if (notices.length !== 1) {
+    throw new Error(`Expected one host-unavailable notice, observed ${notices.length}`);
+  }
+}
+
 async function startPi(context) {
   const args = [
     context.options.piEntry,
     "--mode",
     "rpc",
     "--session-id",
-    randomUUID(),
+    context.sessionId,
     "--session-dir",
     context.sessions,
     "--name",
@@ -631,6 +723,10 @@ async function runRuntimeWorkflow(context, rpc, client, piwBinary) {
     () => hasWorkflowUiState(rpc, workflowName, "completed", resumeEvents),
     { rpc, timeoutMs: 30_000 },
   );
+  if (!context.options.runtimeOnly) {
+    await waitForPiIdle(rpc, MODEL_TIMEOUT_MS);
+    await waitForCompletedSessionCapture(client, runId, rpc, MODEL_TIMEOUT_MS);
+  }
   await new Promise((resolve) => setTimeout(resolve, 2_000));
   if (hasWorkflowUiClear(rpc, resumeEvents)) {
     throw new Error("Pi cleared the completed workflow before its retention interval");
@@ -725,6 +821,9 @@ async function runModelWorkflow(context, rpc, client, api) {
     throw new Error(`Model workflow step was not accepted: ${JSON.stringify(step)}`);
   }
 
+  await waitForPiIdle(rpc, MODEL_TIMEOUT_MS);
+  await waitForCompletedSessionCapture(client, run.runId, rpc, MODEL_TIMEOUT_MS);
+
   const entriesData = requireObject(await rpc.request("get_entries"), "Pi entries response");
   if (!Array.isArray(entriesData.entries)) throw new Error("Pi returned no session entries");
   const deliveries = entriesData.entries.filter(
@@ -801,6 +900,7 @@ async function execute(root, options) {
     profile,
     project: path.join(root, "project"),
     root,
+    sessionId: randomUUID(),
     sessions: path.join(root, "sessions"),
     temporary: path.join(root, "tmp"),
     xdgCache: path.join(root, "xdg-cache"),
@@ -876,18 +976,30 @@ async function execute(root, options) {
       await runProcess("rustc", ["--version"], context.processOptions(context.project))
     ).stdout.trim();
 
+    const databasePath = path.join(context.home, ".pi", "agent", "workflows", "state.sqlite");
+    await createIncompatibleState(candidate, databasePath);
     rpc = await startPi(context);
     await assertPackageIsolation(rpc, candidate);
+    await waitFor(
+      "the initial incompatible-state host failure",
+      () => hasHostUnavailableNotice(rpc),
+      {
+        rpc,
+        timeoutMs: 30_000,
+      },
+    );
+    await moveIncompatibleState(databasePath);
+
     const clientModule = await import(
       `${pathToFileURL(path.join(candidate, "dist", "client", "index.js")).href}?live=${Date.now()}`
     );
-    const databasePath = path.join(context.home, ".pi", "agent", "workflows", "state.sqlite");
     client = new clientModule.WorkflowClient({
       clientId: `live-e2e-${randomUUID()}`,
       databasePath,
       env: context.env,
     });
     await client.ensureAvailable();
+    await waitForSessionCoordinator(client, context.sessionId, rpc);
 
     const runtimeRunId = await runRuntimeWorkflow(context, rpc, client, piwBinary);
     let modelRunId;

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -175,6 +175,8 @@ export default function piWorkflows(pi: ExtensionAPI): void {
   let sessionContext: ExtensionContext | null = null;
   let sessionGeneration = 0;
   let sessionUnsubscribe: (() => Promise<void>) | null = null;
+  let sessionConnectTask: Promise<void> | null = null;
+  let hostUnavailableNotified = false;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let presentationTail = Promise.resolve();
   let toolTail = Promise.resolve();
@@ -547,76 +549,100 @@ export default function piWorkflows(pi: ExtensionAPI): void {
 
   pi.on("session_start", (_event, ctx) => {
     sessionContext = ctx;
+    hostUnavailableNotified = false;
     const sessionId = ctx.sessionManager.getSessionId();
     const generation = ++sessionGeneration;
     let snapshotGeneration = 0;
     const sessionClient = client;
+
+    const connectSession = (): void => {
+      if (
+        generation !== sessionGeneration ||
+        sessionContext !== ctx ||
+        sessionUnsubscribe !== null ||
+        sessionConnectTask !== null
+      ) {
+        return;
+      }
+      const task = (async () => {
+        try {
+          await sessionClient.ensureAvailable();
+          const unsubscribe = await sessionClient.watchSession(
+            sessionId,
+            (event) => {
+              if (generation !== sessionGeneration || sessionContext !== ctx) return;
+              const currentSnapshotGeneration = ++snapshotGeneration;
+              if (event.event === "unavailable") {
+                sessionSnapshots.delete(sessionId);
+                sessionView.clear(ctx);
+                return;
+              }
+              if (!isWorkflowSessionView(event.payload)) return;
+              void materializeSessionView(sessionClient, event.payload)
+                .then((session) => {
+                  if (
+                    generation !== sessionGeneration ||
+                    currentSnapshotGeneration !== snapshotGeneration ||
+                    sessionContext !== ctx
+                  ) {
+                    return;
+                  }
+                  sessionSnapshots.set(sessionId, session);
+                  workflowMessages.updateView(session);
+                  sessionView.update(session, ctx);
+                  const ownedMessageId =
+                    session.nextWorkflowMessageId ?? session.openWorkflowMessageId;
+                  const ownedMessage = session.workflowMessages.find(
+                    (message) => message.workflowMessageId === ownedMessageId,
+                  );
+                  const prepare =
+                    ownedMessage !== undefined &&
+                    (ownedMessage.kind === "step" ||
+                      ownedMessage.kind === "terminal" ||
+                      ownedMessage.kind === "followUp")
+                      ? ensureRecorder(ownedMessage, ctx)
+                      : Promise.resolve();
+                  void prepare.then(async () => await presentInOrder(ctx)).catch(() => undefined);
+                })
+                .catch(() => {
+                  // A newer session revision retries from its own stable snapshot.
+                });
+            },
+            { coordinator: true },
+          );
+          if (generation !== sessionGeneration || sessionContext !== ctx) {
+            await unsubscribe();
+            return;
+          }
+          sessionUnsubscribe = unsubscribe;
+          hostUnavailableNotified = false;
+          const capability = await herdrViewer.probe();
+          if (generation !== sessionGeneration || sessionContext !== ctx) return;
+          sessionView.setActionHint(capability.available ? PIW_SHORTCUT_HINT : undefined, ctx);
+          await presentInOrder(ctx);
+        } catch (error) {
+          if (
+            generation === sessionGeneration &&
+            sessionContext === ctx &&
+            !hostUnavailableNotified
+          ) {
+            hostUnavailableNotified = true;
+            ctx.ui.notify(`Workflow host is unavailable: ${errorMessage(error)}`, "warning");
+          }
+        }
+      })();
+      sessionConnectTask = task;
+      void task.finally(() => {
+        if (sessionConnectTask === task) sessionConnectTask = null;
+      });
+    };
+
     pollTimer = setInterval(() => {
+      connectSession();
       if (sessionContext !== null) void presentInOrder(sessionContext).catch(() => undefined);
     }, INTERACTION_POLL_MS);
     pollTimer.unref?.();
-
-    void (async () => {
-      try {
-        await sessionClient.ensureAvailable();
-        const unsubscribe = await sessionClient.watchSession(
-          sessionId,
-          (event) => {
-            if (generation !== sessionGeneration || sessionContext !== ctx) return;
-            const currentSnapshotGeneration = ++snapshotGeneration;
-            if (event.event === "unavailable") {
-              sessionSnapshots.delete(sessionId);
-              sessionView.clear(ctx);
-              return;
-            }
-            if (!isWorkflowSessionView(event.payload)) return;
-            void materializeSessionView(sessionClient, event.payload)
-              .then((session) => {
-                if (
-                  generation !== sessionGeneration ||
-                  currentSnapshotGeneration !== snapshotGeneration ||
-                  sessionContext !== ctx
-                ) {
-                  return;
-                }
-                sessionSnapshots.set(sessionId, session);
-                workflowMessages.updateView(session);
-                sessionView.update(session, ctx);
-                const ownedMessageId =
-                  session.nextWorkflowMessageId ?? session.openWorkflowMessageId;
-                const ownedMessage = session.workflowMessages.find(
-                  (message) => message.workflowMessageId === ownedMessageId,
-                );
-                const prepare =
-                  ownedMessage !== undefined &&
-                  (ownedMessage.kind === "step" ||
-                    ownedMessage.kind === "terminal" ||
-                    ownedMessage.kind === "followUp")
-                    ? ensureRecorder(ownedMessage, ctx)
-                    : Promise.resolve();
-                void prepare.then(async () => await presentInOrder(ctx)).catch(() => undefined);
-              })
-              .catch(() => {
-                // A newer session revision retries from its own stable snapshot.
-              });
-          },
-          { coordinator: true },
-        );
-        if (generation !== sessionGeneration || sessionContext !== ctx) {
-          await unsubscribe();
-          return;
-        }
-        sessionUnsubscribe = unsubscribe;
-        const capability = await herdrViewer.probe();
-        if (generation !== sessionGeneration || sessionContext !== ctx) return;
-        sessionView.setActionHint(capability.available ? PIW_SHORTCUT_HINT : undefined, ctx);
-        await presentInOrder(ctx);
-      } catch (error) {
-        if (generation === sessionGeneration && sessionContext === ctx) {
-          ctx.ui.notify(`Workflow host is unavailable: ${errorMessage(error)}`, "warning");
-        }
-      }
-    })();
+    connectSession();
   });
 
   pi.on("session_tree", async (_event, ctx) => {
@@ -654,10 +680,23 @@ export default function piWorkflows(pi: ExtensionAPI): void {
     } catch (error) {
       ctx.ui.notify(`Workflow response was rejected: ${errorMessage(error)}`, "error");
     }
+    const finishedMessage = workflowMessages.activeTurnMessage();
     workflowMessages.endTurn(
       workflowTurnStopReason(event.messages, ctx.signal?.aborted === true),
       responseEntryId(ctx.sessionManager.getBranch()),
     );
+    if (
+      activeRecorder !== null &&
+      finishedMessage !== undefined &&
+      (finishedMessage.kind === "terminal" || finishedMessage.kind === "followUp")
+    ) {
+      const finishedRecorder = activeRecorder;
+      activeRecorder = null;
+      await finishedRecorder.finish();
+      if (sessionRecorders.get(finishedMessage.runId) === finishedRecorder) {
+        sessionRecorders.delete(finishedMessage.runId);
+      }
+    }
     await presentInOrder(ctx).catch((error) => {
       ctx.ui.notify(`Could not record workflow model activity: ${errorMessage(error)}`, "warning");
     });
@@ -720,6 +759,8 @@ export default function piWorkflows(pi: ExtensionAPI): void {
     pollTimer = null;
     if (sessionUnsubscribe !== null) await sessionUnsubscribe().catch(() => undefined);
     sessionUnsubscribe = null;
+    sessionConnectTask = null;
+    hostUnavailableNotified = false;
     await client.close();
     client = new WorkflowClient({ clientId: `pi-extension-${randomUUID()}` });
   });

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -1233,7 +1233,15 @@ export class WorkflowHost {
       }
       case "run.resume": {
         const runId = requireRunId(request);
-        if (this.queue.resumePausedInteraction({ runId })) {
+        const resumedInteraction = this.state.transaction(() => {
+          const now = Date.now();
+          if (!this.queue.resumePausedInteraction({ runId, now: new Date(now).toISOString() })) {
+            return false;
+          }
+          this.hostState.resumePendingInteraction(runId, now);
+          return true;
+        });
+        if (resumedInteraction) {
           return {
             outcome: "accepted",
             receipt: {

--- a/src/host/state.ts
+++ b/src/host/state.ts
@@ -517,6 +517,31 @@ export class HostStateStore {
     });
   }
 
+  resumePendingInteraction(runId: string, now: number = Date.now()): InteractiveRequestRecord {
+    return this.state.transaction(() => {
+      const row = this.state.connection
+        .prepare(
+          `SELECT request_id AS requestId FROM interactive_requests
+           WHERE run_id = ? AND status = 'pending' ORDER BY created_at LIMIT 1`,
+        )
+        .get(runId);
+      if (!isRequestIdRow(row)) throw new Error("Pending workflow interaction is missing");
+      const current = this.requireInteractiveRequest(row.requestId);
+      if (current.kind === "decision") return current;
+      this.workflowMessages.cancelPendingForSource(current.requestId, "step", now);
+      const changed = this.state.connection
+        .prepare(
+          `UPDATE interactive_requests SET revision = revision + 1, updated_at = ?
+           WHERE request_id = ? AND status = 'pending'`,
+        )
+        .run(now, row.requestId);
+      if (changed.changes !== 1) throw new Error("Pending workflow interaction resume is stale");
+      const request = this.requireInteractiveRequest(row.requestId);
+      this.ensureInteractionMessage(request, "resumed", now);
+      return request;
+    });
+  }
+
   getInteraction(requestId: string): InteractiveRequestRecord | undefined {
     return this.interactiveRequest(requestId);
   }

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -1464,7 +1464,6 @@ export class WorkflowRunStore {
     this.verifySettingsProjections(runId);
     const revision = this.resourceRevision(runId);
     this.contexts.set(runId, { revision, lock: Promise.resolve() });
-    this.finalizeRecordingCaptures(runId, "Workflow host stopped before the run finished");
     this.state.transaction(() => {
       const row = this.requireRunRow(runId);
       const context = this.contextFor(runId);

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -63,6 +63,21 @@ export default defineWorkflow({
 });
 `;
 
+const PAUSE_RESUME_WORKFLOW = `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "pause-resume-e2e",
+  startAt: "work",
+  nodes: {
+    work: agent({
+      prompt: () => "Submit the durable pause and resume E2E result.",
+      expectedOutput: '{ "resumed": true }',
+    }),
+  },
+  edges: [],
+});
+`;
+
 const CONTROLLER = `import { conditionTrue, defineController } from "@osolmaz/pi-workflows/controllers";
 
 export default defineController({
@@ -382,6 +397,7 @@ describe.sequential("out-of-process workflow host end to end", () => {
   let databasePath: string;
   let sessionDir: string;
   let sessionId: string;
+  let holdPauseSubmission = true;
   let holdRestartSubmission = true;
 
   const piEnvironment = (): Record<string, string> => ({
@@ -413,6 +429,21 @@ describe.sequential("out-of-process workflow host end to end", () => {
         }
         if (contract.workflow === "assistant-e2e" && contract.step === "present") {
           return { kind: "text", text: "Visible assistant E2E response." };
+        }
+        if (contract.workflow === "pause-resume-e2e") {
+          if (holdPauseSubmission) {
+            return { kind: "text", text: "Waiting for the pause. ".repeat(500) };
+          }
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "submit",
+              step: contract.step,
+              attempt: contract.attempt,
+              output: { resumed: true },
+            },
+          };
         }
         if (contract.workflow === "restart-e2e") {
           if (holdRestartSubmission) {
@@ -448,6 +479,10 @@ describe.sequential("out-of-process workflow host end to end", () => {
     await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "restart-e2e.workflow.ts"),
       RESTART_WORKFLOW,
+    );
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "pause-resume-e2e.workflow.ts"),
+      PAUSE_RESUME_WORKFLOW,
     );
     await fs.writeFile(
       path.join(projectDir, ".pi", "controllers", "hosted-e2e.controller.ts"),
@@ -556,6 +591,93 @@ describe.sequential("out-of-process workflow host end to end", () => {
       store.close();
     }
   }, 60_000);
+
+  it("starts a fresh origin-session turn after pause and resume", async () => {
+    const requestStart = mock.requests.length;
+    pi.send({ id: "pause-start", type: "prompt", message: "/workflow pause-resume-e2e" });
+    await waitForCondition(
+      () =>
+        mock.requests
+          .slice(requestStart)
+          .some(({ messages }) =>
+            JSON.stringify(messages.at(-1)).includes(
+              "Submit the durable pause and resume E2E result.",
+            ),
+          ),
+      () => rpcDiagnostic(pi),
+      30_000,
+    );
+
+    pi.send({ id: "pause-abort", type: "abort" });
+    const paused = await waitForRun(
+      databasePath,
+      "pause-resume-e2e",
+      (candidate) => candidate.paused === true,
+      () => rpcDiagnostic(pi),
+    );
+    await waitForPiIdle(pi);
+
+    holdPauseSubmission = false;
+    pi.send({ id: "pause-resume", type: "prompt", message: "/workflow resume" });
+    const { state } = await waitForRun(
+      databasePath,
+      "pause-resume-e2e",
+      (candidate) => candidate.status === "completed",
+      () => rpcDiagnostic(pi),
+      60_000,
+    );
+    expect(state.finalOutput).toEqual({ resumed: true });
+    await waitForPiIdle(pi);
+
+    const client = new WorkflowClient({ databasePath });
+    let runReceipt: JsonValue | undefined;
+    await waitForCondition(
+      async () => {
+        const runView = await client.request({
+          operation: "view.run.get",
+          runId: paused.runId,
+        });
+        runReceipt = runView.receipt;
+        if (!isRecord(runReceipt) || !isRecord(runReceipt.session)) return false;
+        const { capture, integrity } = runReceipt.session;
+        return (
+          isRecord(capture) &&
+          capture.status === "complete" &&
+          isRecord(integrity) &&
+          integrity.status === "complete"
+        );
+      },
+      () => rpcDiagnostic(pi),
+      30_000,
+    );
+    await client.close();
+    expect(runReceipt).toMatchObject({
+      session: {
+        capture: { status: "complete" },
+        integrity: { status: "complete", diagnostics: [] },
+      },
+    });
+
+    const stepEntries = customEntriesForRun(
+      await readRpcEntries(pi),
+      "pi-workflows-step",
+      paused.runId,
+    );
+    expect(stepEntries).toHaveLength(2);
+    const details = stepEntries.map((entry) => entry.details).filter(isRecord);
+    expect(details.map((value) => value.reason)).toEqual(["initial", "resumed"]);
+    expect(new Set(details.map((value) => value.requestId))).toHaveLength(1);
+    expect(new Set(details.map((value) => value.workflowMessageId))).toHaveLength(2);
+    expect(
+      mock.requests
+        .slice(requestStart)
+        .filter(({ messages }) =>
+          JSON.stringify(messages.at(-1)).includes(
+            "Submit the durable pause and resume E2E result.",
+          ),
+        ),
+    ).toHaveLength(2);
+  }, 90_000);
 
   it("adopts one durable interaction across a real Pi restart", async () => {
     pi.send({ id: "restart-start", type: "prompt", message: "/workflow restart-e2e" });

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -352,6 +352,45 @@ describe("pi-workflows hosted extension", () => {
     }
   }, 30_000);
 
+  it("reconnects the session after initial host startup fails", async () => {
+    const { cwd, workflowPath } = await setupProject();
+    const originalEnsureAvailable = WorkflowClient.prototype.ensureAvailable;
+    const ensureAvailable = vi
+      .spyOn(WorkflowClient.prototype, "ensureAvailable")
+      .mockRejectedValueOnce(new Error("injected startup failure"))
+      .mockImplementation(function (this: WorkflowClient) {
+        return originalEnsureAvailable.call(this);
+      });
+    const watchSession = vi.spyOn(WorkflowClient.prototype, "watchSession");
+    const fake = makePi({ cwd });
+
+    await fake.emit("session_start");
+    await waitUntil(
+      () =>
+        fake.notifications.some(
+          (notification) =>
+            notification.level === "warning" &&
+            notification.message.includes("injected startup failure"),
+        ),
+      5_000,
+    );
+    await waitUntil(() => ensureAvailable.mock.calls.length >= 2, 30_000);
+    await waitUntil(() => watchSession.mock.calls.length === 1, 30_000);
+
+    await fake.runCommand(workflowPath);
+    await waitUntil(() => fake.sent.length === 1, 30_000);
+    await new Promise((resolve) => setTimeout(resolve, 1_200));
+
+    expect(fake.sent).toHaveLength(1);
+    expect(watchSession).toHaveBeenCalledTimes(1);
+    expect(
+      fake.notifications.filter((notification) =>
+        notification.message.startsWith("Workflow host is unavailable:"),
+      ),
+    ).toHaveLength(1);
+    await fake.emit("session_shutdown");
+  }, 60_000);
+
   it("starts, presents, updates, and completes an interactive hosted run", async () => {
     const { cwd, workflowPath } = await setupProject();
     const durableRequests = vi.spyOn(WorkflowClient.prototype, "requestDurable");
@@ -464,11 +503,21 @@ describe("pi-workflows hosted extension", () => {
         store.close();
       }
     }, 30_000);
+    await waitUntil(() => fake.sent.length === 2, 30_000);
+    expect(fake.sent[1]?.details).toMatchObject({
+      reason: "resumed",
+      requestId: (fake.sent[0]!.details as { requestId: string }).requestId,
+    });
+    expect((fake.sent[1]!.details as { workflowMessageId: string }).workflowMessageId).not.toBe(
+      (fake.sent[0]!.details as { workflowMessageId: string }).workflowMessageId,
+    );
+    const resumedContract = stepContract(fake.sent[1] as Record<string, unknown>);
+    expect(resumedContract).toEqual(contract);
     await expect(
       fake.runTool("resumed-submit", {
         action: "submit",
-        step: contract.nodeId,
-        attempt: contract.attemptId,
+        step: resumedContract.nodeId,
+        attempt: resumedContract.attemptId,
         output: { reply: "continued" },
       }),
     ).resolves.toMatchObject({ content: [{ text: "Workflow step output accepted." }] });

--- a/test/herdr-plugin.test.ts
+++ b/test/herdr-plugin.test.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeTempDir } from "./helpers.js";
+
+const VIEWER_ENTRY = path.resolve("plugins/herdr/viewer.mjs");
+
+async function writeFakeCommand(directory: string, name: string): Promise<void> {
+  const commandPath = path.join(directory, name);
+  await fs.writeFile(
+    commandPath,
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+fs.appendFileSync(
+  process.env.TEST_COMMAND_LOG,
+  JSON.stringify({ command: path.basename(process.argv[1]), args: process.argv.slice(2) }) + "\\n",
+);
+`,
+  );
+  await fs.chmod(commandPath, 0o700);
+}
+
+describe("Herdr piw plugin", () => {
+  it.skipIf(process.platform === "win32")(
+    "uses PATH when Herdr provides a deleted executable path",
+    async () => {
+      const root = await makeTempDir("pi-workflows-herdr-plugin");
+      const binaryDirectory = path.join(root, "bin");
+      const commandLog = path.join(root, "commands.jsonl");
+      await fs.mkdir(binaryDirectory);
+      await Promise.all([
+        writeFakeCommand(binaryDirectory, "herdr"),
+        writeFakeCommand(binaryDirectory, "piw"),
+      ]);
+
+      const child = spawn(process.execPath, [VIEWER_ENTRY], {
+        env: {
+          HERDR_BIN_PATH: path.join(root, "removed-herdr"),
+          HERDR_PANE_ID: "w1:p1",
+          PATH: `${binaryDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
+          PI_WORKFLOWS_RUN_ID: "20260903T120000Z-autoplan-test",
+          TEST_COMMAND_LOG: commandLog,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      let stderr = "";
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString("utf8");
+      });
+      const [code] = (await once(child, "close")) as [number | null];
+
+      expect(code, stderr).toBe(0);
+      const calls = (await fs.readFile(commandLog, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { command: string; args: string[] });
+      expect(calls).toEqual([
+        {
+          command: "herdr",
+          args: ["pane", "rename", "w1:p1", "piw · 20260903T120000Z-autoplan-test"],
+        },
+        { command: "piw", args: ["20260903T120000Z-autoplan-test"] },
+      ]);
+    },
+  );
+});

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1154,13 +1154,15 @@ setInterval(() => {}, 1000);
       expect(await client.request({ operation: "host.status" })).toMatchObject({
         outcome: "accepted",
       });
-      expect(await client.request({ operation: "channel.status" })).toMatchObject({
-        outcome: "accepted",
-        receipt: {
-          configured: false,
-          error: expect.stringContaining("references unknown channel"),
-        },
-      });
+      await expect
+        .poll(async () => await client.request({ operation: "channel.status" }))
+        .toMatchObject({
+          outcome: "accepted",
+          receipt: {
+            configured: false,
+            error: expect.stringContaining("references unknown channel"),
+          },
+        });
     } finally {
       await client.close();
       await host.stop();

--- a/test/sqlite-run-store-branches.test.ts
+++ b/test/sqlite-run-store-branches.test.ts
@@ -339,6 +339,23 @@ describe("WorkflowRunStore branch behavior", () => {
     store.close();
   });
 
+  it("keeps a live session capture open during normal run preparation", async () => {
+    const store = new WorkflowRunStore(await makeStateDatabasePath("run-recording-capture"));
+    await store.initializeRun(workflow, state("run-recording"));
+    await store.writeSessionBinding("run-recording", {
+      schema: SESSION_BINDING_SCHEMA,
+      runId: "run-recording",
+      piSessionId: "session-a",
+      cwd: "/tmp",
+      boundAt: new Date().toISOString(),
+    });
+    expect(store.readRun("run-recording")?.sessionCapture?.status).toBe("recording");
+    expect((await store.prepareRunResume("run-recording")).sessionCapture?.status).toBe(
+      "recording",
+    );
+    store.close();
+  });
+
   it("adopts an already terminal capture during run preparation", async () => {
     const store = new WorkflowRunStore(await makeStateDatabasePath("run-terminal-capture"));
     await store.initializeRun(workflow, state("run-5"));


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Open Pi sessions could fail to reconnect after the workflow host was reset, resumed workflow steps could remain stuck, and a completed run could falsely report that the host stopped.
This change restores those paths, keeps the Herdr viewer working after a Herdr binary replacement, and adds regression coverage for the failures seen in a real Pi tab.

## What Changed

The origin Pi session now recovers without a restart, and a resumed step always gets a fresh model turn.
Completed session recordings now close only after the terminal or follow-up turn ends.

- Retry the initial workflow-host connection from the existing Pi session, with one bounded warning per outage.
- Create one new durable workflow message when an interrupted agent or assistant step resumes.
- Keep protected decision revisions stable during resume.
- Keep an active session recording open across normal host worker continuation, then finish it after the terminal or follow-up model turn.
- Retry Herdr pane labeling through `PATH` when the server's configured Herdr executable no longer exists.
- Extend the installed live E2E to cover incompatible-state recovery, existing-session reconnect, terminal retention, and complete session recording.

## Testing

The automated checks pass, and the complete behavior also passed in a new Herdr tab with only Pi Workflows loaded.
The live model was the exact requested `openai/gpt-5.6-luna` model through Pi's `openai-responses` API.

- `npm run check` — 98 files and 1,139 tests passed; coverage remained above all 85% thresholds.
- `npm run test:e2e` — 3 files and 10 real-Pi-runtime tests passed.
- `npm run test:e2e:live -- --runtime-only` — passed with installed package `0.16.0` and Pi `0.84.2`.
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna` — passed; model cost was $0.00097417.
- Clean Herdr Pi `0.84.4` tab with only this extension — verified running widget, durable Escape pause, `/workflow resume`, a fresh resumed model turn, completion, `Ctrl+Shift+R`, piw, complete session capture, and zero integrity diagnostics.
- `npx slophammer-ts@latest dry .` — passed.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — passed.
- `git diff --check` — passed.
- `npx -y @simpledoc/simpledoc check` — retained the existing baseline of nine unrelated old naming and frontmatter findings; this change added none.

## Risks

The risk is limited to workflow-session coordination and viewer startup.
The new deterministic and installed tests cover the observed restart, resume, recording, widget, and viewer failures.

- A real provider can respond slowly, so the installed E2E now starts the retention check only after Pi is idle and the session recording is complete.
- The Herdr fallback runs only for `ENOENT`; other launcher errors remain visible instead of being hidden.
