### PR TITLE
fix: align active workflow node status

### DIFF
--- a/docs/WORKFLOW_HOST.md
+++ b/docs/WORKFLOW_HOST.md
@@ -237,6 +237,8 @@ The protocol owns four operation groups:
 
 The host returns one canonical `pi-workflows.run-view.v1` document. It contains the existing bounded workflow projection and page cursors plus a `display` object. The queue field contains display metadata only. It does not repeat the input, launch options, worker affinity, or claim capability; the complete input remains reachable through the state projection. The `display` object contains the effective status, current activity kind, allowed controls, and the stored reason when action is required. A reason above the shared 16 KiB inline-content threshold uses a small `reason` notice and a digest-bound `reasonContent` reference, so one diagnostic cannot exceed the 1 MiB protocol frame while the complete reason remains available. Renderers use this object directly. They must not combine separate queries or infer status from durable rows.
 
+The unfinished node-attempt row is the one durable source for the current node. A running run exposes it as `currentNode`. A parked interactive run exposes the same node as `waitingOn`. A checkpoint has no unfinished attempt, so its completed checkpoint node supplies `waitingOn`. During an exact origin-session model turn, the host `display` changes that waiting node to running for presentation only. It does not infer another node or change the durable run state.
+
 Generated referenced content is stored directly in `run_view_content` under its exact run ID, content digest, and media type. It does not share general state-blob media metadata. A content read must match all three values, so a reference from another run or another media representation is unavailable.
 
 The origin-session response contains the active run view. When no run is active, it keeps the most recent terminal run visible while its terminal workflow message is pending or its first model turn is open, and then for 60 seconds after that turn ends. A newer run or `sessionView.clearTerminal` removes the retained terminal view. `/workflow clear` and the matching `piw` action call that control without changing workflow state.
@@ -524,6 +526,8 @@ The implementation conforms when:
 - the production package contains no embedded execution fallback;
 - the host is the only production process that opens live SQLite state;
 - the widget, status line, Herdr actions, CLI, and `piw` render the same host-produced status and controls;
+- running and waiting projections identify the current workflow node from the same unfinished attempt, while checkpoint waits use the completed checkpoint node;
+- an exact origin-session model turn presents that same waiting node as running without changing its durable identity;
 - a busy origin session displays `running` for the full exact workflow turn, including a terminal or pausing turn, and a stale turn-end report cannot clear newer activity;
 - normal worker continuation does not fail an active Pi session capture or report a false host interruption;
 - `paused` appears only after a durable pause and matching turn end;

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -123,9 +123,7 @@ export function buildWidgetView(
     footer.push(paint(theme, "error", `  error: ${truncate(sanitizeText(state.error), 120)}`));
   }
   if (status === "waiting" && state.waitingOn) {
-    footer.push(
-      paint(theme, "warning", `  waiting on checkpoint: ${sanitizeText(state.waitingOn)}`),
-    );
+    footer.push(paint(theme, "warning", `  waiting on step: ${sanitizeText(state.waitingOn)}`));
   }
   const hint = actionHint?.trim() ? sanitizeText(actionHint) : undefined;
   const progress = progressLines(state, now, updateHistory).slice(0, 4);

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -38,16 +38,27 @@ const STATUS_GLYPHS: Record<WorkflowDisplayStatus, string> = {
 const PI_MAX_WIDGET_LINES = 10;
 const MAX_NODE_ERROR_CHARS = 120;
 
-export function nodeGlyph(state: WorkflowRunState, nodeId: string): string {
-  if (state.currentNode === nodeId) {
+function displayedRunningNode(
+  state: WorkflowRunState,
+  displayStatus: WorkflowDisplayStatus | undefined,
+): string | undefined {
+  return state.currentNode ?? (displayStatus === "running" ? state.waitingOn : undefined);
+}
+
+export function nodeGlyph(
+  state: WorkflowRunState,
+  nodeId: string,
+  displayStatus?: WorkflowDisplayStatus,
+): string {
+  if (displayedRunningNode(state, displayStatus) === nodeId) {
     return "◐";
+  }
+  if (state.waitingOn === nodeId) {
+    return "⏸";
   }
   const result = state.results[nodeId];
   if (!result) {
     return "·";
-  }
-  if (state.waitingOn === nodeId) {
-    return "⏸";
   }
   return result.outcome === "ok" ? "✓" : "✗";
 }
@@ -120,7 +131,7 @@ export function buildWidgetView(
   const progress = progressLines(state, now, updateHistory).slice(0, 4);
   const baseBudget = PI_MAX_WIDGET_LINES - 1 - footer.length - progress.length;
   const nodes = displayNodeIds(snapshot).map((nodeId) =>
-    compactNodeLine(state, snapshot, nodeId, now, paused, theme),
+    compactNodeLine(state, snapshot, nodeId, now, paused, status, theme),
   );
   const combineHintWithWindow =
     hint !== undefined && nodes.length > 0 && nodes.length + 1 > baseBudget;
@@ -268,15 +279,17 @@ function compactNodeLine(
   nodeId: string,
   now: Date,
   paused: boolean,
+  displayStatus: WorkflowDisplayStatus,
   theme?: WidgetTheme,
 ): string {
   const node = snapshot.nodes[nodeId];
-  const glyph = nodeGlyph(state, nodeId);
+  const runningNode = displayedRunningNode(state, displayStatus);
+  const isCurrent = runningNode === nodeId;
+  const isWaiting = state.waitingOn === nodeId && !isCurrent;
+  const glyph = nodeGlyph(state, nodeId, displayStatus);
   const typeGlyph = node ? nodeTypeGlyph(node.nodeType, node.actionExecution) : "?";
   const name = sanitizeText(nodeId);
-  const segments = nodeRuntimeSegments(state, snapshot, nodeId, now);
-  const isCurrent = state.currentNode === nodeId;
-  const isWaiting = state.waitingOn === nodeId;
+  const segments = nodeRuntimeSegments(state, snapshot, nodeId, now, isCurrent);
 
   if (isCurrent || isWaiting) {
     const tone = paused || isWaiting ? "warning" : "accent";
@@ -309,6 +322,7 @@ function nodeRuntimeSegments(
   snapshot: WorkflowDefinitionSnapshot,
   nodeId: string,
   now: Date,
+  isCurrent: boolean,
 ): string[] {
   const segments: string[] = [];
   const node = snapshot.nodes[nodeId];
@@ -320,11 +334,11 @@ function nodeRuntimeSegments(
     segments.push("assistant response");
   }
   const completedAttempts = state.steps.filter((step) => step.nodeId === nodeId).length;
-  const attempts = completedAttempts + (state.currentNode === nodeId ? 1 : 0);
+  const attempts = completedAttempts + (isCurrent ? 1 : 0);
   if (attempts > 1) {
     segments.push(`↻${attempts}`);
   }
-  if (state.currentNode === nodeId && state.currentSettingsChangeNumber !== undefined) {
+  if (isCurrent && state.currentSettingsChangeNumber !== undefined) {
     segments.push(`settings ${state.currentSettingsChangeNumber}`);
   } else {
     const latest = state.steps.findLast((step) => step.nodeId === nodeId);
@@ -334,8 +348,8 @@ function nodeRuntimeSegments(
   }
 
   const result = state.results[nodeId];
-  if (state.currentNode === nodeId) {
-    if (state.statusDetail) {
+  if (isCurrent) {
+    if (state.currentNode === nodeId && state.statusDetail) {
       segments.push(sanitizeText(state.statusDetail));
     }
     const elapsed = elapsedSince(state.currentNodeStartedAt, now);

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -3478,7 +3478,15 @@ export class WorkflowRunStore {
   ): WorkflowRunState {
     const sources = this.readRunSources(row.runId, snapshot);
     const carriedStepCount = this.carriedStepCount(row.runId);
-    const activeAttempt = row.status === "running" ? this.readActiveAttempt(row.runId) : undefined;
+    const activeAttempt =
+      row.status === "running" || row.status === "waiting"
+        ? this.readActiveAttempt(row.runId)
+        : undefined;
+    const runningAttempt = row.status === "running" ? activeAttempt : undefined;
+    const waitingNode =
+      row.status === "waiting"
+        ? (activeAttempt?.nodeId ?? projectionSteps.at(-1)?.nodeId)
+        : undefined;
     const humanDecision = this.readHumanDecisionReceipt(row.runId);
     const outputs: Record<string, unknown> = {};
     const results: Record<string, WorkflowNodeResult> = {};
@@ -3520,7 +3528,7 @@ export class WorkflowRunStore {
       results,
       steps: visibleSteps,
       ...(visibleUpdates.length === 0 ? {} : { updates: visibleUpdates }),
-      ...(activeAttempt === undefined ? {} : { currentNode: activeAttempt.nodeId }),
+      ...(runningAttempt === undefined ? {} : { currentNode: runningAttempt.nodeId }),
       ...(activeAttempt === undefined ? {} : { currentAttemptId: activeAttempt.attemptId }),
       ...(activeAttempt?.startedAt === null || activeAttempt === undefined
         ? {}
@@ -3541,9 +3549,7 @@ export class WorkflowRunStore {
       ...(row.statusDetail === null ? {} : { statusDetail: row.statusDetail }),
       ...(humanDecision === undefined ? {} : { humanDecision }),
       ...(row.paused === 0 ? {} : { paused: true }),
-      ...(row.status === "waiting" && projectionSteps.at(-1) !== undefined
-        ? { waitingOn: projectionSteps.at(-1)?.nodeId as string }
-        : {}),
+      ...(waitingNode === undefined ? {} : { waitingOn: waitingNode }),
       ...(row.finalOutputHash === null
         ? {}
         : { finalOutput: this.state.readJson(row.finalOutputHash) }),

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -607,8 +607,10 @@ describe.sequential("out-of-process workflow host end to end", () => {
       currentAttemptId: expect.any(String),
       results: { first: { outcome: "ok" } },
     });
+    if (!isRecord(runView.state) || typeof runView.state.currentAttemptId !== "string") {
+      throw new Error("Current attempt disappeared");
+    }
     const currentAttemptId = runView.state.currentAttemptId;
-    if (currentAttemptId === undefined) throw new Error("Current attempt disappeared");
     const { stdout: piwOutput } = await execFileAsync(
       process.execPath,
       ["--import", "tsx", path.join(REPO_ROOT, "src", "viewer", "cli.ts"), "view", runId, "--once"],

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { WorkflowClient } from "../../src/client/client.js";
 import { SqliteControllerStore } from "../../src/controllers/sqlite.js";
+import { buildWidgetView } from "../../src/extension/widget.js";
 import { HostStateStore, type InteractiveRequestRecord } from "../../src/host/state.js";
 import { workflowStatePath } from "../../src/state/database.js";
 import { parseJson, type JsonValue } from "../../src/state/json.js";
@@ -75,6 +76,25 @@ export default defineWorkflow({
     }),
   },
   edges: [],
+});
+`;
+
+const MULTI_STEP_WIDGET_WORKFLOW = `import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+
+export default defineWorkflow({
+  name: "multi-step-widget-e2e",
+  startAt: "first",
+  nodes: {
+    first: agent({
+      prompt: () => "Submit the first multi-step widget result.",
+      expectedOutput: '{ "first": true }',
+    }),
+    second: agent({
+      prompt: () => "Submit the second multi-step widget result.",
+      expectedOutput: '{ "second": true }',
+    }),
+  },
+  edges: [{ from: "first", to: "second" }],
 });
 `;
 
@@ -430,6 +450,21 @@ describe.sequential("out-of-process workflow host end to end", () => {
         if (contract.workflow === "assistant-e2e" && contract.step === "present") {
           return { kind: "text", text: "Visible assistant E2E response." };
         }
+        if (contract.workflow === "multi-step-widget-e2e") {
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "submit",
+              step: contract.step,
+              attempt: contract.attempt,
+              output: contract.step === "first" ? { first: true } : { second: true },
+            },
+            ...(contract.step === "second"
+              ? { thinking: "Hold the second workflow turn open for inspection. ".repeat(300) }
+              : {}),
+          };
+        }
         if (contract.workflow === "pause-resume-e2e") {
           if (holdPauseSubmission) {
             return { kind: "text", text: "Waiting for the pause. ".repeat(500) };
@@ -462,7 +497,12 @@ describe.sequential("out-of-process workflow host end to end", () => {
         }
         return { kind: "text", text: "No scripted response." };
       },
-      { textChunkSize: 7, toolArgumentChunkSize: 11, chunkDelayMs: 5 },
+      {
+        textChunkSize: 7,
+        thinkingChunkSize: 10,
+        toolArgumentChunkSize: 11,
+        chunkDelayMs: 5,
+      },
     );
 
     projectDir = await makeTempDir("pi-workflows-host-e2e-project");
@@ -483,6 +523,10 @@ describe.sequential("out-of-process workflow host end to end", () => {
     await fs.writeFile(
       path.join(projectDir, ".pi", "workflows", "pause-resume-e2e.workflow.ts"),
       PAUSE_RESUME_WORKFLOW,
+    );
+    await fs.writeFile(
+      path.join(projectDir, ".pi", "workflows", "multi-step-widget-e2e.workflow.ts"),
+      MULTI_STEP_WIDGET_WORKFLOW,
     );
     await fs.writeFile(
       path.join(projectDir, ".pi", "controllers", "hosted-e2e.controller.ts"),
@@ -527,6 +571,95 @@ describe.sequential("out-of-process workflow host end to end", () => {
     }
     await mock?.close();
   });
+
+  it("marks a completed agent node done while the next agent turn runs", async () => {
+    const requestStart = mock.requests.length;
+    pi.send({
+      id: "multi-step-widget-start",
+      type: "prompt",
+      message: "/workflow multi-step-widget-e2e",
+    });
+    await waitForCondition(
+      () =>
+        mock.requests
+          .slice(requestStart)
+          .some(({ messages }) =>
+            JSON.stringify(messages.at(-1)).includes("Submit the second multi-step widget result."),
+          ),
+      () => rpcDiagnostic(pi),
+      30_000,
+    );
+
+    const { runId } = await waitForRun(
+      databasePath,
+      "multi-step-widget-e2e",
+      (candidate) => candidate.results.first?.outcome === "ok",
+      () => rpcDiagnostic(pi),
+    );
+    const client = new WorkflowClient({ databasePath });
+    const runView = await client.getRun(runId);
+    await client.close();
+    if (runView === null) throw new Error("Multi-step widget run view disappeared");
+    expect(runView.display).toMatchObject({ status: "running", activity: "origin_turn" });
+    expect(runView.state).toMatchObject({
+      status: "waiting",
+      waitingOn: "second",
+      currentAttemptId: expect.any(String),
+      results: { first: { outcome: "ok" } },
+    });
+    const currentAttemptId = runView.state.currentAttemptId;
+    if (currentAttemptId === undefined) throw new Error("Current attempt disappeared");
+    const { stdout: piwOutput } = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", path.join(REPO_ROOT, "src", "viewer", "cli.ts"), "view", runId, "--once"],
+      { cwd: REPO_ROOT, env: { ...process.env, ...piEnvironment() } },
+    );
+    expect(piwOutput).toContain("● running");
+    expect(piwOutput).toContain("✓ first · ok");
+    expect(piwOutput).not.toContain("○ waiting");
+
+    const store = new WorkflowRunStore(databasePath, { readOnly: true });
+    try {
+      const loaded = store.readRun(runId);
+      if (loaded === null) throw new Error("Multi-step widget run disappeared");
+      expect(loaded.state).toMatchObject({
+        status: "waiting",
+        waitingOn: "second",
+        currentAttemptId,
+        results: { first: { outcome: "ok" } },
+      });
+      expect(loaded.state.currentNode).toBeUndefined();
+
+      const lines = buildWidgetView(
+        loaded.state,
+        loaded.snapshot,
+        undefined,
+        null,
+        false,
+        100,
+        undefined,
+        undefined,
+        undefined,
+        runView.display.status,
+      ).lines;
+      expect(lines.find((line) => line.includes("first"))).toContain("✓");
+      expect(lines.find((line) => line.includes("second"))).toContain("◐");
+      expect(lines.join("\n")).not.toContain("second · waiting");
+    } finally {
+      store.close();
+    }
+
+    const completed = await waitForRun(
+      databasePath,
+      "multi-step-widget-e2e",
+      (candidate) => candidate.status === "completed",
+      () => rpcDiagnostic(pi),
+    );
+    expect(completed.state.results).toMatchObject({
+      first: { outcome: "ok" },
+      second: { outcome: "ok" },
+    });
+  }, 60_000);
 
   it("runs structured and visible agent steps through the origin Pi session", async () => {
     pi.send({ id: "assistant-start", type: "prompt", message: "/workflow assistant-e2e" });
@@ -694,6 +827,16 @@ describe.sequential("out-of-process workflow host end to end", () => {
       interaction.requestId,
     );
     expect(new Set(requestEntriesBeforeRestart)).toHaveLength(requestEntriesBeforeRestart.length);
+    const beforeRestartStore = new WorkflowRunStore(databasePath, { readOnly: true });
+    try {
+      expect(beforeRestartStore.readRun(interaction.runId)?.state).toMatchObject({
+        status: "waiting",
+        waitingOn: "work",
+        currentAttemptId: interaction.attemptId,
+      });
+    } finally {
+      beforeRestartStore.close();
+    }
 
     await pi.stop();
     const sessionFileName = (await fs.readdir(sessionDir)).find((name) => name.includes(sessionId));
@@ -707,6 +850,16 @@ describe.sequential("out-of-process workflow host end to end", () => {
     });
     await waitForRequestEntries(pi, interaction.requestId, requestEntriesBeforeRestart);
     await waitForPiIdle(pi);
+    const afterRestartStore = new WorkflowRunStore(databasePath, { readOnly: true });
+    try {
+      expect(afterRestartStore.readRun(interaction.runId)?.state).toMatchObject({
+        status: "waiting",
+        waitingOn: "work",
+        currentAttemptId: interaction.attemptId,
+      });
+    } finally {
+      afterRestartStore.close();
+    }
 
     holdRestartSubmission = false;
     pi.send({ id: "restart-continue", type: "prompt", message: "Complete the pending workflow." });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -11,7 +11,7 @@ import {
   listWorkflowRuns,
   readWorkflowRun,
 } from "../src/workflows/store.js";
-import { ScriptedExecutor, makeStateDatabasePath } from "./helpers.js";
+import { ScriptedExecutor, makeStateDatabasePath, waitUntil } from "./helpers.js";
 
 describe("WorkflowRunStore SQLite", () => {
   it("stores one complete run, definition, events, attempts, and output", async () => {
@@ -52,6 +52,54 @@ describe("WorkflowRunStore SQLite", () => {
     expect(store.state.connection.prepare("SELECT count(*) AS count FROM effects").get()).toEqual({
       count: 0,
     });
+    store.close();
+  });
+
+  it("projects a waiting run from its unfinished attempt instead of its last result", async () => {
+    const databasePath = await makeStateDatabasePath("run-store-waiting-attempt");
+    const workflow = defineWorkflow({
+      name: "waiting-attempt",
+      startAt: "first",
+      nodes: {
+        first: agent({ prompt: () => "first" }),
+        second: agent({ prompt: () => "second" }),
+      },
+      edges: [{ from: "first", to: "second" }],
+    });
+    const executor = new ScriptedExecutor()
+      .respond("first", { output: { first: true } })
+      .respond("second", { hang: true });
+    const store = new WorkflowRunStore(databasePath);
+    const engine = new WorkflowEngine({ store, executor });
+    const running = engine.run(workflow, {});
+    await waitUntil(() => executor.requests.length === 2);
+    engine.park();
+    const parked = await running;
+    const attemptId = parked.state.currentAttemptId;
+    if (attemptId === undefined) throw new Error("Parked attempt is missing");
+
+    store.state.transaction(() => {
+      const now = Date.now();
+      store.state.connection
+        .prepare("UPDATE node_attempts SET status = 'waiting', updated_at = ? WHERE attempt_id = ?")
+        .run(now, attemptId);
+      store.state.connection
+        .prepare(
+          "UPDATE runs SET status = 'waiting', status_detail = ?, updated_at = ?, finished_at = ? WHERE run_id = ?",
+        )
+        .run("waiting for origin Pi session", now, now, parked.runId);
+    });
+
+    const loaded = store.readRun(parked.runId);
+    expect(loaded?.state).toMatchObject({
+      status: "waiting",
+      waitingOn: "second",
+      currentAttemptId: attemptId,
+      statusDetail: "waiting for origin Pi session",
+      results: { first: { outcome: "ok" } },
+    });
+    expect(loaded?.state.currentNode).toBeUndefined();
+    expect(loaded?.state.currentNodeStartedAt).toBe(parked.state.currentNodeStartedAt);
     store.close();
   });
 

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -145,6 +145,8 @@ describe("nodeGlyph", () => {
     expect(nodeGlyph(state, "first")).toBe("✓");
     expect(nodeGlyph(state, "second")).toBe("✗");
     expect(nodeGlyph(state, "third")).toBe("⏸");
+    expect(nodeGlyph(makeState({ waitingOn: "third" }), "third")).toBe("⏸");
+    expect(nodeGlyph(makeState({ waitingOn: "third" }), "third", "running")).toBe("◐");
     expect(nodeGlyph(makeState(), "first")).toBe("·");
   });
 });
@@ -827,8 +829,12 @@ describe("buildWidgetLines", () => {
       undefined,
       "running",
     ).lines;
+    const runningText = stripAnsi(running.join("\n"));
     expect(stripAnsi(running[0] ?? "")).toContain("◐ workflow demo [running]");
-    expect(stripAnsi(running.join("\n"))).not.toContain("waiting on checkpoint");
+    expect(runningText).toContain("◐ ƒ third");
+    expect(runningText).not.toContain("⏸ ƒ third");
+    expect(runningText).not.toContain("third · waiting");
+    expect(runningText).not.toContain("waiting on checkpoint");
 
     const waiting = buildWidgetView(
       waitingState,
@@ -842,7 +848,9 @@ describe("buildWidgetLines", () => {
       undefined,
       "waiting",
     ).lines;
+    const waitingText = stripAnsi(waiting.join("\n"));
     expect(stripAnsi(waiting[0] ?? "")).toContain("○ workflow demo [waiting]");
+    expect(waitingText).toContain("⏸ ƒ third · waiting");
 
     const paused = buildWidgetView(
       waitingState,

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -834,7 +834,7 @@ describe("buildWidgetLines", () => {
     expect(runningText).toContain("◐ ƒ third");
     expect(runningText).not.toContain("⏸ ƒ third");
     expect(runningText).not.toContain("third · waiting");
-    expect(runningText).not.toContain("waiting on checkpoint");
+    expect(runningText).not.toContain("waiting on step");
 
     const waiting = buildWidgetView(
       waitingState,
@@ -882,7 +882,7 @@ describe("buildWidgetLines", () => {
     expect(noNodes.maxScroll).toBe(0);
   });
 
-  it("shows waiting checkpoints and sanitizes external text", () => {
+  it("shows a waiting step and sanitizes external text", () => {
     const waiting = buildWidgetLines(
       makeState({
         runTitle: "evil\u001b[2J\ntitle",
@@ -897,7 +897,7 @@ describe("buildWidgetLines", () => {
     expect(waitingText).not.toContain("\n");
     expect(waiting[0]).toContain("evil title");
     expect(stripAnsi(waitingText)).toContain("⏸ ƒ third · waiting");
-    expect(stripAnsi(waiting.at(-1) ?? "")).toContain("waiting on checkpoint: third");
+    expect(stripAnsi(waiting.at(-1) ?? "")).toContain("waiting on step: third");
 
     const failed = buildWidgetLines(
       makeState({ status: "failed", error: `boom\n${"x".repeat(200)}` }),


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A workflow could show the last completed step as waiting while the next model step was already running.
This change keeps the active step tied to its one unfinished attempt and makes the widget show that same step as running during the exact Pi model turn.
It also adds restart, widget, client, and terminal-view checks for the broken case.

## What Changed

Running and waiting views now use the same unfinished attempt as the source of the active node.
A checkpoint still uses its completed checkpoint node when no unfinished attempt exists.

- Read the unfinished attempt for both running and waiting run states.
- Expose it as `currentNode` while the worker runs and as `waitingOn` while an interactive step is parked.
- Render that waiting node as running when the host reports the exact origin-session model turn.
- Keep completed steps complete instead of showing one of them as the current wait.
- Document the version-1 state projection rule without adding a schema or compatibility path.
- Add regression coverage for active turns, parked waits, restart recovery, completion, the Pi widget, the client, and `piw` output.

## Testing

The full local quality gate and all hosted Pi end-to-end tests pass.
A packed candidate was also installed into an isolated Pi consumer and passed with the real `openai/gpt-5.6-luna` model.

- `npm run check`
- `npm run test:e2e`
- `npx --yes --package typescript --package slophammer-ts@latest slophammer-ts dry .`
- `npx --yes --package typescript --package slophammer-ts@latest slophammer-ts check . --only ts.dependency-boundaries-required`
- `git diff --check`
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna`

SimpleDoc still reports the same nine old documentation naming and frontmatter problems. This change adds no new SimpleDoc failure.

## Risks

The change is limited to the existing version-1 run projection and widget presentation.
It does not change the database schema, protocol, Pi core, Pi session files, or workflow execution path.
