### PR TITLE
fix: align workflow display and model-turn timeouts

### DIFF
--- a/docs/WORKFLOW_HOST.md
+++ b/docs/WORKFLOW_HOST.md
@@ -408,7 +408,7 @@ At startup the host:
 5. Parks uncertain effects for manual review.
 6. Makes pure and fully settled work claimable.
 7. Restores pending interactive requests, workflow messages, external-channel decisions, and scheduled controller work without changing Pi message or turn state.
-8. Starts supervised timeout recovery for pending interactive requests only when their durable deadline expired during a reported model turn. Message delivery, waiting, paused time, and a closed Pi session do not consume the node timeout.
+8. Starts supervised timeout recovery for pending interactive requests only when their durable deadline expired during a reported model turn from an active connected session. A disconnect suspends the timer, and a new branch report resumes it without losing the prior active time. Message delivery, waiting, paused time, host downtime, and a closed Pi session do not consume the node timeout.
 9. Resumes any remaining provisional `validating` submission in a new supervised child.
 10. Waits for the extension's active-branch report before it confirms pending entries as sent, closes a turn as `lost`, or creates a branch-specific replacement. The extension sends this report after every host connection.
 11. Starts no model turn until a matching Pi session connects or headless mode is declared.

--- a/docs/WORKFLOW_HOST.md
+++ b/docs/WORKFLOW_HOST.md
@@ -408,7 +408,7 @@ At startup the host:
 5. Parks uncertain effects for manual review.
 6. Makes pure and fully settled work claimable.
 7. Restores pending interactive requests, workflow messages, external-channel decisions, and scheduled controller work without changing Pi message or turn state.
-8. Starts supervised timeout recovery for pending interactive requests whose durable node deadlines expired.
+8. Starts supervised timeout recovery for pending interactive requests only when their durable deadline expired during a reported model turn. Message delivery, waiting, paused time, and a closed Pi session do not consume the node timeout.
 9. Resumes any remaining provisional `validating` submission in a new supervised child.
 10. Waits for the extension's active-branch report before it confirms pending entries as sent, closes a turn as `lost`, or creates a branch-specific replacement. The extension sends this report after every host connection.
 11. Starts no model turn until a matching Pi session connects or headless mode is declared.

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -11,6 +11,8 @@ The viewer uses the [incremental and virtualized viewer design](plans/2026-08-28
 
 The run browser subscribes to small host-owned metadata views. It does not load trace, step, session, settings, or follow-up payloads. The host publishes a new bounded view only when its content changes.
 
+Each live view keeps the host's `display` value separate from the durable workflow `state`. The run browser, current-run status, timeline, and latest graph use `display` directly. During an origin-session model turn, the latest graph presents the durable `waitingOn` node as running. Replay continues to use durable state and recorded history. `piw` does not calculate another live status.
+
 The selected run contains bounded pages. Step, trace, session-entry, session-event, settings, follow-up, and update pages have both a row limit and a byte budget. Replay can jump to any position. The viewer loads the page that contains that position and keeps only the current windows. A session-event page includes the replay checkpoint immediately before its first event. A compact graph projection keeps the latest attempt for each node and the taken transitions up to the replay point.
 
 Large values use host content references. `piw` fetches them in bounded chunks when the user opens the related detail, verifies the byte count and SHA-256 digest, and then shows the complete text or JSON value. Page and content requests run outside input and drawing through the shared client protocol. A newer page selection replaces the previous request, including when the user returns to an earlier page. A failed first read leaves the run browser usable. A failed refresh keeps the last good view and marks it stale.

--- a/docs/tui-viewer.md
+++ b/docs/tui-viewer.md
@@ -15,7 +15,7 @@ Each live view keeps the host's `display` value separate from the durable workfl
 
 The selected run contains bounded pages. Step, trace, session-entry, session-event, settings, follow-up, and update pages have both a row limit and a byte budget. Replay can jump to any position. The viewer loads the page that contains that position and keeps only the current windows. A session-event page includes the replay checkpoint immediately before its first event. A compact graph projection keeps the latest attempt for each node and the taken transitions up to the replay point.
 
-Large values use host content references. `piw` fetches them in bounded chunks when the user opens the related detail, verifies the byte count and SHA-256 digest, and then shows the complete text or JSON value. Page and content requests run outside input and drawing through the shared client protocol. A newer page selection replaces the previous request, including when the user returns to an earlier page. A failed first read leaves the run browser usable. A failed refresh keeps the last good view and marks it stale.
+Large values use host content references. `piw` fetches workflow definitions, graph history, and complete host display reasons before it publishes the related live view. It fetches other large details when the user opens them. It verifies the byte count and SHA-256 digest before it shows the complete text or JSON value. Page and content requests run outside input and drawing through the shared client protocol. A newer page selection replaces the previous request, including when the user returns to an earlier page. A failed first read leaves the run browser usable. A failed refresh keeps the last good view and marks it stale.
 
 ## Install
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -212,7 +212,9 @@ form's active Pi turn.
 
 `timeoutMs` can be a finite positive number, `null`, or a function of the normal
 node context that returns either value. Omit it to use the 15-minute engine
-default. Set it to `null` to disable only the wall-clock deadline; cancellation,
+default. The limit counts active node execution. For an origin-session agent
+node, it counts reported model-turn time and excludes message delivery, waiting,
+and paused time. Set it to `null` to disable only this deadline; cancellation,
 parking, claim loss, shutdown, and the node's abort signal still work. A timeout
 function can use prepared outputs to select a policy for this run. It has 30
 seconds to return. Computed timeout functions are runtime code, so definition
@@ -727,8 +729,10 @@ possible. Defaults worth knowing:
   number or context callback. A timed-out node has outcome `timed_out` and can
   be routed with `$result.outcome`. A timed-out agent node also aborts its Pi
   turn, and late output for that attempt is rejected. Interactive runs save the
-  resolved wall-clock deadline before they park. The host enforces that deadline
-  while Pi is closed and after host restart.
+  resolved deadline before they park. The host advances it only during a
+  reported origin-session model turn. Message delivery, waiting, pauses, and a
+  closed Pi session do not consume the limit. This active-time budget survives
+  host restart.
 - `maxSteps` (workflow-level, default 100) bounds loops built from cycles in
   the graph.
 - `/workflow pause` atomically parks the run with `paused: true`, stores the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -204,8 +204,8 @@ adopts the stored result. Rejected submissions return
 the validation error and can retry in the same step. If the model settles
 without submitting, the host increments the request's unproductive-turn counter
 and can create at most two step messages with reason `reminder`. The next
-unproductive turn fails the step. Timeout and
-cancellation remain active during this process. For assistant-message output, the engine appends a normal-response contract,
+unproductive turn fails the step. The timeout remains active during each
+reported model turn, and cancellation remains active throughout. For assistant-message output, the engine appends a normal-response contract,
 waits for `agent_settled`, rejects empty, failed, aborted, or tool-only results,
 and never suppresses the visible text. Timeout and cancellation abort either
 form's active Pi turn.
@@ -213,8 +213,8 @@ form's active Pi turn.
 `timeoutMs` can be a finite positive number, `null`, or a function of the normal
 node context that returns either value. Omit it to use the 15-minute engine
 default. The limit counts active node execution. For an origin-session agent
-node, it counts reported model-turn time and excludes message delivery, waiting,
-and paused time. Set it to `null` to disable only this deadline; cancellation,
+node, it counts reported model-turn time from an active connected Pi session.
+It excludes message delivery, waiting, paused time, disconnects, and host downtime. Set it to `null` to disable only this deadline; cancellation,
 parking, claim loss, shutdown, and the node's abort signal still work. A timeout
 function can use prepared outputs to select a policy for this run. It has 30
 seconds to return. Computed timeout functions are runtime code, so definition
@@ -730,9 +730,9 @@ possible. Defaults worth knowing:
   be routed with `$result.outcome`. A timed-out agent node also aborts its Pi
   turn, and late output for that attempt is rejected. Interactive runs save the
   resolved deadline before they park. The host advances it only during a
-  reported origin-session model turn. Message delivery, waiting, pauses, and a
-  closed Pi session do not consume the limit. This active-time budget survives
-  host restart.
+  reported model turn from an active connected origin session. Message delivery,
+  waiting, pauses, disconnects, and host downtime do not consume the limit. This
+  active-time budget survives host restart.
 - `maxSteps` (workflow-level, default 100) bounds loops built from cycles in
   the graph.
 - `/workflow pause` atomically parks the run with `paused: true`, stores the

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -1465,8 +1465,14 @@ export class SqliteControllerStore implements ControllerStore {
           `SELECT i.request_id AS requestId, i.attempt_id AS attemptId
            FROM interactive_requests i
            JOIN node_attempts a ON a.attempt_id = i.attempt_id
-           WHERE i.run_id = ? AND i.status = 'pending'
+           JOIN runs r ON r.run_id = i.run_id
+           WHERE i.run_id = ? AND i.status = 'pending' AND r.paused = 0
              AND a.deadline_at IS NOT NULL AND a.deadline_at <= ?
+             AND EXISTS (
+               SELECT 1 FROM workflow_messages m
+               JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+               WHERE m.source_id = i.request_id AND m.kind = 'step' AND t.state = 'started'
+             )
            ORDER BY a.deadline_at, i.request_id LIMIT 1`,
         )
         .get(options.runId, now);
@@ -1497,7 +1503,7 @@ export class SqliteControllerStore implements ControllerStore {
       if (request.changes !== 1 || run.changes !== 1 || queue.changes !== 1) {
         throw new Error(`Workflow run ${options.runId} changed during interaction timeout`);
       }
-      const error = "Workflow node deadline expired before origin-session input arrived";
+      const error = "Workflow node model-turn deadline expired";
       const receiptHash = this.state.putJson({ status: "rejected", error }, now);
       this.state.connection
         .prepare(

--- a/src/controllers/sqlite.ts
+++ b/src/controllers/sqlite.ts
@@ -1445,6 +1445,7 @@ export class SqliteControllerStore implements ControllerStore {
 
   beginWorkflowRunInteractionTimeout(options: {
     runId: string;
+    targetSessionId: string;
     claimToken: string;
     now?: string;
   }): boolean {
@@ -1466,7 +1467,8 @@ export class SqliteControllerStore implements ControllerStore {
            FROM interactive_requests i
            JOIN node_attempts a ON a.attempt_id = i.attempt_id
            JOIN runs r ON r.run_id = i.run_id
-           WHERE i.run_id = ? AND i.status = 'pending' AND r.paused = 0
+           WHERE i.run_id = ? AND i.target_session_id = ?
+             AND i.status = 'pending' AND r.paused = 0
              AND a.deadline_at IS NOT NULL AND a.deadline_at <= ?
              AND EXISTS (
                SELECT 1 FROM workflow_messages m
@@ -1475,7 +1477,7 @@ export class SqliteControllerStore implements ControllerStore {
              )
            ORDER BY a.deadline_at, i.request_id LIMIT 1`,
         )
-        .get(options.runId, now);
+        .get(options.runId, options.targetSessionId, now);
       if (!isExpiredInteractionRow(interaction)) return false;
       const request = this.state.connection
         .prepare(

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -359,6 +359,7 @@ export class WorkflowHost {
     this.viewTimer = null;
     const server = this.server;
     this.server = null;
+    this.detachSessionCoordinators();
     await this.closeServer(server);
     for (const [runId, claimToken] of this.pendingRunClaims) {
       this.queue.parkWorkflowRun({ runId, claimToken });
@@ -556,15 +557,21 @@ export class WorkflowHost {
     socket.on("close", () => {
       this.sockets.delete(socket);
       this.connections.delete(socket);
-      for (const [sessionId, coordinator] of this.sessionCoordinators) {
-        if (coordinator.connectionId !== connection.id) continue;
-        this.hostState.markSessionModelTurnsInactive(sessionId);
-        this.sessionCoordinators.delete(sessionId);
-        this.views.noteOriginActivityChange();
-      }
+      this.detachSessionCoordinators(connection.id);
       this.views.clearConnection(connection.id);
       this.publishViews();
     });
+  }
+
+  private detachSessionCoordinators(connectionId?: string): void {
+    let changed = false;
+    for (const [sessionId, coordinator] of this.sessionCoordinators) {
+      if (connectionId !== undefined && coordinator.connectionId !== connectionId) continue;
+      this.hostState.markSessionModelTurnsInactive(sessionId);
+      this.sessionCoordinators.delete(sessionId);
+      changed = true;
+    }
+    if (changed) this.views.noteOriginActivityChange();
   }
 
   private async handleClientRequest(

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -177,6 +177,8 @@ type SessionCoordinator = {
   connectionId: string;
   epoch: string;
   branchReported: boolean;
+  modelTurnActive: boolean;
+  needsTimerResume: boolean;
 };
 
 type ActiveChannel = {
@@ -272,8 +274,16 @@ export class WorkflowHost {
       snapshotLifecycle: (context) => this.applyLifecycleProjection(context),
       allowHostSessionRecording: true,
     });
-    this.views = new HostViewStore(this.state, this.queue, this.hostState, this.runStore, (runId) =>
-      this.activeRuns.has(runId),
+    this.views = new HostViewStore(
+      this.state,
+      this.queue,
+      this.hostState,
+      this.runStore,
+      (runId) => this.activeRuns.has(runId),
+      (targetSessionId) => {
+        const coordinator = this.sessionCoordinators.get(targetSessionId);
+        return coordinator?.branchReported === true && coordinator.modelTurnActive;
+      },
     );
     this.registry = options.registry ?? new HostProcessRegistry(this.stateDirectory);
   }
@@ -306,6 +316,9 @@ export class WorkflowHost {
         leaseMs: this.options.hostLeaseMs ?? HOST_LEASE_MS,
       });
       this.recoverPreviousHost(previousHost.hostId, this.claim.epoch);
+      const previousHeartbeatAt =
+        previousHost.heartbeatAt === null ? undefined : Date.parse(previousHost.heartbeatAt);
+      this.hostState.recoverInactiveModelTurns(previousHeartbeatAt);
       await this.listen();
       this.startTimers();
       this.started = true;
@@ -544,7 +557,10 @@ export class WorkflowHost {
       this.sockets.delete(socket);
       this.connections.delete(socket);
       for (const [sessionId, coordinator] of this.sessionCoordinators) {
-        if (coordinator.connectionId === connection.id) this.sessionCoordinators.delete(sessionId);
+        if (coordinator.connectionId !== connection.id) continue;
+        this.hostState.markSessionModelTurnsInactive(sessionId);
+        this.sessionCoordinators.delete(sessionId);
+        this.views.noteOriginActivityChange();
       }
       this.views.clearConnection(connection.id);
       this.publishViews();
@@ -608,12 +624,19 @@ export class WorkflowHost {
           const sessionId = requireString(payload.sessionId, "sessionId");
           this.addSubscription(connection, request, "session", sessionId);
           if (payload.coordinator === true) {
+            const previous = this.sessionCoordinators.get(sessionId);
+            if (previous !== undefined && previous.connectionId !== connection.id) {
+              this.hostState.markSessionModelTurnsInactive(sessionId);
+            }
             const coordinator = {
               connectionId: connection.id,
               epoch: `session-epoch-${randomUUID()}`,
               branchReported: false,
+              modelTurnActive: false,
+              needsTimerResume: true,
             } satisfies SessionCoordinator;
             this.sessionCoordinators.set(sessionId, coordinator);
+            this.views.noteOriginActivityChange();
             this.publishViews();
             return clientResponse(request.requestId, "accepted", {
               subscribed: true,
@@ -863,6 +886,9 @@ export class WorkflowHost {
     const messages = this.hostState.workflowMessages.listSession(report.targetSessionId);
     const allowed = new Set(messages.map((message) => message.workflowMessageId));
     this.state.transaction(() => {
+      if (coordinator.needsTimerResume) {
+        this.hostState.resumeSessionModelTurns(report.targetSessionId);
+      }
       this.hostState.workflowMessages.adoptBranch(report.targetSessionId, report.entries, allowed);
       if (report.isIdle && !report.hasPendingMessages) {
         for (const turn of this.hostState.workflowMessages.openTurnsForSession(
@@ -898,7 +924,10 @@ export class WorkflowHost {
         }
       }
       coordinator.branchReported = true;
+      coordinator.modelTurnActive = !report.isIdle;
+      coordinator.needsTimerResume = false;
     });
+    this.views.noteOriginActivityChange();
     this.publishViews();
     return clientResponse(request.requestId, "accepted", {
       recorded: true,
@@ -941,6 +970,8 @@ export class WorkflowHost {
       }
       return this.applyWorkflowTurnEnd(report);
     });
+    coordinator.modelTurnActive = report.state === "started";
+    this.views.noteOriginActivityChange();
     this.publishViews();
     return clientResponse(request.requestId, "accepted", toJsonValue(turn));
   }
@@ -3429,10 +3460,21 @@ export class WorkflowHost {
 
   private expireTimedOutInteraction(): void {
     if (this.stopping || this.claim === null) return;
-    const runId = this.hostState
-      .expiredInteractionRunIds()
-      .find((candidate) => !this.activeRuns.has(candidate) && !this.pendingStarts.has(candidate));
-    if (runId === undefined) return;
+    const activeSessionIds = new Set(
+      [...this.sessionCoordinators.entries()]
+        .filter(([, coordinator]) => coordinator.branchReported && coordinator.modelTurnActive)
+        .map(([sessionId]) => sessionId),
+    );
+    const expired = this.hostState
+      .expiredInteractionRuns()
+      .find(
+        (candidate) =>
+          activeSessionIds.has(candidate.targetSessionId) &&
+          !this.activeRuns.has(candidate.runId) &&
+          !this.pendingStarts.has(candidate.runId),
+      );
+    if (expired === undefined) return;
+    const { runId, targetSessionId } = expired;
     const claimToken = randomUUID();
     const claimed = this.queue.claimWorkflowRunForControl({
       runId,
@@ -3443,7 +3485,11 @@ export class WorkflowHost {
     if (claimed === undefined) return;
     let activated = false;
     try {
-      activated = this.queue.beginWorkflowRunInteractionTimeout({ runId, claimToken });
+      activated = this.queue.beginWorkflowRunInteractionTimeout({
+        runId,
+        targetSessionId,
+        claimToken,
+      });
       if (activated) {
         this.markPendingStart(runId, claimToken);
         setImmediate(() => void this.activateRun(claimed, claimToken));

--- a/src/host/runner.ts
+++ b/src/host/runner.ts
@@ -918,6 +918,10 @@ export class WorkflowHost {
     }
     const turn = this.state.transaction(() => {
       if (report.state === "started") {
+        const existing = this.hostState.workflowMessages.getTurn(report.workflowTurnId);
+        if (existing === undefined && this.queue.isWorkflowRunPaused(report.runId)) {
+          throw new Error("A paused workflow cannot start a model turn");
+        }
         const session = this.views.session(report.targetSessionId, {
           epoch: coordinator.epoch,
           active: true,
@@ -927,8 +931,11 @@ export class WorkflowHost {
           throw new Error("Workflow turn start does not match the open workflow message");
         }
         const message = this.hostState.workflowMessages.require(report.workflowMessageId);
-        if (message.kind === "step") {
-          this.hostState.workflowMessages.cancelPendingForSource(message.sourceId, "step");
+        if (existing === undefined && message.kind === "step") {
+          const now = Date.now();
+          this.hostState.beginInteractionModelTurn(message.sourceId, now);
+          this.hostState.workflowMessages.cancelPendingForSource(message.sourceId, "step", now);
+          return this.hostState.workflowMessages.startTurn({ ...report, now });
         }
         return this.hostState.workflowMessages.startTurn(report);
       }
@@ -1235,9 +1242,11 @@ export class WorkflowHost {
         const runId = requireRunId(request);
         const resumedInteraction = this.state.transaction(() => {
           const now = Date.now();
+          const pausedAt = this.hostState.interactionPauseStartedAt(runId);
           if (!this.queue.resumePausedInteraction({ runId, now: new Date(now).toISOString() })) {
             return false;
           }
+          this.hostState.resumeInteractionModelTurn(runId, pausedAt, now);
           this.hostState.resumePendingInteraction(runId, now);
           return true;
         });
@@ -3438,7 +3447,7 @@ export class WorkflowHost {
       if (activated) {
         this.markPendingStart(runId, claimToken);
         setImmediate(() => void this.activateRun(claimed, claimToken));
-        this.log(`run ${runId} is finishing its expired origin-session deadline`);
+        this.log(`run ${runId} is finishing its expired origin-session model-turn deadline`);
       }
     } catch (error) {
       this.log(`interaction timeout failed for run ${runId}: ${errorMessage(error)}`);

--- a/src/host/state.ts
+++ b/src/host/state.ts
@@ -542,6 +542,68 @@ export class HostStateStore {
     });
   }
 
+  beginInteractionModelTurn(requestId: string, now: number = Date.now()): void {
+    const row = this.state.connection
+      .prepare(
+        `SELECT i.attempt_id AS attemptId, i.created_at AS createdAt,
+                a.started_at AS startedAt, a.deadline_at AS deadlineAt,
+                (SELECT MAX(t.ended_at)
+                 FROM workflow_messages m
+                 JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+                 WHERE m.source_id = i.request_id AND m.kind = 'step'
+                   AND t.state = 'ended') AS previousTurnEndedAt
+         FROM interactive_requests i
+         JOIN node_attempts a ON a.attempt_id = i.attempt_id
+         WHERE i.request_id = ? AND i.status = 'pending'`,
+      )
+      .get(requestId);
+    if (!isInteractionTimeoutRow(row)) {
+      throw new Error("Pending workflow interaction timeout is missing");
+    }
+    this.shiftInteractionTimeout(
+      row,
+      Math.max(0, now - (row.previousTurnEndedAt ?? row.startedAt ?? row.createdAt)),
+      now,
+    );
+  }
+
+  interactionPauseStartedAt(runId: string): number | undefined {
+    const row = this.state.connection
+      .prepare(
+        `SELECT r.updated_at AS pausedAt
+         FROM runs r
+         JOIN interactive_requests i ON i.run_id = r.run_id AND i.status = 'pending'
+         WHERE r.run_id = ? AND r.paused = 1 LIMIT 1`,
+      )
+      .get(runId);
+    return isPausedAtRow(row) ? row.pausedAt : undefined;
+  }
+
+  resumeInteractionModelTurn(
+    runId: string,
+    pausedAt: number | undefined,
+    now: number = Date.now(),
+  ): void {
+    if (pausedAt === undefined) return;
+    const row = this.state.connection
+      .prepare(
+        `SELECT i.attempt_id AS attemptId, i.created_at AS createdAt,
+                a.started_at AS startedAt, a.deadline_at AS deadlineAt,
+                t.ended_at AS previousTurnEndedAt
+         FROM interactive_requests i
+         JOIN node_attempts a ON a.attempt_id = i.attempt_id
+         JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
+         JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+         WHERE i.run_id = ? AND i.status = 'pending' AND t.started_at <= ?
+           AND (t.ended_at IS NULL OR t.ended_at > ?)
+         ORDER BY t.started_at DESC LIMIT 1`,
+      )
+      .get(runId, pausedAt, pausedAt);
+    if (!isInteractionTimeoutRow(row)) return;
+    const modelTurnStoppedAt = Math.min(now, row.previousTurnEndedAt ?? now);
+    this.shiftInteractionTimeout(row, Math.max(0, modelTurnStoppedAt - pausedAt), now);
+  }
+
   getInteraction(requestId: string): InteractiveRequestRecord | undefined {
     return this.interactiveRequest(requestId);
   }
@@ -629,10 +691,16 @@ export class HostStateStore {
         `SELECT i.run_id AS runId
          FROM interactive_requests i
          JOIN node_attempts a ON a.attempt_id = i.attempt_id
+         JOIN runs r ON r.run_id = i.run_id
          JOIN run_queue q ON q.run_id = i.run_id
-         WHERE i.status = 'pending'
+         WHERE i.status = 'pending' AND r.paused = 0
            AND a.deadline_at IS NOT NULL AND a.deadline_at <= ?
            AND q.status NOT IN ('done', 'failed', 'cancelled')
+           AND EXISTS (
+             SELECT 1 FROM workflow_messages m
+             JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+             WHERE m.source_id = i.request_id AND m.kind = 'step' AND t.state = 'started'
+           )
          GROUP BY i.run_id
          ORDER BY MIN(a.deadline_at), i.run_id`,
       )
@@ -648,8 +716,13 @@ export class HostStateStore {
          JOIN node_attempts a ON a.attempt_id = i.attempt_id
          JOIN runs r ON r.run_id = i.run_id
          WHERE i.run_id = ? AND i.status = 'cancelled' AND r.status = 'running'
-           AND a.deadline_at IS NOT NULL AND a.deadline_at <= ?
+           AND r.paused = 0 AND a.deadline_at IS NOT NULL AND a.deadline_at <= ?
            AND a.status IN ('pending', 'running', 'waiting', 'interrupted', 'timed_out')
+           AND EXISTS (
+             SELECT 1 FROM workflow_messages m
+             JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+             WHERE m.source_id = i.request_id AND m.kind = 'step' AND t.state = 'started'
+           )
          ORDER BY a.deadline_at, i.request_id LIMIT 1`,
       )
       .get(runId, Date.now());
@@ -962,6 +1035,19 @@ export class HostStateStore {
     };
   }
 
+  private shiftInteractionTimeout(row: InteractionTimeoutRow, idleMs: number, now: number): void {
+    if (idleMs === 0 || row.deadlineAt === null) return;
+    const changed = this.state.connection
+      .prepare(
+        `UPDATE node_attempts
+         SET started_at = CASE WHEN started_at IS NULL THEN NULL ELSE started_at + ? END,
+             deadline_at = deadline_at + ?, updated_at = ?
+         WHERE attempt_id = ? AND deadline_at = ?`,
+      )
+      .run(idleMs, idleMs, now, row.attemptId, row.deadlineAt);
+    if (changed.changes !== 1) throw new Error("Workflow interaction timeout changed concurrently");
+  }
+
   private requireInteractiveRequest(requestId: string): InteractiveRequestRecord {
     const request = this.interactiveRequest(requestId);
     if (request === undefined) throw new Error(`Interactive request not found: ${requestId}`);
@@ -1045,6 +1131,14 @@ type TimedOutInteractionRow = {
   attemptId: string;
   nodeId: string;
 };
+type InteractionTimeoutRow = {
+  attemptId: string;
+  createdAt: number;
+  startedAt: number | null;
+  deadlineAt: number | null;
+  previousTurnEndedAt: number | null;
+};
+type PausedAtRow = { pausedAt: number };
 type InteractiveRequestRow = {
   requestId: string;
   runId: string;
@@ -1132,6 +1226,21 @@ function isTimedOutInteractionRow(value: unknown): value is TimedOutInteractionR
     typeof value.attemptId === "string" &&
     typeof value.nodeId === "string"
   );
+}
+
+function isInteractionTimeoutRow(value: unknown): value is InteractionTimeoutRow {
+  return (
+    isRecord(value) &&
+    typeof value.attemptId === "string" &&
+    typeof value.createdAt === "number" &&
+    nullableNumber(value.startedAt) &&
+    nullableNumber(value.deadlineAt) &&
+    nullableNumber(value.previousTurnEndedAt)
+  );
+}
+
+function isPausedAtRow(value: unknown): value is PausedAtRow {
+  return isRecord(value) && typeof value.pausedAt === "number";
 }
 
 function isSubmissionRow(value: unknown): value is SubmissionRow {

--- a/src/host/state.ts
+++ b/src/host/state.ts
@@ -607,8 +607,8 @@ export class HostStateStore {
   markSessionModelTurnsInactive(targetSessionId: string, now: number = Date.now()): void {
     this.state.connection
       .prepare(
-        `UPDATE node_attempts SET updated_at = ?
-         WHERE attempt_id IN (
+        `UPDATE node_attempts SET status = 'interrupted', updated_at = ?
+         WHERE status <> 'interrupted' AND attempt_id IN (
            SELECT DISTINCT i.attempt_id
            FROM interactive_requests i
            JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
@@ -626,7 +626,7 @@ export class HostStateStore {
   ): void {
     const rows = this.state.connection
       .prepare(
-        `SELECT i.attempt_id AS attemptId, a.started_at AS startedAt,
+        `SELECT i.attempt_id AS attemptId, a.status, a.started_at AS startedAt,
                 a.deadline_at AS deadlineAt, a.updated_at AS updatedAt,
                 MAX(t.started_at) AS turnStartedAt
          FROM interactive_requests i
@@ -641,17 +641,25 @@ export class HostStateStore {
       .filter(isInactiveInteractionTimeoutRow);
     for (const row of rows) {
       const inactiveAt =
-        previousHeartbeatAt === undefined
+        row.status === "interrupted"
           ? row.updatedAt
-          : Math.max(previousHeartbeatAt, row.turnStartedAt);
+          : previousHeartbeatAt === undefined
+            ? row.updatedAt
+            : Math.max(previousHeartbeatAt, row.turnStartedAt);
       this.shiftInteractionTimeout(row, Math.max(0, now - inactiveAt), now);
+      this.state.connection
+        .prepare(
+          `UPDATE node_attempts SET status = 'interrupted', updated_at = ?
+           WHERE attempt_id = ? AND status IN ('pending', 'running', 'waiting', 'interrupted')`,
+        )
+        .run(now, row.attemptId);
     }
   }
 
   resumeSessionModelTurns(targetSessionId: string, now: number = Date.now()): void {
     const rows = this.state.connection
       .prepare(
-        `SELECT i.attempt_id AS attemptId, a.started_at AS startedAt,
+        `SELECT i.attempt_id AS attemptId, a.status, a.started_at AS startedAt,
                 a.deadline_at AS deadlineAt, a.updated_at AS updatedAt,
                 MAX(t.started_at) AS turnStartedAt
          FROM interactive_requests i
@@ -660,12 +668,19 @@ export class HostStateStore {
          JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
                               AND t.state = 'started'
          WHERE i.target_session_id = ? AND i.status = 'pending'
+           AND a.status = 'interrupted'
          GROUP BY i.attempt_id`,
       )
       .all(targetSessionId)
       .filter(isInactiveInteractionTimeoutRow);
     for (const row of rows) {
       this.shiftInteractionTimeout(row, Math.max(0, now - row.updatedAt), now);
+      this.state.connection
+        .prepare(
+          `UPDATE node_attempts SET status = 'waiting', updated_at = ?
+           WHERE attempt_id = ? AND status = 'interrupted'`,
+        )
+        .run(now, row.attemptId);
     }
   }
 
@@ -1209,6 +1224,7 @@ type InteractionTimeoutRow = {
 };
 type InactiveInteractionTimeoutRow = {
   attemptId: string;
+  status: "pending" | "running" | "waiting" | "interrupted";
   startedAt: number | null;
   deadlineAt: number | null;
   updatedAt: number;
@@ -1320,6 +1336,7 @@ function isInactiveInteractionTimeoutRow(value: unknown): value is InactiveInter
   return (
     isRecord(value) &&
     typeof value.attemptId === "string" &&
+    ["pending", "running", "waiting", "interrupted"].includes(value.status as string) &&
     nullableNumber(value.startedAt) &&
     nullableNumber(value.deadlineAt) &&
     typeof value.updatedAt === "number" &&

--- a/src/host/state.ts
+++ b/src/host/state.ts
@@ -604,6 +604,71 @@ export class HostStateStore {
     this.shiftInteractionTimeout(row, Math.max(0, modelTurnStoppedAt - pausedAt), now);
   }
 
+  markSessionModelTurnsInactive(targetSessionId: string, now: number = Date.now()): void {
+    this.state.connection
+      .prepare(
+        `UPDATE node_attempts SET updated_at = ?
+         WHERE attempt_id IN (
+           SELECT DISTINCT i.attempt_id
+           FROM interactive_requests i
+           JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
+           JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+                                AND t.state = 'started'
+           WHERE i.target_session_id = ? AND i.status = 'pending'
+         )`,
+      )
+      .run(now, targetSessionId);
+  }
+
+  recoverInactiveModelTurns(
+    previousHeartbeatAt: number | undefined,
+    now: number = Date.now(),
+  ): void {
+    const rows = this.state.connection
+      .prepare(
+        `SELECT i.attempt_id AS attemptId, a.started_at AS startedAt,
+                a.deadline_at AS deadlineAt, a.updated_at AS updatedAt,
+                MAX(t.started_at) AS turnStartedAt
+         FROM interactive_requests i
+         JOIN node_attempts a ON a.attempt_id = i.attempt_id
+         JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
+         JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+                              AND t.state = 'started'
+         WHERE i.status = 'pending'
+         GROUP BY i.attempt_id`,
+      )
+      .all()
+      .filter(isInactiveInteractionTimeoutRow);
+    for (const row of rows) {
+      const inactiveAt =
+        previousHeartbeatAt === undefined
+          ? row.updatedAt
+          : Math.max(previousHeartbeatAt, row.turnStartedAt);
+      this.shiftInteractionTimeout(row, Math.max(0, now - inactiveAt), now);
+    }
+  }
+
+  resumeSessionModelTurns(targetSessionId: string, now: number = Date.now()): void {
+    const rows = this.state.connection
+      .prepare(
+        `SELECT i.attempt_id AS attemptId, a.started_at AS startedAt,
+                a.deadline_at AS deadlineAt, a.updated_at AS updatedAt,
+                MAX(t.started_at) AS turnStartedAt
+         FROM interactive_requests i
+         JOIN node_attempts a ON a.attempt_id = i.attempt_id
+         JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
+         JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
+                              AND t.state = 'started'
+         WHERE i.target_session_id = ? AND i.status = 'pending'
+         GROUP BY i.attempt_id`,
+      )
+      .all(targetSessionId)
+      .filter(isInactiveInteractionTimeoutRow);
+    for (const row of rows) {
+      this.shiftInteractionTimeout(row, Math.max(0, now - row.updatedAt), now);
+    }
+  }
+
   getInteraction(requestId: string): InteractiveRequestRecord | undefined {
     return this.interactiveRequest(requestId);
   }
@@ -685,10 +750,10 @@ export class HostStateStore {
       .flatMap((row) => (isRunIdRow(row) ? [row.runId] : []));
   }
 
-  expiredInteractionRunIds(now: number = Date.now()): string[] {
+  expiredInteractionRuns(now: number = Date.now()): ExpiredInteractionRunRow[] {
     return this.state.connection
       .prepare(
-        `SELECT i.run_id AS runId
+        `SELECT i.run_id AS runId, i.target_session_id AS targetSessionId
          FROM interactive_requests i
          JOIN node_attempts a ON a.attempt_id = i.attempt_id
          JOIN runs r ON r.run_id = i.run_id
@@ -701,11 +766,11 @@ export class HostStateStore {
              JOIN workflow_turns t ON t.workflow_message_id = m.workflow_message_id
              WHERE m.source_id = i.request_id AND m.kind = 'step' AND t.state = 'started'
            )
-         GROUP BY i.run_id
+         GROUP BY i.run_id, i.target_session_id
          ORDER BY MIN(a.deadline_at), i.run_id`,
       )
       .all(now)
-      .flatMap((row) => (isRunIdRow(row) ? [row.runId] : []));
+      .filter(isExpiredInteractionRunRow);
   }
 
   timedOutInteraction(runId: string): TimedOutInteractionRow | undefined {
@@ -1035,7 +1100,11 @@ export class HostStateStore {
     };
   }
 
-  private shiftInteractionTimeout(row: InteractionTimeoutRow, idleMs: number, now: number): void {
+  private shiftInteractionTimeout(
+    row: Pick<InteractionTimeoutRow, "attemptId" | "startedAt" | "deadlineAt">,
+    idleMs: number,
+    now: number,
+  ): void {
     if (idleMs === 0 || row.deadlineAt === null) return;
     const changed = this.state.connection
       .prepare(
@@ -1138,6 +1207,14 @@ type InteractionTimeoutRow = {
   deadlineAt: number | null;
   previousTurnEndedAt: number | null;
 };
+type InactiveInteractionTimeoutRow = {
+  attemptId: string;
+  startedAt: number | null;
+  deadlineAt: number | null;
+  updatedAt: number;
+  turnStartedAt: number;
+};
+type ExpiredInteractionRunRow = { runId: string; targetSessionId: string };
 type PausedAtRow = { pausedAt: number };
 type InteractiveRequestRow = {
   requestId: string;
@@ -1236,6 +1313,23 @@ function isInteractionTimeoutRow(value: unknown): value is InteractionTimeoutRow
     nullableNumber(value.startedAt) &&
     nullableNumber(value.deadlineAt) &&
     nullableNumber(value.previousTurnEndedAt)
+  );
+}
+
+function isInactiveInteractionTimeoutRow(value: unknown): value is InactiveInteractionTimeoutRow {
+  return (
+    isRecord(value) &&
+    typeof value.attemptId === "string" &&
+    nullableNumber(value.startedAt) &&
+    nullableNumber(value.deadlineAt) &&
+    typeof value.updatedAt === "number" &&
+    typeof value.turnStartedAt === "number"
+  );
+}
+
+function isExpiredInteractionRunRow(value: unknown): value is ExpiredInteractionRunRow {
+  return (
+    isRecord(value) && typeof value.runId === "string" && typeof value.targetSessionId === "string"
   );
 }
 

--- a/src/host/view.ts
+++ b/src/host/view.ts
@@ -69,6 +69,7 @@ export class HostViewStore {
   private readonly runCache = new Map<string, { version: string; view: WorkflowRunView | null }>();
   private readonly sessionCache = new Map<string, { version: string; view: WorkflowSessionView }>();
   private contentBytes = 0;
+  private originActivityRevision = 0;
   private readonly workflowMessages: WorkflowMessageStore;
 
   constructor(
@@ -77,8 +78,13 @@ export class HostViewStore {
     private readonly hostState: HostStateStore,
     private readonly runs: WorkflowRunStore,
     private readonly hasLiveWorker: (runId: string) => boolean,
+    private readonly hasActiveSessionTurn: (targetSessionId: string) => boolean,
   ) {
     this.workflowMessages = hostState.workflowMessages;
+  }
+
+  noteOriginActivityChange(): void {
+    this.originActivityRevision += 1;
   }
 
   list(cursor = 0, limit?: number): WorkflowRunListPage {
@@ -773,8 +779,8 @@ export class HostViewStore {
     return isObjectRecord(row) &&
       typeof row.messageUpdatedAt === "number" &&
       typeof row.turnUpdatedAt === "number"
-      ? `${row.messageUpdatedAt}:${row.turnUpdatedAt}`
-      : "0:0";
+      ? `${row.messageUpdatedAt}:${row.turnUpdatedAt}${this.originActivityRevision === 0 ? "" : `-${this.originActivityRevision}`}`
+      : `0:0${this.originActivityRevision === 0 ? "" : `-${this.originActivityRevision}`}`;
   }
 
   private display(
@@ -796,12 +802,16 @@ export class HostViewStore {
   private hasActivity(runId: string): boolean {
     const row = this.state.connection
       .prepare(
-        `SELECT 1 AS present FROM workflow_turns t
+        `SELECT t.target_session_id AS targetSessionId FROM workflow_turns t
          JOIN workflow_messages m ON m.workflow_message_id = t.workflow_message_id
          WHERE t.run_id = ? AND t.state = 'started' AND m.kind IN ('step', 'terminal') LIMIT 1`,
       )
       .get(runId);
-    return row !== undefined;
+    return (
+      isObjectRecord(row) &&
+      typeof row.targetSessionId === "string" &&
+      this.hasActiveSessionTurn(row.targetSessionId)
+    );
   }
 
   private hasPendingInteraction(runId: string): boolean {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -97,9 +97,9 @@ export type WorkflowProgressData = {
 
 export type WorkflowNodeCommon = {
   /**
-   * Per-node timeout or a callback that derives it from the run context.
-   * Null disables the wall-clock deadline. Omission falls back to the engine
-   * default (15 minutes).
+   * Per-node active-execution timeout or a callback that derives it from the run context.
+   * Waiting and paused origin-session time does not count. Null disables the deadline.
+   * Omission falls back to the engine default (15 minutes).
    */
   timeoutMs?: number | null | ((context: WorkflowNodeContext) => MaybePromise<number | null>);
   /** Short human-readable label shown in the viewer while the node runs. */
@@ -719,7 +719,7 @@ export type WorkflowRunState = {
   currentNode?: string;
   currentAttemptId?: string;
   currentNodeStartedAt?: string;
-  /** Durable wall-clock deadline for the current attempt. Null disables the deadline. */
+  /** Durable active-execution deadline for the current attempt. Null disables the deadline. */
   currentNodeDeadlineAt?: string | null;
   currentSettingsScopeId?: string;
   currentSettingsChangeNumber?: number;

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -98,8 +98,8 @@ export type WorkflowProgressData = {
 export type WorkflowNodeCommon = {
   /**
    * Per-node active-execution timeout or a callback that derives it from the run context.
-   * Waiting and paused origin-session time does not count. Null disables the deadline.
-   * Omission falls back to the engine default (15 minutes).
+   * Waiting, paused, disconnected, and host-down origin-session time does not count.
+   * Null disables the deadline. Omission falls back to the engine default (15 minutes).
    */
   timeoutMs?: number | null | ((context: WorkflowNodeContext) => MaybePromise<number | null>);
   /** Short human-readable label shown in the viewer while the node runs. */

--- a/test/host-view.test.ts
+++ b/test/host-view.test.ts
@@ -238,7 +238,14 @@ describe("host workflow display reducer", () => {
     ];
     await runs.appendSessionEventBatch("run-large-view", events);
 
-    const views = new HostViewStore(state, queue, hostState, runs, () => false);
+    const views = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     const legacyRead = vi.spyOn(runs, "readRun");
     const boundedRead = vi.spyOn(runs, "readRunView");
     const view = views.run("run-large-view");
@@ -284,7 +291,14 @@ describe("host workflow display reducer", () => {
     if (contentPath === undefined) throw new Error("large output was not externalized");
     expect(views.content(view.runId, "not-a-content-path", 0)).toBeNull();
     expect(() => views.content(view.runId, contentPath, -1)).toThrow(/offset/);
-    const coldViews = new HostViewStore(state, queue, hostState, runs, () => false);
+    const coldViews = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     const chunks: Buffer[] = [];
     let offset = 0;
     for (;;) {
@@ -436,7 +450,14 @@ describe("host workflow display reducer", () => {
       {},
       { runId: "run-large-graph" },
     );
-    const views = new HostViewStore(state, queue, hostState, runs, () => false);
+    const views = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     const view = views.run("run-large-graph");
     if (view === null) throw new Error("large graph view missing");
     expect(view.graphStepTotal).toBe(nodeCount);
@@ -502,7 +523,14 @@ describe("host workflow display reducer", () => {
       originSessionId: "session-large-topology",
     });
     const runs = new WorkflowRunStore(databasePath, { state });
-    const views = new HostViewStore(state, queue, hostState, runs, () => false);
+    const views = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     const view = views.run("run-large-topology");
     if (view === null) throw new Error("large topology view missing");
     const encoded = encodeProtocolLine({
@@ -601,6 +629,7 @@ describe("host workflow display reducer", () => {
       hostState,
       runs,
       (runId) => runId === "run-view",
+      () => false,
     );
     expect(applyingViews.run("run-view")?.display.status).toBe("running");
     await runs.settleEffect({
@@ -633,7 +662,15 @@ describe("host workflow display reducer", () => {
         },
       },
     });
-    const views = new HostViewStore(state, queue, hostState, runs, () => false);
+    let modelTurnActive = true;
+    const views = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => modelTurnActive,
+    );
     const readRun = vi.spyOn(runs, "readRun");
     const initialList = views.list();
     expect(initialList.items).toHaveLength(1);
@@ -667,6 +704,11 @@ describe("host workflow display reducer", () => {
       status: "running",
       activity: "origin_turn",
     });
+    modelTurnActive = false;
+    views.noteOriginActivityChange();
+    expect(views.run("run-view")?.display.status).toBe("waiting");
+    modelTurnActive = true;
+    views.noteOriginActivityChange();
     const runningList = views.list();
     expect(runningList.revision).not.toBe(initialList.revision);
     expect(runningList.items).toMatchObject([
@@ -705,7 +747,14 @@ describe("host workflow display reducer", () => {
       )
       .run(errorHash, Date.now());
     state.connection.prepare("UPDATE runs SET status = 'failed' WHERE run_id = 'run-view'").run();
-    const failedViews = new HostViewStore(state, queue, hostState, runs, () => false);
+    const failedViews = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     expect(failedViews.list().items[0]?.display).toMatchObject({
       status: "failed",
       reason: completeFailureReason,
@@ -719,7 +768,14 @@ describe("host workflow display reducer", () => {
     state.connection
       .prepare("UPDATE run_queue SET error_hash = ?, updated_at = ? WHERE run_id = 'run-view'")
       .run(oversizedErrorHash, Date.now() + 1);
-    const oversizedViews = new HostViewStore(state, queue, hostState, runs, () => false);
+    const oversizedViews = new HostViewStore(
+      state,
+      queue,
+      hostState,
+      runs,
+      () => false,
+      () => false,
+    );
     const oversizedList = oversizedViews.list();
     const reasonContent = oversizedList.items[0]?.display.reasonContent as
       | { $artifact?: { path?: string; sha256?: string } }

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1450,7 +1450,7 @@ setInterval(() => {}, 1000);
     }
   }, 60_000);
 
-  it("expires a parked interaction from its durable deadline after restart", async () => {
+  it("counts only active model-turn time toward an interactive node timeout", async () => {
     const cwd = await makeTempDir("host-interaction-timeout-project");
     const databasePath = path.join(
       await makeTempDir("host-interaction-timeout-state"),
@@ -1462,16 +1462,18 @@ setInterval(() => {}, 1000);
       runnerId: "host-timeout-first",
       claimPollMs: 10,
     });
+    const firstClient = new WorkflowClient({ databasePath });
     await first.start();
     await startRun({
-      client: new WorkflowClient({ databasePath }),
+      client: firstClient,
       cwd,
       workflowPath,
       runId: "interaction-timeout-run",
       executionMode: "interactive",
     });
     let requestId: string | undefined;
-    let deadlineAt: number | null | undefined;
+    let initialStartedAt: number | null | undefined;
+    let initialDeadlineAt: number | null | undefined;
     await waitUntil(() => {
       const state = new HostStateStore(databasePath, { readOnly: true });
       try {
@@ -1479,25 +1481,36 @@ setInterval(() => {}, 1000);
         requestId = interaction?.requestId;
         const deadline = state.state.connection
           .prepare(
-            `SELECT a.deadline_at AS deadlineAt
+            `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
              FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
              WHERE i.run_id = ?`,
           )
-          .get("interaction-timeout-run") as { deadlineAt: number | null } | undefined;
-        deadlineAt = deadline?.deadlineAt;
-        return requestId !== undefined && deadlineAt !== null && deadlineAt !== undefined;
+          .get("interaction-timeout-run") as
+          | { startedAt: number | null; deadlineAt: number | null }
+          | undefined;
+        initialStartedAt = deadline?.startedAt;
+        initialDeadlineAt = deadline?.deadlineAt;
+        return requestId !== undefined && initialStartedAt != null && initialDeadlineAt != null;
       } finally {
         state.close();
       }
     }, 30_000);
-    await first.stop();
-    if (requestId === undefined || deadlineAt === null || deadlineAt === undefined) {
+    if (requestId === undefined || initialStartedAt == null || initialDeadlineAt == null) {
       throw new Error("durable interaction deadline was not created");
     }
     const timedRequestId = requestId;
-    const timedDeadlineAt = deadlineAt;
+    const firstDeadlineAt = initialDeadlineAt;
+    const configuredDurationMs = initialDeadlineAt - initialStartedAt;
+    expect(
+      await firstClient.request({
+        operation: "run.pause",
+        runId: "interaction-timeout-run",
+      }),
+    ).toMatchObject({ outcome: "accepted", receipt: { paused: true } });
+    await firstClient.close();
+    await first.stop();
     await new Promise((resolve) =>
-      setTimeout(resolve, Math.max(0, timedDeadlineAt - Date.now()) + 50),
+      setTimeout(resolve, Math.max(0, firstDeadlineAt - Date.now()) + 100),
     );
 
     const restarted = new WorkflowHost({
@@ -1505,8 +1518,225 @@ setInterval(() => {}, 1000);
       runnerId: "host-timeout-restarted",
       claimPollMs: 10,
     });
+    const client = new WorkflowClient({ databasePath });
     await restarted.start();
     try {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const pausedState = new HostStateStore(databasePath, { readOnly: true });
+      try {
+        expect(pausedState.getInteraction(timedRequestId)?.status).toBe("pending");
+        expect(
+          pausedState.state.connection
+            .prepare("SELECT status, paused FROM runs WHERE run_id = ?")
+            .get("interaction-timeout-run"),
+        ).toEqual({ status: "waiting", paused: 1 });
+      } finally {
+        pausedState.close();
+      }
+
+      const subscribed = await client.request({
+        operation: "view.session.watch",
+        payload: {
+          subscriptionId: "timeout-session",
+          sessionId: "host-test-session",
+          coordinator: true,
+        },
+      });
+      const coordinatorEpoch = (subscribed.receipt as { coordinatorEpoch?: string } | undefined)
+        ?.coordinatorEpoch;
+      if (coordinatorEpoch === undefined) throw new Error("coordinator epoch missing");
+      expect(
+        await client.request({
+          operation: "workflowMessage.reportBranch",
+          payload: {
+            targetSessionId: "host-test-session",
+            coordinatorEpoch,
+            entries: [],
+            isIdle: true,
+            hasPendingMessages: false,
+          },
+        }),
+      ).toMatchObject({ outcome: "accepted" });
+      expect(
+        await client.request({ operation: "run.resume", runId: "interaction-timeout-run" }),
+      ).toMatchObject({ outcome: "accepted", receipt: { paused: false } });
+
+      const resumedState = new HostStateStore(databasePath, { readOnly: true });
+      const message = resumedState.workflowMessages
+        .listSession("host-test-session")
+        .findLast((candidate) => candidate.sourceId === timedRequestId);
+      resumedState.close();
+      if (message === undefined) throw new Error("resumed workflow message missing");
+      expect(
+        await client.request({
+          operation: "workflowMessage.reportBranch",
+          payload: {
+            targetSessionId: "host-test-session",
+            coordinatorEpoch,
+            entries: [
+              {
+                workflowMessageId: message.workflowMessageId,
+                piSessionEntryId: "timeout-step-entry",
+              },
+            ],
+            isIdle: false,
+            hasPendingMessages: true,
+          },
+        }),
+      ).toMatchObject({ outcome: "accepted" });
+      const started = {
+        state: "started" as const,
+        workflowMessageId: message.workflowMessageId,
+        workflowTurnId: "timeout-turn-1",
+        runId: message.runId,
+        targetSessionId: message.targetSessionId,
+        coordinatorEpoch,
+      };
+      expect(
+        await client.request({
+          operation: "workflowTurn.report",
+          runId: message.runId,
+          payload: started,
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { state: "started" } });
+      const activeState = new HostStateStore(databasePath, { readOnly: true });
+      const activeDeadline = activeState.state.connection
+        .prepare(
+          `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
+           FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+           WHERE i.request_id = ?`,
+        )
+        .get(timedRequestId) as { startedAt: number | null; deadlineAt: number | null } | undefined;
+      activeState.close();
+      if (activeDeadline?.startedAt == null || activeDeadline.deadlineAt == null) {
+        throw new Error("active workflow interaction deadline is missing");
+      }
+      const firstActiveDeadlineAt = activeDeadline.deadlineAt;
+      expect(firstActiveDeadlineAt).toBeGreaterThan(Date.now() + 1_000);
+      expect(firstActiveDeadlineAt).toBeGreaterThan(firstDeadlineAt);
+      expect(firstActiveDeadlineAt - activeDeadline.startedAt).toBe(configuredDurationMs);
+      expect(
+        await client.request({
+          operation: "workflowTurn.report",
+          runId: message.runId,
+          payload: started,
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { state: "started" } });
+      const duplicateState = new HostStateStore(databasePath, { readOnly: true });
+      try {
+        expect(
+          duplicateState.state.connection
+            .prepare(
+              `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
+               FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+               WHERE i.request_id = ?`,
+            )
+            .get(timedRequestId),
+        ).toEqual(activeDeadline);
+      } finally {
+        duplicateState.close();
+      }
+
+      expect(
+        await client.request({
+          operation: "run.pause",
+          runId: "interaction-timeout-run",
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { paused: true } });
+      expect(
+        await client.request({
+          operation: "workflowTurn.report",
+          runId: message.runId,
+          payload: {
+            ...started,
+            state: "ended",
+            stopReason: "aborted",
+            responseSessionEntryId: null,
+          },
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { state: "ended" } });
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.max(0, firstActiveDeadlineAt - Date.now()) + 100),
+      );
+      const activePauseState = new HostStateStore(databasePath, { readOnly: true });
+      try {
+        expect(activePauseState.getInteraction(timedRequestId)?.status).toBe("pending");
+        expect(
+          activePauseState.state.connection
+            .prepare("SELECT status, paused FROM runs WHERE run_id = ?")
+            .get("interaction-timeout-run"),
+        ).toEqual({ status: "waiting", paused: 1 });
+      } finally {
+        activePauseState.close();
+      }
+
+      expect(
+        await client.request({ operation: "run.resume", runId: "interaction-timeout-run" }),
+      ).toMatchObject({ outcome: "accepted", receipt: { paused: false } });
+      const secondResumeState = new HostStateStore(databasePath, { readOnly: true });
+      const resumedMessage = secondResumeState.workflowMessages
+        .listSession("host-test-session")
+        .findLast(
+          (candidate) =>
+            candidate.sourceId === timedRequestId &&
+            candidate.workflowMessageId !== message.workflowMessageId,
+        );
+      secondResumeState.close();
+      if (resumedMessage === undefined) throw new Error("second resumed workflow message missing");
+      expect(
+        await client.request({
+          operation: "workflowMessage.reportBranch",
+          payload: {
+            targetSessionId: "host-test-session",
+            coordinatorEpoch,
+            entries: [
+              {
+                workflowMessageId: message.workflowMessageId,
+                piSessionEntryId: "timeout-step-entry",
+              },
+              {
+                workflowMessageId: resumedMessage.workflowMessageId,
+                piSessionEntryId: "timeout-step-entry-2",
+              },
+            ],
+            isIdle: false,
+            hasPendingMessages: true,
+          },
+        }),
+      ).toMatchObject({ outcome: "accepted" });
+      const resumedTurn = {
+        state: "started" as const,
+        workflowMessageId: resumedMessage.workflowMessageId,
+        workflowTurnId: "timeout-turn-2",
+        runId: resumedMessage.runId,
+        targetSessionId: resumedMessage.targetSessionId,
+        coordinatorEpoch,
+      };
+      expect(
+        await client.request({
+          operation: "workflowTurn.report",
+          runId: resumedMessage.runId,
+          payload: resumedTurn,
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { state: "started" } });
+      const resumedTurnState = new HostStateStore(databasePath, { readOnly: true });
+      const resumedTurnDeadline = resumedTurnState.state.connection
+        .prepare(
+          `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
+           FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+           WHERE i.request_id = ?`,
+        )
+        .get(timedRequestId) as { startedAt: number | null; deadlineAt: number | null } | undefined;
+      resumedTurnState.close();
+      if (resumedTurnDeadline?.startedAt == null || resumedTurnDeadline.deadlineAt == null) {
+        throw new Error("resumed model-turn deadline is missing");
+      }
+      expect(resumedTurnDeadline.deadlineAt).toBeGreaterThan(firstActiveDeadlineAt);
+      expect(resumedTurnDeadline.deadlineAt).toBeGreaterThan(Date.now() + 1_000);
+      expect(resumedTurnDeadline.deadlineAt - resumedTurnDeadline.startedAt).toBe(
+        configuredDurationMs,
+      );
+
       await waitUntil(() => {
         const store = new SqliteControllerStore(databasePath, { readOnly: true, global: true });
         try {
@@ -1515,25 +1745,23 @@ setInterval(() => {}, 1000);
           store.close();
         }
       }, 30_000);
-      const state = new HostStateStore(databasePath, { readOnly: true });
+      const finalState = new HostStateStore(databasePath, { readOnly: true });
       try {
-        expect(state.getInteraction(timedRequestId)?.status).toBe("cancelled");
-        const attempt = state.state.connection
+        expect(finalState.getInteraction(timedRequestId)?.status).toBe("cancelled");
+        const attempt = finalState.state.connection
           .prepare(
             `SELECT a.status, a.deadline_at AS deadlineAt
              FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
              WHERE i.request_id = ?`,
           )
           .get(timedRequestId) as { status: string; deadlineAt: number | null } | undefined;
-        expect(attempt).toEqual({ status: "timed_out", deadlineAt: timedDeadlineAt });
-        const run = state.state.connection
-          .prepare("SELECT status FROM runs WHERE run_id = ?")
-          .get("interaction-timeout-run") as { status: string } | undefined;
-        expect(run?.status).toBe("timed_out");
+        expect(attempt?.status).toBe("timed_out");
+        expect(attempt?.deadlineAt).toBe(resumedTurnDeadline.deadlineAt);
       } finally {
-        state.close();
+        finalState.close();
       }
     } finally {
+      await client.close();
       await restarted.stop();
     }
   }, 60_000);

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1517,6 +1517,7 @@ setInterval(() => {}, 1000);
       databasePath,
       runnerId: "host-timeout-restarted",
       claimPollMs: 10,
+      hostRenewMs: 40,
     });
     const client = new WorkflowClient({ databasePath });
     let reconnectedClient: WorkflowClient | undefined;
@@ -1739,6 +1740,25 @@ setInterval(() => {}, 1000);
       expect(secondActiveDeadlineAt - resumedTurnDeadline.startedAt).toBe(configuredDurationMs);
 
       await client.close();
+      let disconnectedAt: number | undefined;
+      await waitUntil(() => {
+        const state = new HostStateStore(databasePath, { readOnly: true });
+        try {
+          const attempt = state.state.connection
+            .prepare(
+              `SELECT a.status, a.updated_at AS updatedAt
+               FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+               WHERE i.request_id = ?`,
+            )
+            .get(timedRequestId) as { status: string; updatedAt: number } | undefined;
+          disconnectedAt = attempt?.updatedAt;
+          return attempt?.status === "interrupted";
+        } finally {
+          state.close();
+        }
+      }, 30_000);
+      if (disconnectedAt === undefined) throw new Error("disconnect time was not recorded");
+      const recordedDisconnectAt = disconnectedAt;
       await new Promise((resolve) =>
         setTimeout(resolve, Math.max(0, secondActiveDeadlineAt - Date.now()) + 100),
       );
@@ -1750,6 +1770,18 @@ setInterval(() => {}, 1000);
             .prepare("SELECT error_code AS errorCode FROM run_queue WHERE run_id = ?")
             .get("interaction-timeout-run"),
         ).toEqual({ errorCode: null });
+        expect(
+          disconnectedState.state.connection
+            .prepare(
+              `SELECT a.status, a.updated_at AS updatedAt
+               FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+               WHERE i.request_id = ?`,
+            )
+            .get(timedRequestId),
+        ).toEqual({ status: "interrupted", updatedAt: recordedDisconnectAt });
+        const heartbeatAt = disconnectedState.hostStatus().heartbeatAt;
+        expect(heartbeatAt).not.toBeNull();
+        expect(Date.parse(heartbeatAt ?? "")).toBeGreaterThan(recordedDisconnectAt);
       } finally {
         disconnectedState.close();
       }
@@ -1775,6 +1807,20 @@ setInterval(() => {}, 1000);
       const recoveredState = new HostStateStore(databasePath, { readOnly: true });
       try {
         expect(recoveredState.getInteraction(timedRequestId)?.status).toBe("pending");
+        const recoveredAttempt = recoveredState.state.connection
+          .prepare(
+            `SELECT a.status, a.deadline_at AS deadlineAt, a.updated_at AS updatedAt
+             FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+             WHERE i.request_id = ?`,
+          )
+          .get(timedRequestId) as
+          | { status: string; deadlineAt: number | null; updatedAt: number }
+          | undefined;
+        expect(recoveredAttempt?.status).toBe("interrupted");
+        expect(recoveredAttempt?.updatedAt).toBeGreaterThan(recordedDisconnectAt);
+        expect((recoveredAttempt?.deadlineAt ?? 0) - secondActiveDeadlineAt).toBe(
+          (recoveredAttempt?.updatedAt ?? 0) - recordedDisconnectAt,
+        );
       } finally {
         recoveredState.close();
       }
@@ -1821,19 +1867,31 @@ setInterval(() => {}, 1000);
       const reconnectedState = new HostStateStore(databasePath, { readOnly: true });
       const reconnectedDeadline = reconnectedState.state.connection
         .prepare(
-          `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
+          `SELECT a.status, a.started_at AS startedAt, a.deadline_at AS deadlineAt,
+                  a.updated_at AS updatedAt
            FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
            WHERE i.request_id = ?`,
         )
-        .get(timedRequestId) as { startedAt: number | null; deadlineAt: number | null } | undefined;
+        .get(timedRequestId) as
+        | {
+            status: string;
+            startedAt: number | null;
+            deadlineAt: number | null;
+            updatedAt: number;
+          }
+        | undefined;
       reconnectedState.close();
       if (reconnectedDeadline?.startedAt == null || reconnectedDeadline.deadlineAt == null) {
         throw new Error("reconnected model-turn deadline is missing");
       }
+      expect(reconnectedDeadline.status).toBe("waiting");
       expect(reconnectedDeadline.deadlineAt).toBeGreaterThan(secondActiveDeadlineAt);
       expect(reconnectedDeadline.deadlineAt).toBeGreaterThan(Date.now() + 1_000);
       expect(reconnectedDeadline.deadlineAt - reconnectedDeadline.startedAt).toBe(
         configuredDurationMs,
+      );
+      expect(reconnectedDeadline.deadlineAt - secondActiveDeadlineAt).toBe(
+        reconnectedDeadline.updatedAt - recordedDisconnectAt,
       );
 
       await waitUntil(() => {

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1519,6 +1519,8 @@ setInterval(() => {}, 1000);
       claimPollMs: 10,
     });
     const client = new WorkflowClient({ databasePath });
+    let reconnectedClient: WorkflowClient | undefined;
+    let recoveredHost: WorkflowHost | undefined;
     await restarted.start();
     try {
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -1731,9 +1733,106 @@ setInterval(() => {}, 1000);
       if (resumedTurnDeadline?.startedAt == null || resumedTurnDeadline.deadlineAt == null) {
         throw new Error("resumed model-turn deadline is missing");
       }
-      expect(resumedTurnDeadline.deadlineAt).toBeGreaterThan(firstActiveDeadlineAt);
-      expect(resumedTurnDeadline.deadlineAt).toBeGreaterThan(Date.now() + 1_000);
-      expect(resumedTurnDeadline.deadlineAt - resumedTurnDeadline.startedAt).toBe(
+      const secondActiveDeadlineAt = resumedTurnDeadline.deadlineAt;
+      expect(secondActiveDeadlineAt).toBeGreaterThan(firstActiveDeadlineAt);
+      expect(secondActiveDeadlineAt).toBeGreaterThan(Date.now() + 1_000);
+      expect(secondActiveDeadlineAt - resumedTurnDeadline.startedAt).toBe(configuredDurationMs);
+
+      await client.close();
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.max(0, secondActiveDeadlineAt - Date.now()) + 100),
+      );
+      const disconnectedState = new HostStateStore(databasePath, { readOnly: true });
+      try {
+        expect(disconnectedState.getInteraction(timedRequestId)?.status).toBe("pending");
+        expect(
+          disconnectedState.state.connection
+            .prepare("SELECT error_code AS errorCode FROM run_queue WHERE run_id = ?")
+            .get("interaction-timeout-run"),
+        ).toEqual({ errorCode: null });
+      } finally {
+        disconnectedState.close();
+      }
+      const disconnectedViewer = new WorkflowClient({ databasePath });
+      try {
+        expect(
+          await disconnectedViewer.request({
+            operation: "run.status",
+            runId: "interaction-timeout-run",
+          }),
+        ).toMatchObject({ outcome: "accepted", receipt: { display: { status: "waiting" } } });
+      } finally {
+        await disconnectedViewer.close();
+      }
+
+      await restarted.stop();
+      recoveredHost = new WorkflowHost({
+        databasePath,
+        runnerId: "host-timeout-recovered",
+        claimPollMs: 10,
+      });
+      await recoveredHost.start();
+      const recoveredState = new HostStateStore(databasePath, { readOnly: true });
+      try {
+        expect(recoveredState.getInteraction(timedRequestId)?.status).toBe("pending");
+      } finally {
+        recoveredState.close();
+      }
+
+      reconnectedClient = new WorkflowClient({ databasePath });
+      const reconnected = await reconnectedClient.request({
+        operation: "view.session.watch",
+        payload: {
+          subscriptionId: "timeout-session-reconnected",
+          sessionId: "host-test-session",
+          coordinator: true,
+        },
+      });
+      const reconnectedEpoch = (reconnected.receipt as { coordinatorEpoch?: string } | undefined)
+        ?.coordinatorEpoch;
+      if (reconnectedEpoch === undefined) throw new Error("reconnected coordinator epoch missing");
+      expect(
+        await reconnectedClient.request({
+          operation: "workflowMessage.reportBranch",
+          payload: {
+            targetSessionId: "host-test-session",
+            coordinatorEpoch: reconnectedEpoch,
+            entries: [
+              {
+                workflowMessageId: message.workflowMessageId,
+                piSessionEntryId: "timeout-step-entry",
+              },
+              {
+                workflowMessageId: resumedMessage.workflowMessageId,
+                piSessionEntryId: "timeout-step-entry-2",
+              },
+            ],
+            isIdle: false,
+            hasPendingMessages: true,
+          },
+        }),
+      ).toMatchObject({ outcome: "accepted" });
+      expect(
+        await reconnectedClient.request({
+          operation: "run.status",
+          runId: "interaction-timeout-run",
+        }),
+      ).toMatchObject({ outcome: "accepted", receipt: { display: { status: "running" } } });
+      const reconnectedState = new HostStateStore(databasePath, { readOnly: true });
+      const reconnectedDeadline = reconnectedState.state.connection
+        .prepare(
+          `SELECT a.started_at AS startedAt, a.deadline_at AS deadlineAt
+           FROM node_attempts a JOIN interactive_requests i ON i.attempt_id = a.attempt_id
+           WHERE i.request_id = ?`,
+        )
+        .get(timedRequestId) as { startedAt: number | null; deadlineAt: number | null } | undefined;
+      reconnectedState.close();
+      if (reconnectedDeadline?.startedAt == null || reconnectedDeadline.deadlineAt == null) {
+        throw new Error("reconnected model-turn deadline is missing");
+      }
+      expect(reconnectedDeadline.deadlineAt).toBeGreaterThan(secondActiveDeadlineAt);
+      expect(reconnectedDeadline.deadlineAt).toBeGreaterThan(Date.now() + 1_000);
+      expect(reconnectedDeadline.deadlineAt - reconnectedDeadline.startedAt).toBe(
         configuredDurationMs,
       );
 
@@ -1756,12 +1855,14 @@ setInterval(() => {}, 1000);
           )
           .get(timedRequestId) as { status: string; deadlineAt: number | null } | undefined;
         expect(attempt?.status).toBe("timed_out");
-        expect(attempt?.deadlineAt).toBe(resumedTurnDeadline.deadlineAt);
+        expect(attempt?.deadlineAt).toBe(reconnectedDeadline.deadlineAt);
       } finally {
         finalState.close();
       }
     } finally {
       await client.close();
+      await reconnectedClient?.close();
+      await recoveredHost?.stop();
       await restarted.stop();
     }
   }, 60_000);

--- a/tui/src/client.rs
+++ b/tui/src/client.rs
@@ -73,6 +73,7 @@ fn decode_view(
     raw: &Value,
     definition_content: Option<&str>,
     graph_history_content: Option<&str>,
+    display_reason_content: Option<&str>,
 ) -> Option<RemoteView> {
     let graph_revision = raw
         .get("graphRevision")
@@ -80,7 +81,10 @@ fn decode_view(
         .unwrap_or(revision);
     let manifest: Manifest = serde_json::from_value(raw.get("manifest")?.clone()).ok()?;
     let state: RunState = serde_json::from_value(raw.get("state")?.clone()).ok()?;
-    let display: WorkflowDisplay = serde_json::from_value(raw.get("display")?.clone()).ok()?;
+    let mut display: WorkflowDisplay = serde_json::from_value(raw.get("display")?.clone()).ok()?;
+    if display_reason_artifact(raw).is_some() {
+        display.reason_content = Some(display_reason_value(raw, display_reason_content)?);
+    }
     let graph_history = graph_history_value(raw, graph_history_content);
     let graph_steps = graph_history
         .as_ref()
@@ -249,6 +253,23 @@ fn graph_history_value(raw: &Value, content: Option<&str>) -> Option<Value> {
     Some(history.clone())
 }
 
+fn display_reason_artifact(raw: &Value) -> Option<ArtifactRef> {
+    raw.pointer("/display/reasonContent")
+        .and_then(as_artifact_ref)
+}
+
+fn display_reason_value(raw: &Value, content: Option<&str>) -> Option<Value> {
+    let reason = raw.pointer("/display/reasonContent")?;
+    let Some(artifact) = display_reason_artifact(raw) else {
+        return Some(reason.clone());
+    };
+    match artifact.media_type.as_str() {
+        "text/plain" => Some(Value::String(content?.to_string())),
+        "application/json" => serde_json::from_str(content?).ok(),
+        _ => None,
+    }
+}
+
 fn workflow_definition_content(
     state: &mut Shared,
     run_id: &str,
@@ -257,26 +278,52 @@ fn workflow_definition_content(
     let Some(artifact) = workflow_definition_artifact(raw) else {
         return (None, false);
     };
-    referenced_json_content(state, run_id, artifact, "workflow definition")
+    referenced_content(
+        state,
+        run_id,
+        artifact,
+        &["application/json"],
+        "workflow definition",
+    )
 }
 
 fn graph_history_content(state: &mut Shared, run_id: &str, raw: &Value) -> (Option<String>, bool) {
     let Some(artifact) = graph_history_artifact(raw) else {
         return (None, false);
     };
-    referenced_json_content(state, run_id, artifact, "workflow graph history")
+    referenced_content(
+        state,
+        run_id,
+        artifact,
+        &["application/json"],
+        "workflow graph history",
+    )
 }
 
-fn referenced_json_content(
+fn display_reason_content(state: &mut Shared, run_id: &str, raw: &Value) -> (Option<String>, bool) {
+    let Some(artifact) = display_reason_artifact(raw) else {
+        return (None, false);
+    };
+    referenced_content(
+        state,
+        run_id,
+        artifact,
+        &["text/plain", "application/json"],
+        "workflow display reason",
+    )
+}
+
+fn referenced_content(
     state: &mut Shared,
     run_id: &str,
     artifact: ArtifactRef,
+    accepted_media_types: &[&str],
     label: &str,
 ) -> (Option<String>, bool) {
     let key = (run_id.to_string(), artifact.path.clone());
     match state.artifacts.get(&key).cloned() {
         Some(ArtifactEntry::Ready(content)) => {
-            let valid = artifact.media_type == "application/json"
+            let valid = accepted_media_types.contains(&artifact.media_type.as_str())
                 && content.len() as u64 == artifact.bytes
                 && hex_sha256(content.as_bytes()) == artifact.sha256;
             if valid {
@@ -535,15 +582,18 @@ impl RemoteRuns {
             self.decoded.remove(run_id);
             return None;
         };
-        let (definition_content, graph_history_content, requested) = {
+        let (definition_content, graph_history_content, display_reason_content, requested) = {
             let mut shared = self.shared.lock().unwrap();
             let (definition, definition_requested) =
                 workflow_definition_content(&mut shared, run_id, &raw);
             let (graph_history, graph_requested) = graph_history_content(&mut shared, run_id, &raw);
+            let (display_reason, display_reason_requested) =
+                display_reason_content(&mut shared, run_id, &raw);
             (
                 definition,
                 graph_history,
-                definition_requested || graph_requested,
+                display_reason,
+                definition_requested || graph_requested || display_reason_requested,
             )
         };
         if requested {
@@ -560,10 +610,9 @@ impl RemoteRuns {
                 &raw,
                 definition_content.as_deref(),
                 graph_history_content.as_deref(),
+                display_reason_content.as_deref(),
             ) {
                 self.decoded.insert(run_id.to_string(), decoded);
-            } else {
-                self.decoded.remove(run_id);
             }
         }
         self.decoded.get(run_id)
@@ -1362,19 +1411,20 @@ mod tests {
             "possiblyInterrupted":false
         });
 
-        let view = decode_view(4, 1, &raw, None, None).expect("host view should decode");
+        let view = decode_view(4, 1, &raw, None, None, None).expect("host view should decode");
         assert_eq!(view.manifest.workflow_name, "smoke");
         assert_eq!(view.state.status, crate::state::types::RunStatus::Completed);
         assert_eq!(view.update_total, 300);
 
         let mut missing_display = raw;
         missing_display.as_object_mut().unwrap().remove("display");
-        assert!(decode_view(4, 1, &missing_display, None, None).is_none());
+        assert!(decode_view(4, 1, &missing_display, None, None, None).is_none());
     }
 
     #[test]
     fn uses_the_host_display_status_during_an_origin_turn() {
         let source = json!({"kind":"file","path":"/tmp/smoke.workflow.ts","hash":"abc"});
+        let reason_content = "The origin-session model turn is active.";
         let raw = json!({
             "manifest": {
                 "schema":"pi-workflows.run-manifest.v1",
@@ -1407,7 +1457,15 @@ mod tests {
                 "status":"running",
                 "activity":"origin_turn",
                 "controls":["pause","cancel"],
-                "reason":null
+                "reason":"The model is running.",
+                "reasonContent": {
+                    "$artifact": {
+                        "path":"artifacts/sha256/display-reason.txt",
+                        "mediaType":"text/plain",
+                        "bytes":reason_content.len(),
+                        "sha256":hex_sha256(reason_content.as_bytes())
+                    }
+                }
             },
             "workflow": {
                 "schema":"pi-workflows.definition-snapshot.v1",
@@ -1418,10 +1476,15 @@ mod tests {
             }
         });
 
-        let view = decode_view(4, 1, &raw, None, None).expect("host view should decode");
+        let view = decode_view(4, 1, &raw, None, None, Some(reason_content))
+            .expect("host view should decode");
 
         assert_eq!(view.state.status, crate::state::types::RunStatus::Waiting);
         assert_eq!(view.display.status, crate::state::types::RunStatus::Running);
+        assert_eq!(
+            view.display.reason_content,
+            Some(Value::String(reason_content.to_string()))
+        );
         assert_eq!(view.display.active_node(&view.state), Some("work"));
 
         let graph = GraphView {
@@ -1574,6 +1637,42 @@ mod tests {
         assert!(!requested);
         let complete = graph_history_value(&raw, loaded.as_deref()).unwrap();
         assert_eq!(complete["transitions"].as_array().map(Vec::len), Some(300));
+    }
+
+    #[test]
+    fn complete_display_reason_uses_the_shared_content_loader() {
+        let content = "complete workflow failure reason";
+        let path = "artifacts/sha256/display-reason.txt";
+        let raw = json!({
+            "display": {
+                "status":"failed",
+                "activity":null,
+                "controls":[],
+                "reason":"Complete workflow failure details are available.",
+                "reasonContent": {
+                    "$artifact": {
+                        "path":path,
+                        "mediaType":"text/plain",
+                        "bytes":content.len(),
+                        "sha256":hex_sha256(content.as_bytes())
+                    }
+                }
+            }
+        });
+        let mut state = Shared::default();
+        let (missing, requested) = display_reason_content(&mut state, "run-1", &raw);
+        assert!(missing.is_none());
+        assert!(requested);
+        state.artifacts.insert(
+            ("run-1".to_string(), path.to_string()),
+            ArtifactEntry::Ready(content.to_string()),
+        );
+        let (loaded, requested) = display_reason_content(&mut state, "run-1", &raw);
+        assert!(!requested);
+        assert_eq!(
+            display_reason_value(&raw, loaded.as_deref()),
+            Some(Value::String(content.to_string()))
+        );
     }
 
     #[test]

--- a/tui/src/client.rs
+++ b/tui/src/client.rs
@@ -7,6 +7,7 @@ use crate::protocol::{
 };
 use crate::state::types::{
     as_artifact_ref, ArtifactRef, DefinitionSnapshot, Manifest, RunState, StepRecord,
+    WorkflowDisplay,
 };
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -32,6 +33,7 @@ pub struct RemoteView {
     generation: u64,
     pub manifest: Manifest,
     pub state: RunState,
+    pub display: WorkflowDisplay,
     pub graph_steps: Vec<StepRecord>,
     pub taken_transitions: Vec<String>,
     pub graph_cursor: u64,
@@ -78,6 +80,7 @@ fn decode_view(
         .unwrap_or(revision);
     let manifest: Manifest = serde_json::from_value(raw.get("manifest")?.clone()).ok()?;
     let state: RunState = serde_json::from_value(raw.get("state")?.clone()).ok()?;
+    let display: WorkflowDisplay = serde_json::from_value(raw.get("display")?.clone()).ok()?;
     let graph_history = graph_history_value(raw, graph_history_content);
     let graph_steps = graph_history
         .as_ref()
@@ -148,6 +151,7 @@ fn decode_view(
         generation,
         manifest,
         state,
+        display,
         graph_steps,
         taken_transitions,
         graph_cursor,
@@ -1269,6 +1273,7 @@ fn page_name(kind: PageKind) -> &'static str {
 mod tests {
     use super::*;
     use crate::protocol::PatchOp;
+    use crate::render::{render_graph, render_graph_lines, GraphNodeStyle, GraphView};
 
     #[test]
     fn missing_run_watch_sets_a_visible_client_error() {
@@ -1326,6 +1331,12 @@ mod tests {
                 "nodes":{"done":{"nodeType":"compute"}},
                 "edges":[]
             },
+            "display": {
+                "status":"completed",
+                "activity":null,
+                "controls":[],
+                "reason":null
+            },
             "graphSteps":[],
             "takenTransitions":[],
             "graphCursor":0,
@@ -1355,6 +1366,114 @@ mod tests {
         assert_eq!(view.manifest.workflow_name, "smoke");
         assert_eq!(view.state.status, crate::state::types::RunStatus::Completed);
         assert_eq!(view.update_total, 300);
+
+        let mut missing_display = raw;
+        missing_display.as_object_mut().unwrap().remove("display");
+        assert!(decode_view(4, 1, &missing_display, None, None).is_none());
+    }
+
+    #[test]
+    fn uses_the_host_display_status_during_an_origin_turn() {
+        let source = json!({"kind":"file","path":"/tmp/smoke.workflow.ts","hash":"abc"});
+        let raw = json!({
+            "manifest": {
+                "schema":"pi-workflows.run-manifest.v1",
+                "runId":"run-1",
+                "workflowName":"smoke",
+                "workflowSource":source,
+                "startedAt":"2026-01-01T00:00:00.000Z",
+                "finishedAt":null,
+                "status":"running",
+                "traceSchema":"pi-workflows.trace-event.v1",
+                "paths":{"workflow":"host","state":"host","trace":"host"}
+            },
+            "state": {
+                "schema":"pi-workflows.run-state.v1",
+                "traceSeq":1,
+                "runId":"run-1",
+                "workflowName":"smoke",
+                "workflowSource":source,
+                "startedAt":"2026-01-01T00:00:00.000Z",
+                "finishedAt":"2026-01-01T00:00:01.000Z",
+                "updatedAt":"2026-01-01T00:00:01.000Z",
+                "status":"waiting",
+                "input":{},
+                "outputs":{},
+                "results":{},
+                "steps":[],
+                "waitingOn":"work"
+            },
+            "display": {
+                "status":"running",
+                "activity":"origin_turn",
+                "controls":["pause","cancel"],
+                "reason":null
+            },
+            "workflow": {
+                "schema":"pi-workflows.definition-snapshot.v1",
+                "name":"smoke",
+                "startAt":"work",
+                "nodes":{"work":{"nodeType":"agent"}},
+                "edges":[]
+            }
+        });
+
+        let view = decode_view(4, 1, &raw, None, None).expect("host view should decode");
+
+        assert_eq!(view.state.status, crate::state::types::RunStatus::Waiting);
+        assert_eq!(view.display.status, crate::state::types::RunStatus::Running);
+        assert_eq!(view.display.active_node(&view.state), Some("work"));
+
+        let graph = GraphView {
+            state: &view.state,
+            display: &view.display,
+            snapshot: view.snapshot.as_ref(),
+            graph_steps: Some(&view.graph_steps),
+            taken_transitions: Some(&view.taken_transitions),
+        };
+        let rendered =
+            render_graph_lines(&graph, -1, 1_767_225_660_000, GraphNodeStyle::Line).join("\n");
+        assert!(rendered.contains("◐ work"), "{rendered}");
+        assert!(!rendered.contains("⏸ work"), "{rendered}");
+
+        let replayed = render_graph(&graph, -1, false, 1_767_225_660_000, GraphNodeStyle::Line)
+            .expect("graph should render")
+            .canvas
+            .render_plain()
+            .join("\n");
+        assert!(!replayed.contains("◐ work"), "{replayed}");
+    }
+
+    #[test]
+    fn display_only_patch_changes_the_live_status_without_changing_durable_state() {
+        let mut raw = json!({
+            "display": {
+                "status":"waiting",
+                "activity":null,
+                "controls":["pause","cancel","answer"],
+                "reason":"The workflow is waiting for origin-session input."
+            },
+            "state":{"status":"waiting"}
+        });
+
+        apply_patch(
+            &mut raw,
+            &[
+                PatchOp::Replace {
+                    path: "/display/status".into(),
+                    value: json!("running"),
+                },
+                PatchOp::Replace {
+                    path: "/display/activity".into(),
+                    value: json!("origin_turn"),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(raw["display"]["status"], "running");
+        assert_eq!(raw["display"]["activity"], "origin_turn");
+        assert_eq!(raw["state"]["status"], "waiting");
     }
 
     #[test]

--- a/tui/src/render.rs
+++ b/tui/src/render.rs
@@ -8,7 +8,7 @@ use crate::canvas::{CanvasStyle, CharCanvas};
 use crate::format::{format_duration, parse_timestamp_ms, sanitize_text};
 use crate::layout::{layout_graph, GraphCell, GraphEdge, GraphLayout, GraphSegment};
 use crate::state::types::{
-    DefinitionSnapshot, EdgeDef, NodeOutcome, RunState, RunStatus, StepRecord,
+    DefinitionSnapshot, EdgeDef, NodeOutcome, RunState, StepRecord, WorkflowDisplay,
 };
 use serde_json::Value;
 use std::collections::HashSet;
@@ -17,6 +17,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 /// Everything the graph needs from a loaded run.
 pub struct GraphView<'a> {
     pub state: &'a RunState,
+    pub display: &'a WorkflowDisplay,
     pub snapshot: Option<&'a DefinitionSnapshot>,
     pub graph_steps: Option<&'a [StepRecord]>,
     pub taken_transitions: Option<&'a [String]>,
@@ -214,7 +215,7 @@ fn derive_node_status(
     at_latest_step: bool,
 ) -> NodeStatus {
     let state = view.state;
-    if at_latest_step && state.current_node.as_deref() == Some(node_id) {
+    if at_latest_step && view.display.active_node(state) == Some(node_id) {
         return NodeStatus::Active;
     }
     if at_latest_step && state.waiting_on.as_deref() == Some(node_id) {
@@ -471,7 +472,8 @@ fn render_cell_text(
         .snapshot
         .is_some_and(|snapshot| snapshot.start_at == *node_id);
     let is_end = outgoing == 0;
-    let elapsed = if at_latest_step && state.current_node.as_deref() == Some(node_id.as_str()) {
+    let is_active = at_latest_step && view.display.active_node(state) == Some(node_id.as_str());
+    let elapsed = if is_active {
         let started_at = state
             .current_node_started_at
             .as_deref()
@@ -516,11 +518,7 @@ fn render_cell_text(
             .join(" · ")
     });
     let branch_lines = bounded_branch_lines(&labels);
-    let count = if at_latest_step && state.current_node.as_deref() == Some(node_id.as_str()) {
-        attempts.max(1)
-    } else {
-        attempts
-    };
+    let count = if is_active { attempts.max(1) } else { attempts };
     let timing = if attempt.is_some() || count > 0 {
         format!(
             "{count} attempt{} · {elapsed}",
@@ -878,15 +876,14 @@ fn derive_pair_in_flight(
     visible_steps: &[StepRecord],
     at_latest_step: bool,
 ) -> Option<String> {
-    let state = view.state;
     if at_latest_step {
-        if state.status == RunStatus::Running {
-            if let (Some(current), Some(last)) = (
-                state.current_node.as_deref().filter(|id| !id.is_empty()),
-                visible_steps.last(),
-            ) {
-                return Some(format!("{}->{current}", last.node_id));
-            }
+        if let (Some(current), Some(last)) = (
+            view.display
+                .active_node(view.state)
+                .filter(|id| !id.is_empty()),
+            visible_steps.last(),
+        ) {
+            return Some(format!("{}->{current}", last.node_id));
         }
         return None;
     }

--- a/tui/src/state/types.rs
+++ b/tui/src/state/types.rs
@@ -51,6 +51,96 @@ impl RunStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum WorkflowActivity {
+    SupervisedWorker,
+    OriginTurn,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowControl {
+    Pause,
+    Resume,
+    Cancel,
+    Answer,
+    Review,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowDisplay {
+    pub status: RunStatus,
+    pub activity: Option<WorkflowActivity>,
+    pub controls: Vec<WorkflowControl>,
+    pub reason: Option<String>,
+    #[serde(rename = "reasonContent", skip_serializing_if = "Option::is_none")]
+    pub reason_content: Option<Value>,
+}
+
+impl WorkflowDisplay {
+    pub fn active_node<'a>(&self, state: &'a RunState) -> Option<&'a str> {
+        if self.status != RunStatus::Running {
+            return None;
+        }
+        state.current_node.as_deref().or_else(|| {
+            (self.activity == Some(WorkflowActivity::OriginTurn))
+                .then_some(state.waiting_on.as_deref())
+                .flatten()
+        })
+    }
+}
+
+#[cfg(test)]
+mod workflow_display_tests {
+    use super::{RunState, RunStatus, WorkflowActivity, WorkflowControl, WorkflowDisplay};
+    use serde_json::json;
+
+    #[test]
+    fn preserves_the_host_display_and_uses_only_a_running_origin_turn_as_the_active_wait() {
+        let state: RunState = serde_json::from_value(json!({
+            "schema":"pi-workflows.run-state.v1",
+            "traceSeq":1,
+            "runId":"run-1",
+            "workflowName":"smoke",
+            "startedAt":"2026-01-01T00:00:00.000Z",
+            "updatedAt":"2026-01-01T00:00:01.000Z",
+            "status":"waiting",
+            "input":{},
+            "outputs":{},
+            "results":{},
+            "steps":[],
+            "waitingOn":"work"
+        }))
+        .unwrap();
+        let running: WorkflowDisplay = serde_json::from_value(json!({
+            "status":"running",
+            "activity":"origin_turn",
+            "controls":["pause","cancel"],
+            "reason":null,
+            "reasonContent":{"turn":"active"}
+        }))
+        .unwrap();
+
+        assert_eq!(running.status, RunStatus::Running);
+        assert_eq!(running.activity, Some(WorkflowActivity::OriginTurn));
+        assert_eq!(
+            running.controls,
+            vec![WorkflowControl::Pause, WorkflowControl::Cancel]
+        );
+        assert_eq!(running.active_node(&state), Some("work"));
+
+        let waiting = WorkflowDisplay {
+            status: RunStatus::Waiting,
+            activity: None,
+            controls: vec![WorkflowControl::Pause, WorkflowControl::Cancel],
+            reason: Some("waiting".into()),
+            reason_content: None,
+        };
+        assert_eq!(waiting.active_node(&state), None);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum NodeOutcome {
     Ok,
     TimedOut,

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -2977,6 +2977,14 @@ fn page_range(start: u64, length: usize, total: u64) -> String {
     }
 }
 
+fn display_reason_content(display: &WorkflowDisplay) -> Option<String> {
+    match display.reason_content.as_ref()? {
+        Value::Null => None,
+        Value::String(text) => Some(text.clone()),
+        other => Some(serde_json::to_string_pretty(other).unwrap_or_else(|_| other.to_string())),
+    }
+}
+
 fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'static>> {
     let state = data.state;
     let label =
@@ -3005,6 +3013,18 @@ fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'stat
             label("reason"),
             Span::raw(sanitize_text(reason)),
         ]));
+    }
+    if let Some(content) = display_reason_content(data.display) {
+        for (index, logical_line) in content.lines().enumerate() {
+            lines.push(Line::from(vec![
+                if index == 0 {
+                    label("reason detail")
+                } else {
+                    Span::raw(" ".repeat(14))
+                },
+                Span::raw(sanitize_text(logical_line)),
+            ]));
+        }
     }
     if data.display.status.is_terminal() {
         if let Some(finished) = &state.finished_at {
@@ -3469,13 +3489,14 @@ fn draw_transport(
 mod tests {
     use super::{
         centered_camera, clamp_camera_axis, collect_artifact_paths, completed_step_at, contains,
-        current_progress_epoch, display_end_ms, graph_position_label, inspector_height_for_drag,
-        inspector_tab_label, inspector_tab_layout, next_page_cursor, page_range, parse_run_summary,
-        progress_rates, push_human_decision_presentation, reconcile_selected_run,
-        resolve_remote_artifacts, resolved_inspector_height, sidebar_width_for_drag,
-        step_projection_contains, temporal_delay_from_page, temporal_through_seq,
-        trace_events_for_scope, valid_session_binding, GraphNodeStyle, InspectorTab, NodeBounds,
-        Palette, Rect, StepRecord, TemporalDelay, TraceScope, DEFAULT_NODE_STYLE,
+        current_progress_epoch, display_end_ms, display_reason_content, graph_position_label,
+        inspector_height_for_drag, inspector_tab_label, inspector_tab_layout, next_page_cursor,
+        page_range, parse_run_summary, progress_rates, push_human_decision_presentation,
+        reconcile_selected_run, resolve_remote_artifacts, resolved_inspector_height,
+        sidebar_width_for_drag, step_projection_contains, temporal_delay_from_page,
+        temporal_through_seq, trace_events_for_scope, valid_session_binding, GraphNodeStyle,
+        InspectorTab, NodeBounds, Palette, Rect, StepRecord, TemporalDelay, TraceScope,
+        DEFAULT_NODE_STYLE,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -3508,6 +3529,23 @@ mod tests {
         assert_eq!(
             summary.display.status,
             crate::state::types::RunStatus::Running
+        );
+    }
+
+    #[test]
+    fn display_reason_content_renders_the_complete_hydrated_host_value() {
+        let display: crate::state::types::WorkflowDisplay = serde_json::from_value(json!({
+            "status":"failed",
+            "activity":null,
+            "controls":[],
+            "reason":"Complete workflow failure details are available.",
+            "reasonContent":"complete failure reason"
+        }))
+        .unwrap();
+
+        assert_eq!(
+            display_reason_content(&display).as_deref(),
+            Some("complete failure reason")
         );
     }
 

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -19,7 +19,7 @@ use crate::render::{
 use crate::session::{assess_capture, CaptureIntegrity};
 use crate::state::types::{
     DefinitionSnapshot, EdgeDef, NodeOutcome, RunState, RunStatus, SessionCapture,
-    SessionEntryRecord, SessionEventRecord, StepRecord, SESSION_BINDING_SCHEMA,
+    SessionEntryRecord, SessionEventRecord, StepRecord, WorkflowDisplay, SESSION_BINDING_SCHEMA,
 };
 use crate::theme::{self, Palette, ThemeConfig};
 use anyhow::Result;
@@ -54,7 +54,7 @@ pub struct RunSummary {
     pub run_id: String,
     pub workflow_name: String,
     pub run_title: Option<String>,
-    pub status: RunStatus,
+    pub display: WorkflowDisplay,
     pub started_at: String,
     pub finished_at: Option<String>,
     pub live: bool,
@@ -65,6 +65,7 @@ pub struct RunSummary {
 pub struct RunData<'a> {
     pub graph_revision: u64,
     pub state: &'a RunState,
+    pub display: &'a WorkflowDisplay,
     pub graph_steps: &'a [crate::state::types::StepRecord],
     pub taken_transitions: &'a [String],
     pub graph_cursor: u64,
@@ -116,11 +117,12 @@ fn valid_session_binding(binding: Option<&Value>) -> bool {
 fn parse_run_summary(summary: &Value) -> Option<RunSummary> {
     let manifest: crate::state::types::Manifest =
         serde_json::from_value(summary.get("manifest")?.clone()).ok()?;
+    let display: WorkflowDisplay = serde_json::from_value(summary.get("display")?.clone()).ok()?;
     Some(RunSummary {
         run_id: manifest.run_id,
         workflow_name: manifest.workflow_name,
         run_title: manifest.run_title,
-        status: manifest.status,
+        display,
         started_at: manifest.started_at,
         finished_at: manifest.finished_at,
         live: summary
@@ -158,6 +160,7 @@ impl Provider {
         Some(RunData {
             graph_revision: view.graph_revision,
             state: &view.state,
+            display: &view.display,
             graph_steps: &view.graph_steps,
             taken_transitions: &view.taken_transitions,
             graph_cursor: view.graph_cursor,
@@ -1621,6 +1624,14 @@ fn status_glyph(status: RunStatus) -> &'static str {
     }
 }
 
+fn display_end_ms(status: RunStatus, finished_at: Option<&str>, now: i64) -> i64 {
+    if status == RunStatus::Running {
+        now
+    } else {
+        finished_at.and_then(parse_timestamp_ms).unwrap_or(now)
+    }
+}
+
 fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
@@ -1805,6 +1816,7 @@ fn draw(frame: &mut Frame, app: &mut App, summaries: &[RunSummary]) {
     // Graph pane.
     let view = GraphView {
         state: data.state,
+        display: data.display,
         snapshot: data.snapshot,
         graph_steps: Some(data.graph_steps),
         taken_transitions: Some(data.taken_transitions),
@@ -1822,9 +1834,8 @@ fn draw(frame: &mut Frame, app: &mut App, summaries: &[RunSummary]) {
             .and_then(Value::as_str)
     });
     let followed_node_id = if at_latest {
-        data.state
-            .current_node
-            .as_deref()
+        data.display
+            .active_node(data.state)
             .or(data.state.waiting_on.as_deref())
             .or_else(|| selected_step.map(|step| step.node_id.as_str()))
     } else {
@@ -1839,7 +1850,7 @@ fn draw(frame: &mut Frame, app: &mut App, summaries: &[RunSummary]) {
         graph_cursor: data.graph_cursor,
         at_latest,
         node_style,
-        elapsed_second: if at_latest && data.state.current_node.is_some() {
+        elapsed_second: if at_latest && data.display.active_node(data.state).is_some() {
             rendered_at / 1_000
         } else {
             0
@@ -1909,7 +1920,7 @@ fn draw(frame: &mut Frame, app: &mut App, summaries: &[RunSummary]) {
     if follow {
         graph_flags.push("FOLLOW");
     }
-    if data.state.paused == Some(true) {
+    if data.display.status == RunStatus::Paused {
         graph_flags.push("PAUSED");
     }
     if capture.status == "failed" {
@@ -2225,11 +2236,11 @@ fn draw_runs(
             } else {
                 ""
             };
-            let end = summary
-                .finished_at
-                .as_deref()
-                .and_then(parse_timestamp_ms)
-                .unwrap_or_else(now_ms);
+            let end = display_end_ms(
+                summary.display.status,
+                summary.finished_at.as_deref(),
+                now_ms(),
+            );
             let elapsed = parse_timestamp_ms(&summary.started_at)
                 .map(|start| format!(" {}", format_duration((end - start).max(0))))
                 .unwrap_or_default();
@@ -2242,8 +2253,8 @@ fn draw_runs(
                 vec![
                     Span::raw(if index == selected { "▶" } else { " " }),
                     Span::styled(
-                        status_glyph(summary.status),
-                        status_style(summary.status, palette),
+                        status_glyph(summary.display.status),
+                        status_style(summary.display.status, palette),
                     ),
                     Span::raw(initial),
                     Span::styled(
@@ -2259,8 +2270,8 @@ fn draw_runs(
                 vec![
                     Span::raw(marker.to_string()),
                     Span::styled(
-                        format!("{} ", status_glyph(summary.status)),
-                        status_style(summary.status, palette),
+                        format!("{} ", status_glyph(summary.display.status)),
+                        status_style(summary.display.status, palette),
                     ),
                     Span::raw(sanitize_text(&name)),
                     Span::styled(elapsed, Style::default().fg(palette.muted)),
@@ -2980,8 +2991,8 @@ fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'stat
         Line::from(vec![
             label("status"),
             Span::styled(
-                state.status.label().to_string(),
-                status_style(state.status, palette),
+                data.display.status.label().to_string(),
+                status_style(data.display.status, palette),
             ),
         ]),
         Line::from(vec![
@@ -2989,11 +3000,19 @@ fn info_lines(data: &RunData, run_id: &str, palette: &Palette) -> Vec<Line<'stat
             Span::raw(sanitize_text(&state.started_at)),
         ]),
     ];
-    if let Some(finished) = &state.finished_at {
+    if let Some(reason) = &data.display.reason {
         lines.push(Line::from(vec![
-            label("finished"),
-            Span::raw(sanitize_text(finished)),
+            label("reason"),
+            Span::raw(sanitize_text(reason)),
         ]));
+    }
+    if data.display.status.is_terminal() {
+        if let Some(finished) = &state.finished_at {
+            lines.push(Line::from(vec![
+                label("finished"),
+                Span::raw(sanitize_text(finished)),
+            ]));
+        }
     }
     if let Some(source) = &state.workflow_source {
         lines.push(Line::from(vec![
@@ -3398,21 +3417,30 @@ fn draw_transport(
     options: TransportOptions<'_>,
     palette: &Palette,
 ) -> timeline::TimelineGeometry {
-    let elapsed = data.map(|(data, _, _)| {
+    let elapsed = data.map(|(data, _, at_latest)| {
         let state = data.state;
-        let end = state
-            .finished_at
-            .as_deref()
-            .and_then(parse_timestamp_ms)
-            .unwrap_or_else(now_ms);
+        let now = now_ms();
+        let end = if at_latest {
+            display_end_ms(data.display.status, state.finished_at.as_deref(), now)
+        } else {
+            state
+                .finished_at
+                .as_deref()
+                .and_then(parse_timestamp_ms)
+                .unwrap_or(now)
+        };
         let start = parse_timestamp_ms(&state.started_at).unwrap_or(end);
         format_duration((end - start).max(0))
     });
     let view = data.map(|(data, bounded_index, at_latest)| {
         let temporal = data.session_event_total > 0;
         timeline::TimelineView {
-            status: data.state.status,
-            paused: data.state.paused == Some(true),
+            status: if at_latest {
+                data.display.status
+            } else {
+                data.state.status
+            },
+            paused: at_latest && data.display.status == RunStatus::Paused,
             elapsed: elapsed.as_deref().unwrap_or("0ms"),
             steps: if temporal {
                 data.session_event_total as usize
@@ -3441,17 +3469,71 @@ fn draw_transport(
 mod tests {
     use super::{
         centered_camera, clamp_camera_axis, collect_artifact_paths, completed_step_at, contains,
-        current_progress_epoch, graph_position_label, inspector_height_for_drag,
-        inspector_tab_label, inspector_tab_layout, next_page_cursor, page_range, progress_rates,
-        push_human_decision_presentation, reconcile_selected_run, resolve_remote_artifacts,
-        resolved_inspector_height, sidebar_width_for_drag, step_projection_contains,
-        temporal_delay_from_page, temporal_through_seq, trace_events_for_scope,
-        valid_session_binding, GraphNodeStyle, InspectorTab, NodeBounds, Palette, Rect, StepRecord,
-        TemporalDelay, TraceScope, DEFAULT_NODE_STYLE,
+        current_progress_epoch, display_end_ms, graph_position_label, inspector_height_for_drag,
+        inspector_tab_label, inspector_tab_layout, next_page_cursor, page_range, parse_run_summary,
+        progress_rates, push_human_decision_presentation, reconcile_selected_run,
+        resolve_remote_artifacts, resolved_inspector_height, sidebar_width_for_drag,
+        step_projection_contains, temporal_delay_from_page, temporal_through_seq,
+        trace_events_for_scope, valid_session_binding, GraphNodeStyle, InspectorTab, NodeBounds,
+        Palette, Rect, StepRecord, TemporalDelay, TraceScope, DEFAULT_NODE_STYLE,
     };
     use serde_json::json;
     use std::collections::HashMap;
     use std::time::Duration;
+
+    #[test]
+    fn run_summary_uses_the_host_display_status() {
+        let summary = parse_run_summary(&json!({
+            "manifest": {
+                "schema":"pi-workflows.run-manifest.v1",
+                "runId":"run-1",
+                "workflowName":"smoke",
+                "startedAt":"2026-01-01T00:00:00.000Z",
+                "finishedAt":null,
+                "status":"waiting",
+                "traceSchema":"pi-workflows.trace-event.v1",
+                "paths":{"workflow":"host","state":"host","trace":"host"}
+            },
+            "display": {
+                "status":"running",
+                "activity":"origin_turn",
+                "controls":["pause","cancel"],
+                "reason":null
+            },
+            "live":true,
+            "possiblyInterrupted":false
+        }))
+        .expect("run summary should decode");
+
+        assert_eq!(
+            summary.display.status,
+            crate::state::types::RunStatus::Running
+        );
+    }
+
+    #[test]
+    fn running_display_keeps_elapsed_time_live() {
+        let finished_at = "2026-01-01T00:00:05.000Z";
+        let finished_ms = crate::format::parse_timestamp_ms(finished_at).unwrap();
+        let now = finished_ms + 1_000;
+
+        assert_eq!(
+            display_end_ms(
+                crate::state::types::RunStatus::Running,
+                Some(finished_at),
+                now,
+            ),
+            now
+        );
+        assert_eq!(
+            display_end_ms(
+                crate::state::types::RunStatus::Waiting,
+                Some(finished_at),
+                now,
+            ),
+            finished_ms
+        );
+    }
 
     #[test]
     fn progress_estimation_resets_on_phase_change() {

--- a/tui/tests/parity.rs
+++ b/tui/tests/parity.rs
@@ -1,5 +1,5 @@
 use piw::render::{render_graph_lines, GraphNodeStyle, GraphView};
-use piw::state::types::{DefinitionSnapshot, RunState};
+use piw::state::types::{DefinitionSnapshot, RunState, WorkflowDisplay};
 use serde::Deserialize;
 use std::path::PathBuf;
 
@@ -42,8 +42,16 @@ fn rust_renderer_matches_every_typescript_fixture() {
     for path in paths {
         let fixture: LayoutFixture =
             serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let display = WorkflowDisplay {
+            status: fixture.state.status,
+            activity: None,
+            controls: Vec::new(),
+            reason: None,
+            reason_content: None,
+        };
         let view = GraphView {
             state: &fixture.state,
+            display: &display,
             snapshot: Some(&fixture.snapshot),
             graph_steps: None,
             taken_transitions: None,


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

`piw` showed a workflow as waiting while Pi was running its model turn.
Paused and waiting origin-session workflows could also consume the node timeout even though no model was running.
This change makes the widget and `piw` use the same host display, and it counts only reported model-turn time toward an interactive node timeout.

## What Changed

The host remains the one source for live workflow presentation.
The Rust viewer now consumes that complete presentation, and the host now stops the interactive timeout clock whenever the model turn is not active.

- Added typed Rust values for the full host display contract.
- Made the run list, current-run status, timeline, elapsed time, and latest graph use the host display.
- Showed the waiting node as active during an origin-session model turn.
- Kept historical replay based on durable state and recorded history.
- Loaded and verified complete externalized host display reasons before publishing the related Rust view.
- Started the interactive node timeout on reported model-turn activity only.
- Excluded message delivery, waiting, closed Pi sessions, host downtime, and paused time from that timeout.
- Suspended both the timeout clock and live running status when the origin Pi session disconnects, then resumed both after its new branch report.
- Preserved the first disconnect time across later host heartbeats and repeated host recovery.
- Detached session coordinators before host state closes so shutdown cannot write through a closed database.
- Made duplicate turn-start reports adopt the existing timing without extending it twice.
- Rechecked pause state and an open model turn in the atomic timeout transition.
- Kept schema version 1 in place. There is no migration, fallback, or second runtime path.
- Updated the workflow-host, workflow-authoring, and `piw` documentation.

## Testing

All required local checks pass.
The installed-package check also passed with a clean base Pi, only the candidate Pi Workflows package, the candidate `piw`, and the exact `openai/gpt-5.6-luna` model pair.

- `npm run check` — 98 files and 1,140 tests passed with coverage thresholds.
- `npm run test:e2e` — 3 files and 11 tests passed.
- `cargo fmt --manifest-path tui/Cargo.toml --check`
- `cargo clippy --manifest-path tui/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml --locked` — 71 unit tests plus CLI, parity, and protocol tests passed.
- `npx --yes --package typescript --package slophammer-ts@latest slophammer-ts dry .`
- `npx --yes --package typescript --package slophammer-ts@latest slophammer-ts check . --only ts.dependency-boundaries-required`
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna`
- `git diff --check`

The final real-model check used Pi 0.84.2 and `openai-responses`. It cost $0.00105216.
Pi Reviewer found no issues against `main`.
SimpleDoc still reports the same nine unrelated old file-name and frontmatter findings. This change adds no finding.

## Risks

The live display has one source, and replay remains separate by design.
Interactive timeout accounting now depends on the documented origin-session turn reports, which are already required for workflow message coordination.
An old or incomplete host view without the version-1 display value is rejected instead of using a fallback.


