### PR TITLE
feat: add automatic workflow state retention

### DIFF
--- a/docs/SQLITE_STATE.md
+++ b/docs/SQLITE_STATE.md
@@ -1,6 +1,6 @@
 # SQLite state
 
-Status: this is the implemented single-server database contract. The [workflow-message plan](2026-09-02-unify-workflow-messages-plan.md) records the schema version 1 hard cut that unified Pi message state and restored hosted behavior.
+Status: this is the implemented single-server database contract. The [workflow-message plan](2026-09-02-unify-workflow-messages-plan.md) records the schema version 1 hard cut that unified Pi message state and restored hosted behavior. The [automatic state-retention plan](plans/2026-09-04-automatic-state-retention-plan.md) records the approved 30-day cleanup contract.
 
 Pi Workflows stores all live durable state in one database:
 
@@ -156,7 +156,7 @@ state-changing child messages.
 
 `blobs` stores canonical JSON and UTF-8 text as bytes. Its primary key is the 32-byte SHA-256 digest of the bytes. An oversized required runner result uses this same content-addressed store, and the runner reads and verifies it in bounded parts. It does not copy session history into runner resume state. `run_view_content` separately keeps server-generated large view values reachable for the life of the run, including aggregate outputs that do not exist as one source record. The server creates this link before it sends a content reference. Deleting the run removes the link, and normal blob pruning can then remove unreferenced content.
 
-Insertion verifies the digest, media type, byte length, and exact bytes. Repeated content adopts the existing row. This replaces separate artifact files while keeping outputs, errors, settled Pi entries, and rendered channel text deduplicated. Opening the database never deletes blobs. The explicit prune command removes unreferenced blobs after it deletes safe old run trees. It retains each blob referenced by an active runner transfer until that runner exits.
+Insertion verifies the digest, media type, byte length, and exact bytes. Repeated content adopts the existing row. This replaces separate artifact files while keeping outputs, errors, settled Pi entries, and rendered channel text deduplicated. Automatic retention and explicit prune remove unreferenced blobs after they delete safe old run trees. They retain each blob referenced by a database foreign key or active runner transfer.
 
 Runs do not store a nested `WorkflowRunState` blob. `runs` stores run-level facts and hashes for independent values. `run_sources` stores source identity without source JSON blobs. `node_attempts` stores structured workflow outputs and small execution receipts. `session_entries` is the only stored copy of each settled Pi entry. `attempt_entries` links an attempt to its prompt, response, first, and last Pi entries. `run_steps` stores ordered attempt membership and only stores an output override when a continuation changes a carried checkpoint answer.
 
@@ -247,6 +247,24 @@ SQLite WAL keeps bounded projection reads consistent with commits. Writers are s
 
 This contract is for local storage on one machine. It does not claim distributed consensus or network-filesystem safety.
 
+## Automatic retention
+
+The server keeps terminal root-run trees for 30 days from `finished_at`. A tree is eligible only when every restart or continuation descendant is terminal, older than the cutoff, free of protected work, and free of references from outside the tree.
+
+Automatic cleanup keeps a tree when it has a waiting or parked run, a live queue row, a pending workflow message, an open workflow turn, a pending interaction or human decision, a recording session segment, a queued follow-up, an active lease, an unsettled effect, controller ownership, an active runner content hash, a resumable checkpoint, an undelivered terminal result, or a continuation or step reference from outside the tree. Unknown or conflicting ownership also blocks deletion.
+
+The server requests cleanup after startup recovery and after workflow runners exit. Overlapping requests use one in-process task. Cleanup starts only while there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes no more than one sweep in 24 hours. An interrupted sweep stays due until another idle startup or runner-exit trigger.
+
+Automatic cleanup does not create a backup. It rechecks and deletes one complete root tree in one transaction, yields, and checks for new work before it selects another tree. Manual prune uses the same selection and deletion code, but keeps its backup requirement.
+
+After logical deletion, the server truncates the WAL while idle and measures `page_count`, `freelist_count`, and `page_size`. SQLite can reuse free pages without shrinking the main file. Automatic cleanup runs `VACUUM` only while the server remains idle, at least 64 MiB is reclaimable, and at least 20 percent of pages are free. A skipped or failed `VACUUM` does not undo committed deletion. The server reports the result and leaves the free pages available for reuse.
+
+A cleanup error does not fail a workflow or stop the server. The server records one bounded diagnostic and waits for a later safe trigger. It does not retry in a tight loop.
+
+Retained runs keep their current resume, viewer, content-reference, and terminal-result behavior. A deleted run is absent from run lists and direct views. Cleanup never edits Pi session history.
+
+The retention policy does not promise a hard database-size limit. Recent or protected work can be large, and physical file shrink depends on a safe, successful `VACUUM`.
+
 ## Backup and verification
 
 An active database must be backed up with the SQLite backup API. Copying only `state.sqlite` while WAL writes are active is not supported.
@@ -275,7 +293,7 @@ These commands send maintenance operations to the server when they target the ac
 `status` reports only safe counts, file size, active leases, and unsettled effects.
 It does not print actor IDs, channel references, payloads, or credentials.
 
-`prune --dry-run` reports complete terminal run trees older than the cutoff and the trees that safety checks block. It does not change the database. `prune --apply` requires a new absolute backup path. It verifies the backup, locks maintenance, rechecks the same selection in an exclusive transaction, and refuses trees with live queues, active leases, unsettled effects, managed resource references, channel references, or step links from runs outside the tree. It deletes the safe aggregates, removes blobs with no remaining foreign-key reference, checkpoints the WAL, vacuums the file, and runs integrity and foreign-key checks. Pi Workflows never runs prune at startup.
+`prune --dry-run` reports complete terminal run trees older than the cutoff and the trees that safety checks block. It does not change the database. `prune --apply` requires a new absolute backup path. It verifies the backup, locks maintenance, rechecks the same selection in an exclusive transaction, deletes safe aggregates and unreferenced blobs, checkpoints the WAL, vacuums the file, and runs integrity and foreign-key checks. The manual command and automatic retention use the same blocker rules. Automatic retention starts after server recovery and does not create a backup.
 
 ## Alpha cutover
 

--- a/docs/SQLITE_STATE.md
+++ b/docs/SQLITE_STATE.md
@@ -253,13 +253,13 @@ The server keeps terminal root-run trees for 30 days from `finished_at`. A tree 
 
 Automatic cleanup keeps a tree when it has a waiting or parked run, a live queue row, a pending workflow message, an open workflow turn, a pending interaction or human decision, a recording session segment, a queued follow-up, an active lease, an unsettled effect, controller ownership, an active runner content hash, a resumable checkpoint, an undelivered terminal result, or a continuation or step reference from outside the tree. Unknown or conflicting ownership also blocks deletion.
 
-The server requests cleanup after startup recovery and after workflow runners exit. Overlapping requests use one in-process task. Cleanup starts only while there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes no more than one sweep in 24 hours. An interrupted sweep stays due until another idle startup or runner-exit trigger.
+The server requests cleanup after startup recovery and after workflow runners exit. It also schedules the next daily check after a completed sweep. Overlapping requests use one in-process task. Cleanup starts only while there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes no more than one sweep in 24 hours. A due sweep that finds work active or stops between trees remains due. The next idle lifecycle trigger or a five-minute idle retry continues it.
 
 Automatic cleanup does not create a backup. It rechecks and deletes one complete root tree in one transaction, yields, and checks for new work before it selects another tree. Manual prune uses the same selection and deletion code, but keeps its backup requirement.
 
 After logical deletion, the server truncates the WAL while idle and measures `page_count`, `freelist_count`, and `page_size`. SQLite can reuse free pages without shrinking the main file. Automatic cleanup runs `VACUUM` only while the server remains idle, at least 64 MiB is reclaimable, and at least 20 percent of pages are free. A skipped or failed `VACUUM` does not undo committed deletion. The server reports the result and leaves the free pages available for reuse.
 
-A cleanup error does not fail a workflow or stop the server. The server records one bounded diagnostic and waits for a later safe trigger. It does not retry in a tight loop.
+A cleanup error does not fail a workflow or stop the server. The server records one bounded diagnostic and waits five minutes before another safe attempt. It does not retry in a tight loop.
 
 Retained runs keep their current resume, viewer, content-reference, and terminal-result behavior. A deleted run is absent from run lists and direct views. Cleanup never edits Pi session history.
 

--- a/docs/WORKFLOW_SERVER.md
+++ b/docs/WORKFLOW_SERVER.md
@@ -438,7 +438,7 @@ The server keeps terminal root-run trees for 30 days from `finished_at`. A tree 
 
 The server protects waiting and parked runs, live queue rows, pending workflow messages, open workflow turns, pending interactions and human decisions, recording session segments, queued follow-ups, active leases, unsettled effects, controller ownership, active runner content, resumable checkpoints, and undelivered terminal results. A cross-tree continuation or step reference also blocks deletion. Unknown ownership blocks deletion.
 
-The server requests a sweep after startup recovery and after a workflow runner exits. Overlapping requests join one in-process task. A sweep starts only when there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes at most one sweep in 24 hours. If new work appears, cleanup stops between complete root trees and remains due for the next idle trigger.
+The server requests a sweep after startup recovery and after a workflow runner exits. It also schedules the next daily check after a completed sweep. Overlapping requests join one in-process task. A sweep starts only when there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes at most one sweep in 24 hours. If new work appears, cleanup stops between complete root trees and remains due. The next idle lifecycle trigger or a five-minute idle retry continues it.
 
 Automatic cleanup and `state prune` use the same selector, exact-tree deletion, and unreferenced-blob collection. Automatic cleanup does not make a backup. The explicit manual apply command still requires a new absolute verified backup.
 
@@ -446,7 +446,7 @@ Automatic cleanup deletes one root tree per transaction and rechecks that tree b
 
 After deletion, SQLite can reuse free pages. The server truncates the WAL while idle. It runs automatic `VACUUM` only when it is still idle, at least 64 MiB is reclaimable, and at least 20 percent of database pages are free. A skipped or failed compaction leaves committed deletion and reusable pages intact.
 
-A cleanup failure records one bounded diagnostic. It does not fail a workflow, stop the server, or start a tight retry loop.
+A cleanup failure records one bounded diagnostic. It does not fail a workflow or stop the server. The next attempt waits five minutes, so it cannot start a tight retry loop.
 
 Retained runs keep their normal resume, bounded viewer, content-reference, and terminal-result behavior. Deleted expired runs disappear from run lists and direct views. Pi session history is unchanged.
 

--- a/docs/WORKFLOW_SERVER.md
+++ b/docs/WORKFLOW_SERVER.md
@@ -1,6 +1,6 @@
 # Workflow server
 
-Status: the out-of-process server, unified live client, workflow-message contract, and restored session behavior are implemented. [Unify workflow run state](2026-09-04-workflow-run-state-plan.md) records the approved refactor for turn ownership, managed effects, restarts, terminal data, cancellation, and runner recovery. [Unify workflow messages and restore hosted behavior](2026-09-02-unify-workflow-messages-plan.md), [run workflows outside Pi](2026-08-30-out-of-process-workflow-host-plan.md), [restore workflow session delivery and controls](2026-09-01-restore-session-delivery-controls-plan.md), and [unify live workflow clients](2026-09-01-unified-workflow-client-plan.md) record the earlier design and implementation plans.
+Status: the out-of-process server, unified live client, workflow-message contract, and restored session behavior are implemented. [Unify workflow run state](2026-09-04-workflow-run-state-plan.md) records the approved refactor for turn ownership, managed effects, restarts, terminal data, cancellation, and runner recovery. [Add automatic workflow state retention](plans/2026-09-04-automatic-state-retention-plan.md) records the approved 30-day cleanup contract. [Unify workflow messages and restore hosted behavior](2026-09-02-unify-workflow-messages-plan.md), [run workflows outside Pi](2026-08-30-out-of-process-workflow-host-plan.md), [restore workflow session delivery and controls](2026-09-01-restore-session-delivery-controls-plan.md), and [unify live workflow clients](2026-09-01-unified-workflow-client-plan.md) record the earlier design and implementation plans.
 
 ## Purpose
 
@@ -426,10 +426,31 @@ At startup the server:
 9. Resumes any remaining provisional `validating` submission in a new supervised child.
 10. Waits for the extension's active-branch report before it confirms pending entries as sent, closes a turn as `lost`, or creates a branch-specific replacement. The extension sends this report after every server connection.
 11. Starts no model turn until a matching Pi session connects or headless mode is declared.
+12. Requests an automatic state-retention sweep after recovery. The sweep waits until normal server work is idle.
 
 Recovery resumes from the last committed boundary. An uncommitted compute node may run again because compute is pure. An action with a stored effect receipt adopts that receipt. An effect in `ambiguous` state requires explicit recovery.
 
 Claim loss is a handoff, not a run failure. The old owner writes no terminal event after claim loss.
+
+## State retention
+
+The server keeps terminal root-run trees for 30 days from `finished_at`. A tree can expire only when all restart and continuation descendants are terminal, older than the cutoff, and free of protected state or references from outside the tree.
+
+The server protects waiting and parked runs, live queue rows, pending workflow messages, open workflow turns, pending interactions and human decisions, recording session segments, queued follow-ups, active leases, unsettled effects, controller ownership, active runner content, resumable checkpoints, and undelivered terminal results. A cross-tree continuation or step reference also blocks deletion. Unknown ownership blocks deletion.
+
+The server requests a sweep after startup recovery and after a workflow runner exits. Overlapping requests join one in-process task. A sweep starts only when there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or shutdown. One server process completes at most one sweep in 24 hours. If new work appears, cleanup stops between complete root trees and remains due for the next idle trigger.
+
+Automatic cleanup and `state prune` use the same selector, exact-tree deletion, and unreferenced-blob collection. Automatic cleanup does not make a backup. The explicit manual apply command still requires a new absolute verified backup.
+
+Automatic cleanup deletes one root tree per transaction and rechecks that tree before deletion. It then yields so server work can start. Matching repeated cleanup has no additional effect.
+
+After deletion, SQLite can reuse free pages. The server truncates the WAL while idle. It runs automatic `VACUUM` only when it is still idle, at least 64 MiB is reclaimable, and at least 20 percent of database pages are free. A skipped or failed compaction leaves committed deletion and reusable pages intact.
+
+A cleanup failure records one bounded diagnostic. It does not fail a workflow, stop the server, or start a tight retry loop.
+
+Retained runs keep their normal resume, bounded viewer, content-reference, and terminal-result behavior. Deleted expired runs disappear from run lists and direct views. Pi session history is unchanged.
+
+This policy limits old completed history. It does not set a hard database-size cap because recent or protected work can be arbitrarily large. Physical file shrink also depends on a safe, successful SQLite compaction.
 
 ## Effects and retry safety
 
@@ -549,4 +570,11 @@ The implementation conforms when:
 - a terminal run remains in the origin-session view while its terminal message is pending or its first turn is open, and then for 60 seconds after that turn ends, without retaining execution authority;
 - a TypeScript-created live database is viewable by the matching Rust `piw` through the client protocol without a duplicated SQLite digest;
 - no removed server, replay, or direct SQLite client path remains selectable;
+- only complete terminal run trees older than 30 days and free of protected work can expire;
+- startup and runner-exit cleanup share the manual prune selector and deletion rules;
+- automatic cleanup creates no backup, while manual apply remains backup-first;
+- repeated cleanup cannot partly delete a lineage tree or remove a referenced blob;
+- retained runs keep their resume, viewer, content-reference, and terminal-result behavior;
+- large session history does not get copied into repeated runner result blobs;
+- free pages remain reusable when automatic compaction is skipped or fails;
 - real Pi end-to-end tests, repository checks, reviewer checks, and CI pass.

--- a/docs/plans/2026-09-04-automatic-state-retention-plan.md
+++ b/docs/plans/2026-09-04-automatic-state-retention-plan.md
@@ -1,0 +1,283 @@
+---
+title: Add automatic workflow state retention
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-09-04
+status: approved
+---
+
+# Add automatic workflow state retention
+
+## Goal
+
+Pi Workflows will remove old completed workflow state automatically. It will keep active, resumable, pending, unsettled, and undelivered work.
+
+The server will retain terminal run trees for 30 days. It will then remove safe expired trees and blobs that no retained record or active runner uses. The manual prune command will use the same safety rules.
+
+A regression test will also protect the earlier runner fix. Repeated runner replies must not copy growing Pi session history and make the database grow by several gigabytes.
+
+## Observed problem
+
+One old state database reached about 6.1 GB. The `blobs` table held about 6.06 GB across 101,355 blobs, which were almost all JSON. `worker_messages.result_hash` was the main reference path.
+
+Older runner replies copied growing session and workflow history into new immutable result blobs. Small changes produced another large blob, so content hashing could not deduplicate the replies. [Keep large workflow history out of runner resume replies](2026-09-04-workflow-runner-resume-state-plan.md) fixed that interface by returning only the execution state a runner needs.
+
+That fix stops the main amplification path. Completed workflow history still remains until a person runs `pi-workflows state prune`, so the database can still grow without a retention rule.
+
+## Selected design
+
+Use the existing run-tree prune logic as the one cleanup engine. Automatic cleanup and manual prune will share selection, deletion, blob collection, and compaction rules.
+
+A terminal root run and all its restart or continuation descendants remain for 30 days after `finished_at`. Every descendant must be terminal and older than the cutoff before the server can remove the tree. Protected state or a reference from outside the tree blocks removal.
+
+The Workflow Server checks for cleanup after startup recovery and after workflow runners exit. It starts cleanup only while normal server work is idle. One server process completes no more than one sweep in 24 hours. An interrupted sweep remains due and continues at the next safe trigger.
+
+Automatic cleanup creates no backup. Creating a new backup for every sweep would cause another unbounded store. The explicit manual prune command keeps its current dry-run and backup-first apply forms.
+
+This design does not add size-based deletion. A clear time limit gives users predictable history. Recent or protected data can still be large, so this design does not promise a hard disk-size cap.
+
+## Retention contract
+
+### Eligible run trees
+
+A run tree is eligible only when all of these facts are true:
+
+- The root run and every descendant have status `completed`, `failed`, `timed_out`, or `cancelled`.
+- Every run in the tree has `finished_at` earlier than the 30-day cutoff.
+- No row outside the tree depends on a row inside it.
+- No protected work belongs to the tree.
+
+The cleanup transaction rechecks the exact root tree before deletion. A changed tree is skipped.
+
+### Protected work
+
+Automatic cleanup must keep a tree when it contains or owns any of this work:
+
+- a waiting or parked run
+- a queued, starting, running, or parked queue row
+- a pending workflow message
+- an open workflow turn
+- a pending interaction or human decision
+- a recording session segment
+- a queued follow-up
+- an active lease
+- a pending, applying, or ambiguous effect
+- controller ownership or a managed resource reference
+- a continuation or step reference from outside the tree
+- an active runner content hash
+- a resumable checkpoint
+- an undelivered terminal result
+
+Unknown or conflicting ownership blocks deletion. Cleanup must fail closed.
+
+### Automatic scheduling
+
+The server requests one automatic sweep after recovery and after a workflow runner exits. Overlapping requests join the same in-process task.
+
+A sweep starts only when there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or server shutdown. It deletes one complete root tree in one transaction, yields, and checks for new work before it selects another tree.
+
+A completed sweep starts a 24-hour in-process interval. A sweep that stops because new work appeared remains due. The next idle startup or runner-exit trigger can continue it without waiting for another complete interval.
+
+The cleanup scheduler is part of the existing server process. It does not add a service, scheduler process, or second writer.
+
+### Blob cleanup
+
+After run deletion, the state layer removes only blobs with no database foreign-key reference and no active runner reference. The existing schema scan remains the source for blob references, so a future blob foreign key is protected automatically.
+
+A repeated sweep is safe. A second sweep finds no extra rows from work that was already removed.
+
+### Space reuse and file compaction
+
+After logical deletion, the server truncates the WAL while idle and reads SQLite `page_count`, `freelist_count`, and `page_size`. SQLite can reuse free pages even when the main file does not shrink.
+
+Automatic cleanup runs `VACUUM` only when all of these facts are true:
+
+- normal server work is still idle
+- at least 64 MiB is reclaimable
+- at least 20 percent of database pages are free
+
+A skipped or failed `VACUUM` does not undo committed logical deletion. The server reports the outcome and leaves the free pages available for reuse. It does not claim that the file shrank unless measurement proves it.
+
+Manual prune keeps its current backup-first full compaction and integrity checks.
+
+### Failure handling
+
+A cleanup error does not fail a workflow or stop the server. The server records one clear diagnostic and waits for a later safe trigger. It does not retry in a tight loop.
+
+Cleanup is atomic for one complete root tree. An interruption can leave later trees for another sweep, but it cannot leave half of one lineage tree deleted.
+
+## Public behavior
+
+Retained runs keep their current resume, viewer, content-reference, and terminal-result behavior. The viewer continues to read bounded pages. Pi Workflows does not edit Pi session history.
+
+After an expired tree is removed, it no longer appears in run lists. A direct run view returns not found.
+
+The manual commands remain:
+
+```bash
+pi-workflows state prune --before <timestamp> --dry-run
+pi-workflows state prune --before <timestamp> --backup <absolute-path> --apply
+```
+
+Automatic cleanup adds no client protocol operation. The SQLite schema name and version remain `pi-workflows-state` version 1. This change adds no migration, compatibility reader, second state path, fallback, feature flag, archive, or external resource.
+
+## Implementation
+
+### Share the cleanup engine
+
+**Where**
+
+- `src/state/prune.ts`
+- version-1 invariants in `src/state/schema.ts`
+
+**Change**
+
+Split the current prune work into shared run-tree selection, exact-tree deletion, unreferenced-blob collection, page measurement, and compaction operations. Add every protected-state check from this plan.
+
+Automatic deletion must recheck and delete one root tree in the same transaction. Manual prune keeps its backup and complete-selection recheck.
+
+**Check**
+
+State tests prove that eligible trees are removed as one unit. Each protected state keeps its whole tree. Foreign-key and integrity checks pass after deletion.
+
+### Add automatic cleanup
+
+**Where**
+
+- `src/state/prune.ts`
+- `src/server/server.ts`
+
+**Change**
+
+Add an automatic entry point with a cutoff of the current time minus 30 days. It uses the shared cleanup engine without creating a backup.
+
+Process one complete root tree per transaction. Yield between trees. Stop when normal server work appears and leave the sweep due.
+
+**Check**
+
+Automatic and manual cleanup select the same eligible trees. Automatic cleanup creates no backup. A stopped sweep continues later without duplicate deletion.
+
+### Schedule cleanup from the server lifecycle
+
+**Where**
+
+- lifecycle fields in `src/server/server.ts`
+- `WorkflowServer.start()`
+- server shutdown
+- the active-run exit path after the server removes the run from `activeRuns`
+
+**Change**
+
+Request cleanup after startup recovery and after runner exit. Coalesce overlapping requests. Enforce the idle check and 24-hour completed-sweep interval.
+
+A failed sweep logs one bounded error and waits for a later trigger. Shutdown starts no new sweep and settles any current scheduling task safely.
+
+**Check**
+
+Server tests use fake time and temporary databases to cover startup, runner exit, coalescing, the 24-hour interval, interruption, clean shutdown, and one injected failure.
+
+### Reuse pages and compact when worthwhile
+
+**Where**
+
+- database-size helpers in `src/state/prune.ts`
+- `test/prune.test.ts`
+
+**Change**
+
+Measure free SQLite pages after deletion. Truncate the WAL while idle. Run automatic `VACUUM` only above the 64 MiB and 20 percent thresholds.
+
+Keep committed deletion when compaction is skipped or fails. Report logical deletion and physical file size separately.
+
+**Check**
+
+Tests prove page reuse below the thresholds, no early automatic `VACUUM`, physical reduction after successful compaction, and intact retained data after a simulated compaction failure.
+
+### Add the large-state regression
+
+**Where**
+
+- `test/server.test.ts`
+- `test/workflow-runner-content.test.ts`
+- the existing large-resume test fixture
+
+**Change**
+
+Create more than 2 MiB of distinct recorded session history. Run several resume, wait, continue, and terminal runner exchanges. Add a small unique item between exchanges.
+
+Measure distinct blobs referenced by `worker_messages.result_hash`, every runner frame, total blob bytes, and SQLite pages. The test must prove that runner control replies contain only required execution state or content references. They must not copy complete session history into every reply.
+
+**Check**
+
+The regression fails when each reply includes the growing history. It passes when result growth follows new workflow state, and every runner frame stays inside its protocol limit.
+
+### Cover retention behavior
+
+**Where**
+
+- `test/prune.test.ts`
+- `test/server.test.ts`
+- `test/server-view.test.ts`
+- the existing state-prune client tests
+
+**Change**
+
+Test recent and expired trees, restart and continuation families, pending and sent terminal messages, open turns, waiting and parked work, every blocker, concurrent manual prune, automatic blob cleanup, viewer access, and resume.
+
+Use temporary databases and deterministic executors. Automated tests must not call a model or touch the user's live state.
+
+**Check**
+
+Retained runs still resume and render. Expired delivered terminal trees disappear as one unit. Protected trees remain. Repeated cleanup has no additional effect.
+
+### Update documentation
+
+**Where**
+
+- `docs/SQLITE_STATE.md`
+- `docs/WORKFLOW_SERVER.md`
+- `docs/workflows.md`
+- CLI help where it describes state retention
+
+**Change**
+
+Document the contract in this plan. Remove the old statement that Pi Workflows never prunes at startup.
+
+**Check**
+
+Documentation matches the code constants and tests. It makes no hard size or file-shrink promise.
+
+## Tests and checks
+
+Run:
+
+```bash
+npm run check
+npm run test:e2e
+npx slophammer-ts@latest dry .
+npx slophammer-ts@latest check . --only ts.dependency-boundaries-required
+npx -y @simpledoc/simpledoc check
+git diff --check
+```
+
+Automated tests use temporary directories and deterministic executors. They do not call a real model.
+
+After these checks pass, run the separate installed-package E2E with the exact authenticated low-cost model `openai/gpt-5.6-luna`. Use temporary workflow state. Do not prune or seed the user's live database.
+
+## Acceptance criteria
+
+The work is complete when all of these statements are true:
+
+- Terminal root-run trees remain for 30 days.
+- Cleanup removes only complete eligible trees.
+- Every active, pending, open, resumable, recording, queued, leased, unsettled, controller-owned, cross-linked, undelivered, or active-content case remains protected.
+- Automatic cleanup runs without a second service or manual command.
+- Manual prune remains backup-first.
+- Repeated cleanup is safe and does not partly delete a lineage tree.
+- Freed pages can be reused.
+- Automatic `VACUUM` follows the 64 MiB, 20 percent, and idle rules.
+- Retained runs still resume and render through bounded reads.
+- Deleted runs return not found.
+- The large-state regression proves that repeated runner replies do not copy growing session history.
+- The SQLite schema stays at version 1 with no migration or compatibility path.
+- Pi core, Pi session history, other repositories, external services, and the user's live workflow state remain unchanged.
+- All repository checks and the separate real-model E2E pass.

--- a/docs/plans/2026-09-04-automatic-state-retention-plan.md
+++ b/docs/plans/2026-09-04-automatic-state-retention-plan.md
@@ -29,7 +29,7 @@ Use the existing run-tree prune logic as the one cleanup engine. Automatic clean
 
 A terminal root run and all its restart or continuation descendants remain for 30 days after `finished_at`. Every descendant must be terminal and older than the cutoff before the server can remove the tree. Protected state or a reference from outside the tree blocks removal.
 
-The Workflow Server checks for cleanup after startup recovery and after workflow runners exit. It starts cleanup only while normal server work is idle. One server process completes no more than one sweep in 24 hours. An interrupted sweep remains due and continues at the next safe trigger.
+The Workflow Server checks for cleanup after startup recovery and after workflow runners exit. It also schedules a daily check after each completed sweep. It starts cleanup only while normal server work is idle. One server process completes no more than one sweep in 24 hours. An interrupted sweep remains due. The next idle lifecycle trigger or a five-minute idle retry continues it.
 
 Automatic cleanup creates no backup. Creating a new backup for every sweep would cause another unbounded store. The explicit manual prune command keeps its current dry-run and backup-first apply forms.
 
@@ -75,7 +75,7 @@ The server requests one automatic sweep after recovery and after a workflow runn
 
 A sweep starts only when there is no active or pending workflow runner, resource-manager runner, state-maintenance command, or server shutdown. It deletes one complete root tree in one transaction, yields, and checks for new work before it selects another tree.
 
-A completed sweep starts a 24-hour in-process interval. A sweep that stops because new work appeared remains due. The next idle startup or runner-exit trigger can continue it without waiting for another complete interval.
+A completed sweep starts a 24-hour in-process interval and schedules the next daily check. A sweep that stops because new work appeared remains due. The next idle lifecycle trigger or a five-minute idle retry continues it. A new request during the completed-sweep interval waits until that interval ends.
 
 The cleanup scheduler is part of the existing server process. It does not add a service, scheduler process, or second writer.
 
@@ -101,7 +101,7 @@ Manual prune keeps its current backup-first full compaction and integrity checks
 
 ### Failure handling
 
-A cleanup error does not fail a workflow or stop the server. The server records one clear diagnostic and waits for a later safe trigger. It does not retry in a tight loop.
+A cleanup error does not fail a workflow or stop the server. The server records one clear diagnostic and waits five minutes before another safe attempt. It does not retry in a tight loop.
 
 Cleanup is atomic for one complete root tree. An interruption can leave later trees for another sweep, but it cannot leave half of one lineage tree deleted.
 
@@ -167,13 +167,13 @@ Automatic and manual cleanup select the same eligible trees. Automatic cleanup c
 
 **Change**
 
-Request cleanup after startup recovery and after runner exit. Coalesce overlapping requests. Enforce the idle check and 24-hour completed-sweep interval.
+Request cleanup after startup recovery and after runner exit. Schedule a daily check after each completed sweep. Coalesce overlapping requests. Enforce the idle check, five-minute idle retry, and 24-hour completed-sweep interval.
 
 A failed sweep logs one bounded error and waits for a later trigger. Shutdown starts no new sweep and settles any current scheduling task safely.
 
 **Check**
 
-Server tests use fake time and temporary databases to cover startup, runner exit, coalescing, the 24-hour interval, interruption, clean shutdown, and one injected failure.
+Server tests use controlled scheduler timestamps and temporary databases to cover startup, runner exit, coalescing, the 24-hour interval, interruption, clean shutdown, and one injected failure.
 
 ### Reuse pages and compact when worthwhile
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -777,7 +777,7 @@ Pi Workflows keeps a terminal root run and all its restart or continuation desce
 
 Protected work includes waiting or parked runs, live queue rows, pending workflow messages, open workflow turns, pending interactions or decisions, recording session segments, queued follow-ups, active leases, unsettled effects, controller ownership, active runner content, resumable checkpoints, and undelivered terminal results.
 
-The server checks for cleanup after startup recovery and after workflow runners exit. It runs only while normal server work is idle. One process completes at most one sweep in 24 hours. If work appears, cleanup stops between complete root trees and continues at a later idle trigger.
+The server checks for cleanup after startup recovery and after workflow runners exit. It also schedules a daily check after each completed sweep. Cleanup runs only while normal server work is idle. One process completes at most one sweep in 24 hours. If work appears, cleanup stops between complete root trees. The next idle lifecycle trigger or a five-minute idle retry continues it.
 
 Automatic cleanup does not create a backup. The explicit `pi-workflows state prune` apply command still requires a new absolute verified backup. Both paths use the same eligibility, deletion, and blob-reference rules.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -771,6 +771,22 @@ resume` takes a new generation and reruns only work after the last durable
 - Server status reports safe counts and timestamps. It does not report session
   IDs, project paths, prompts, payloads, tokens, process IDs, or credentials.
 
+## Run history retention
+
+Pi Workflows keeps a terminal root run and all its restart or continuation descendants for 30 days from `finished_at`. The server can remove the tree after that point only when every descendant is terminal and no protected work or outside reference remains.
+
+Protected work includes waiting or parked runs, live queue rows, pending workflow messages, open workflow turns, pending interactions or decisions, recording session segments, queued follow-ups, active leases, unsettled effects, controller ownership, active runner content, resumable checkpoints, and undelivered terminal results.
+
+The server checks for cleanup after startup recovery and after workflow runners exit. It runs only while normal server work is idle. One process completes at most one sweep in 24 hours. If work appears, cleanup stops between complete root trees and continues at a later idle trigger.
+
+Automatic cleanup does not create a backup. The explicit `pi-workflows state prune` apply command still requires a new absolute verified backup. Both paths use the same eligibility, deletion, and blob-reference rules.
+
+Deleting a run tree removes its unreferenced blobs. SQLite can reuse those pages immediately. Automatic `VACUUM` runs only while the server remains idle, at least 64 MiB is reclaimable, and at least 20 percent of pages are free. A failed or skipped compaction does not restore deleted history or make free pages unusable.
+
+Retained runs keep complete resume and viewer behavior through the existing bounded reads. An expired deleted run no longer appears in lists and a direct view returns not found. Pi session history is not changed.
+
+This is a history policy, not a hard disk limit. Recent or protected runs can be large. See [SQLite state](SQLITE_STATE.md) and [the automatic state-retention plan](plans/2026-09-04-automatic-state-retention-plan.md) for the full safety and test contract.
+
 ## Workflows started by resource managers
 
 A resource manager can start a workflow as a finite child job with `ctx.workflows.ensure()`. The request key is stable across reconciliation passes, and the input fingerprint prevents one key from being reused for different work.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -62,7 +62,11 @@ import {
 import { StateDatabase, workflowStatePath } from "../state/database.js";
 import { canonicalJson, type JsonValue } from "../state/json.js";
 import { resourceIdFor } from "../state/mutation.js";
-import { pruneState } from "../state/prune.js";
+import {
+  AUTOMATIC_STATE_PRUNE_INTERVAL_MS,
+  pruneState,
+  pruneStateAutomatically,
+} from "../state/prune.js";
 import { recordViewerDeltas } from "../state/viewer.js";
 import { workflowMessageIdFor } from "../state/workflow-messages.js";
 import { humanDecisionChannelRequest } from "../workflows/decision-presentation.js";
@@ -135,6 +139,7 @@ const SERVER_RENEW_MS = 10_000;
 const PACKAGE_VERSION = runtimePackageVersion();
 const CLAIM_POLL_MS = 2_000;
 const TERMINAL_MESSAGE_RECONCILE_MS = 1_000;
+const AUTOMATIC_STATE_PRUNE_IDLE_RETRY_MS = 5 * 60 * 1_000;
 const RUN_CLAIM_LEASE_MS = 30_000;
 const RESOURCE_MANAGER_CLAIM_LEASE_MS = 120_000;
 const RESOURCE_MANAGER_RENEW_MS = 30_000;
@@ -264,6 +269,12 @@ export class WorkflowServer {
   private decisionChannelConfig: DecisionChannelConfig | null = null;
   private decisionChannelError: string | null = null;
   private channelReloading = false;
+  private automaticStatePruneTask: Promise<void> | null = null;
+  private automaticStatePruneTimer: ReturnType<typeof setTimeout> | null = null;
+  private automaticStatePruneScheduled = false;
+  private automaticStatePruneDue = true;
+  private lastAutomaticStatePruneAt: number | null = null;
+  private nextAutomaticStatePruneAttemptAt = 0;
   private nextTerminalMessageReconciliationAt = 0;
 
   constructor(options: WorkflowServerOptions = {}) {
@@ -347,13 +358,16 @@ export class WorkflowServer {
       this.startTimers();
       this.started = true;
       this.log(`ready on ${this.socketPath} at epoch ${this.claim.epoch}`);
+      this.requestAutomaticStatePrune();
       this.expireTimedOutInteraction();
-      void this.expireTimedOutDecision();
-      void this.claimOne();
-      void this.claimResourceManagerOne();
-      void this.reloadDecisionChannels().catch((error) => {
-        this.log(`decision channel startup failed: ${errorMessage(error)}`);
-      });
+      void this.expireTimedOutDecision().finally(() => this.resumeAutomaticStatePruneIfDue());
+      void this.claimOne().finally(() => this.resumeAutomaticStatePruneIfDue());
+      void this.claimResourceManagerOne().finally(() => this.resumeAutomaticStatePruneIfDue());
+      void this.reloadDecisionChannels()
+        .catch((error) => {
+          this.log(`decision channel startup failed: ${errorMessage(error)}`);
+        })
+        .finally(() => this.resumeAutomaticStatePruneIfDue());
     } catch (error) {
       const server = this.server;
       this.server = null;
@@ -378,9 +392,12 @@ export class WorkflowServer {
     if (this.heartbeatTimer !== null) clearInterval(this.heartbeatTimer);
     if (this.pollTimer !== null) clearInterval(this.pollTimer);
     if (this.viewTimer !== null) clearInterval(this.viewTimer);
+    if (this.automaticStatePruneTimer !== null) clearTimeout(this.automaticStatePruneTimer);
     this.heartbeatTimer = null;
     this.pollTimer = null;
     this.viewTimer = null;
+    this.automaticStatePruneTimer = null;
+    this.automaticStatePruneScheduled = false;
     const server = this.server;
     this.server = null;
     this.detachSessionCoordinators();
@@ -419,6 +436,9 @@ export class WorkflowServer {
     this.activeChannels.clear();
     await Promise.allSettled(this.activationTasks.values());
     await Promise.allSettled(this.maintenanceCommands.values());
+    if (this.automaticStatePruneTask !== null) {
+      await Promise.allSettled([this.automaticStatePruneTask]);
+    }
     this.registry.killAll();
     if (this.claim !== null) this.serverState.releaseServer(this.claim);
     this.claim = null;
@@ -763,6 +783,7 @@ export class WorkflowServer {
           });
         case "state.prune":
           return await this.executeMaintenanceCommand(request, async () => {
+            await this.waitForAutomaticStatePrune();
             const payload = requireRecord(request.payload, "state.prune payload");
             const before = requireString(payload.before, "before");
             const apply = requireBoolean(payload.apply, "apply");
@@ -836,6 +857,7 @@ export class WorkflowServer {
       if (this.maintenanceCommands.get(key) === execution) {
         this.maintenanceCommands.delete(key);
       }
+      this.requestAutomaticStatePrune();
     }
   }
 
@@ -1925,6 +1947,127 @@ export class WorkflowServer {
       for (const digest of active.contentDigests) digests.add(digest);
     }
     return [...digests].map((digest) => Buffer.from(digest, "hex"));
+  }
+
+  private requestAutomaticStatePrune(): void {
+    this.automaticStatePruneDue = true;
+    if (
+      !this.started ||
+      this.stopping ||
+      this.automaticStatePruneScheduled ||
+      this.automaticStatePruneTask !== null
+    ) {
+      return;
+    }
+    this.automaticStatePruneScheduled = true;
+    setImmediate(() => {
+      if (!this.automaticStatePruneScheduled) return;
+      this.automaticStatePruneScheduled = false;
+      this.startAutomaticStatePrune();
+    });
+  }
+
+  private resumeAutomaticStatePruneIfDue(): void {
+    if (this.automaticStatePruneDue) this.requestAutomaticStatePrune();
+  }
+
+  private startAutomaticStatePrune(): void {
+    if (this.automaticStatePruneTask !== null || this.stopping || !this.started) return;
+    const task = this.runAutomaticStatePrune();
+    this.automaticStatePruneTask = task;
+    void task.finally(() => {
+      if (this.automaticStatePruneTask === task) this.automaticStatePruneTask = null;
+    });
+  }
+
+  private async runAutomaticStatePrune(): Promise<void> {
+    if (!this.automaticStatePruneDue) return;
+    if (!this.automaticStatePruneCanContinue()) {
+      this.scheduleAutomaticStatePruneTimer(AUTOMATIC_STATE_PRUNE_IDLE_RETRY_MS);
+      return;
+    }
+    const now = Date.now();
+    if (now < this.nextAutomaticStatePruneAttemptAt) {
+      this.scheduleAutomaticStatePruneTimer(this.nextAutomaticStatePruneAttemptAt - now);
+      return;
+    }
+    if (
+      this.lastAutomaticStatePruneAt !== null &&
+      now - this.lastAutomaticStatePruneAt < AUTOMATIC_STATE_PRUNE_INTERVAL_MS
+    ) {
+      this.scheduleAutomaticStatePruneTimer(
+        this.lastAutomaticStatePruneAt + AUTOMATIC_STATE_PRUNE_INTERVAL_MS - now,
+      );
+      return;
+    }
+    try {
+      const report = await pruneStateAutomatically(this.state, this.databasePath, {
+        now,
+        activeBlobHashes: () => this.activeRunnerContentHashes(),
+        shouldContinue: () => this.automaticStatePruneCanContinue(),
+      });
+      if (!report.completed) {
+        this.automaticStatePruneDue = true;
+        this.scheduleAutomaticStatePruneTimer(AUTOMATIC_STATE_PRUNE_IDLE_RETRY_MS);
+        return;
+      }
+      this.lastAutomaticStatePruneAt = now;
+      this.nextAutomaticStatePruneAttemptAt = 0;
+      this.automaticStatePruneDue = false;
+      this.scheduleAutomaticStatePruneTimer(AUTOMATIC_STATE_PRUNE_INTERVAL_MS);
+      this.log(
+        `automatic state prune completed: ${report.selectedRuns} run(s) selected, ` +
+          `${report.blockedTrees} tree(s) blocked, ${report.deletedBlobs} blob(s) and ` +
+          `${report.deletedBlobBytes} byte(s) removed`,
+      );
+      if (report.compactionError !== undefined) {
+        this.log(`automatic state compaction failed: ${report.compactionError}`);
+      }
+    } catch (error) {
+      this.automaticStatePruneDue = true;
+      this.nextAutomaticStatePruneAttemptAt = Date.now() + AUTOMATIC_STATE_PRUNE_IDLE_RETRY_MS;
+      this.scheduleAutomaticStatePruneTimer(AUTOMATIC_STATE_PRUNE_IDLE_RETRY_MS);
+      this.log(`automatic state prune failed: ${errorMessage(error)}`);
+    }
+  }
+
+  private scheduleAutomaticStatePruneTimer(delayMs: number): void {
+    if (this.stopping || !this.started) return;
+    if (this.automaticStatePruneTimer !== null) clearTimeout(this.automaticStatePruneTimer);
+    this.automaticStatePruneTimer = setTimeout(
+      () => {
+        this.automaticStatePruneTimer = null;
+        this.requestAutomaticStatePrune();
+      },
+      Math.max(1, delayMs),
+    );
+    this.automaticStatePruneTimer.unref?.();
+  }
+
+  private automaticStatePruneCanContinue(): boolean {
+    return (
+      this.started &&
+      !this.stopping &&
+      this.activeRuns.size === 0 &&
+      this.activeResourceManagers.size === 0 &&
+      this.activationTasks.size === 0 &&
+      this.maintenanceCommands.size === 0 &&
+      this.pendingStarts.size === 0 &&
+      this.pendingRunClaims.size === 0 &&
+      this.pendingResumes.size === 0 &&
+      this.controlClaims.size === 0 &&
+      this.pendingTerminalMessageReconciliations.size === 0 &&
+      !this.resourceManagerPollActive &&
+      !this.decisionTimeoutActive &&
+      !this.channelReloading &&
+      [...this.activeChannels.values()].every((channel) => channel.inFlight.size === 0)
+    );
+  }
+
+  private async waitForAutomaticStatePrune(): Promise<void> {
+    this.automaticStatePruneScheduled = false;
+    const task = this.automaticStatePruneTask;
+    if (task !== null) await task;
   }
 
   private stateStatusReceipt(): JsonValue {
@@ -3139,6 +3282,7 @@ export class WorkflowServer {
     } finally {
       clearInterval(renewTimer);
       this.activeResourceManagers.delete(key);
+      this.requestAutomaticStatePrune();
       if (!this.stopping) setImmediate(() => void this.claimResourceManagerOne());
     }
   }
@@ -3798,6 +3942,7 @@ export class WorkflowServer {
     } finally {
       this.reapRunnerDescendants(envelope.runnerEpoch);
       this.activeRuns.delete(runId);
+      this.requestAutomaticStatePrune();
     }
   }
 
@@ -4434,6 +4579,10 @@ export class WorkflowServer {
            AND generation = ?`,
       )
       .run(context.runId, active.generation);
+    this.queue.settleRunEffect(
+      context.runId,
+      context.state.status === "waiting" ? "run.park_queue" : "run.settle_queue",
+    );
   }
 
   private ensureTerminalWorkflowMessage(

--- a/src/state/prune.ts
+++ b/src/state/prune.ts
@@ -5,14 +5,36 @@ import { StateDatabase } from "./database.js";
 
 const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "timed_out", "cancelled"]);
 const LIVE_QUEUE_STATUSES = ["queued", "starting", "running", "parked"];
+const ACTIVE_RUNNER_STATUSES = ["starting", "ready", "running"];
+const ACTIVE_ATTEMPT_STATUSES = ["pending", "running", "waiting", "interrupted"];
 const UNSETTLED_EFFECT_STATUSES = ["pending", "applying", "ambiguous"];
+
+export const AUTOMATIC_STATE_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
+export const AUTOMATIC_STATE_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+export const AUTOMATIC_STATE_VACUUM_MIN_BYTES = 64 * 1024 * 1024;
+export const AUTOMATIC_STATE_VACUUM_MIN_FREE_RATIO = 0.2;
 
 type RunAgeRow = {
   runId: string;
   parentRunId: string | null;
+  rootRunId: string;
   launchOptionsHash: Buffer;
   status: string;
   finishedAt: number | null;
+};
+
+type SelectedRunTree = {
+  rootRunId: string;
+  runIds: string[];
+  signature: string;
+};
+
+type RunTreeSelection = {
+  candidateTrees: number;
+  blockedTrees: number;
+  trees: SelectedRunTree[];
+  runIds: string[];
+  signature: string;
 };
 
 export type StatePruneOptions = {
@@ -32,6 +54,38 @@ export type StatePruneReport = {
   databaseBytesBefore: number;
   databaseBytesAfter: number;
   applied: boolean;
+};
+
+export type AutomaticStatePruneOptions = {
+  now?: number;
+  activeBlobHashes?: () => readonly Buffer[];
+  shouldContinue?: () => boolean;
+  yieldControl?: () => Promise<void>;
+  vacuumMinBytes?: number;
+  vacuumMinFreeRatio?: number;
+  vacuum?: (database: Database.Database) => void;
+};
+
+export type AutomaticStatePruneReport = StatePruneReport & {
+  completed: boolean;
+  compacted: boolean;
+  pageCount: number;
+  freePageCount: number;
+  pageSize: number;
+  reclaimableBytes: number;
+  freePageRatio: number;
+  compactionError?: string;
+};
+
+type DatabasePageMetrics = Pick<
+  AutomaticStatePruneReport,
+  "pageCount" | "freePageCount" | "pageSize" | "reclaimableBytes" | "freePageRatio"
+>;
+
+type DeletedState = {
+  deletedRows: number;
+  deletedBlobs: number;
+  deletedBlobBytes: number;
 };
 
 export function validateStatePruneOptions(options: StatePruneOptions): void {
@@ -57,13 +111,7 @@ export async function pruneState(
   try {
     const selection = selectRunTrees(state, cutoff);
     const sizeBefore = databaseBytes(databasePath);
-    const base = {
-      cutoff: new Date(cutoff).toISOString(),
-      candidateTrees: selection.candidateTrees,
-      blockedTrees: selection.blockedTrees,
-      selectedRuns: selection.runIds.length,
-      databaseBytesBefore: sizeBefore,
-    };
+    const base = reportBase(cutoff, selection, sizeBefore);
     if (!options.apply) {
       return {
         ...base,
@@ -81,46 +129,14 @@ export async function pruneState(
     }
     await state.backup(backupPath);
 
-    let deletedRows = 0;
-    let deletedBlobs = 0;
-    let deletedBlobBytes = 0;
+    let deleted: DeletedState;
     state.connection.exec("BEGIN EXCLUSIVE");
     try {
       const checked = selectRunTrees(state, cutoff);
-      if (
-        checked.runIds.join("\0") !== selection.runIds.join("\0") ||
-        checked.signature !== selection.signature
-      ) {
+      if (!sameSelection(checked, selection)) {
         throw new Error("Prune selection changed after backup; run the command again");
       }
-      const beforeChanges = totalChanges(state.connection);
-      if (checked.runIds.length !== 0) {
-        deleteRunAggregates(state.connection, checked.runIds);
-      }
-      state.connection
-        .prepare(
-          `DELETE FROM workflow_definitions
-         WHERE NOT EXISTS (
-           SELECT 1 FROM runs WHERE runs.definition_digest = workflow_definitions.definition_digest
-         )`,
-        )
-        .run();
-      state.connection
-        .prepare(
-          `DELETE FROM projects
-         WHERE NOT EXISTS (SELECT 1 FROM runs WHERE runs.project_id = projects.project_id)
-           AND NOT EXISTS (
-             SELECT 1 FROM controller_resources
-             WHERE controller_resources.project_id = projects.project_id
-           )`,
-        )
-        .run();
-      const retainedBlobHashes = activeBlobHashes();
-      const blobStats = unreferencedBlobStats(state.connection, retainedBlobHashes);
-      deleteUnreferencedBlobs(state.connection, retainedBlobHashes);
-      deletedRows = totalChanges(state.connection) - beforeChanges;
-      deletedBlobs = blobStats.count;
-      deletedBlobBytes = blobStats.bytes;
+      deleted = deleteSelectedState(state.connection, checked.runIds, activeBlobHashes());
       state.connection.exec("COMMIT");
     } catch (error) {
       if (state.connection.inTransaction) state.connection.exec("ROLLBACK");
@@ -132,9 +148,7 @@ export async function pruneState(
     state.integrityCheck();
     return {
       ...base,
-      deletedRows,
-      deletedBlobs,
-      deletedBlobBytes,
+      ...deleted,
       databaseBytesAfter: databaseBytes(databasePath),
       applied: true,
     };
@@ -143,14 +157,151 @@ export async function pruneState(
   }
 }
 
+export async function pruneStateAutomatically(
+  state: StateDatabase,
+  databasePath: string,
+  options: AutomaticStatePruneOptions = {},
+): Promise<AutomaticStatePruneReport> {
+  const now = options.now ?? Date.now();
+  const cutoff = now - AUTOMATIC_STATE_RETENTION_MS;
+  const shouldContinue = options.shouldContinue ?? (() => true);
+  const yieldControl = options.yieldControl ?? yieldToEventLoop;
+  const activeBlobHashes = options.activeBlobHashes ?? (() => []);
+  const sizeBefore = databaseBytes(databasePath);
+  const lockPath = `${databasePath}.maintenance.lock`;
+  const lock = acquireMaintenanceLock(lockPath);
+  let initial = emptySelection();
+  let deletedRows = 0;
+  let deletedBlobs = 0;
+  let deletedBlobBytes = 0;
+  let completed = true;
+  let compacted = false;
+  let compactionError: string | undefined;
+  let metrics: DatabasePageMetrics = {
+    pageCount: 0,
+    freePageCount: 0,
+    pageSize: 0,
+    reclaimableBytes: 0,
+    freePageRatio: 0,
+  };
+
+  try {
+    metrics = databasePageMetrics(state.connection);
+    initial = selectRunTrees(state, cutoff, now);
+    for (const selectedTree of initial.trees) {
+      if (!shouldContinue()) {
+        completed = false;
+        break;
+      }
+      state.connection.exec("BEGIN IMMEDIATE");
+      try {
+        const checked = selectRunTrees(state, cutoff, now).trees.find(
+          (tree) => tree.rootRunId === selectedTree.rootRunId,
+        );
+        if (checked === undefined || !sameTree(checked, selectedTree)) {
+          completed = false;
+          state.connection.exec("ROLLBACK");
+          break;
+        }
+        const beforeChanges = totalChanges(state.connection);
+        deleteRunAggregates(state.connection, checked.runIds);
+        deleteUnusedDefinitionsAndProjects(state.connection);
+        deletedRows += totalChanges(state.connection) - beforeChanges;
+        state.connection.exec("COMMIT");
+      } catch (error) {
+        if (state.connection.inTransaction) state.connection.exec("ROLLBACK");
+        throw error;
+      }
+      await yieldControl();
+    }
+
+    if (completed && shouldContinue()) {
+      state.connection.exec("BEGIN IMMEDIATE");
+      try {
+        const beforeChanges = totalChanges(state.connection);
+        deleteUnusedDefinitionsAndProjects(state.connection);
+        const retainedBlobHashes = activeBlobHashes();
+        const blobStats = unreferencedBlobStats(state.connection, retainedBlobHashes);
+        deleteUnreferencedBlobs(state.connection, retainedBlobHashes);
+        deletedRows += totalChanges(state.connection) - beforeChanges;
+        deletedBlobs = blobStats.count;
+        deletedBlobBytes = blobStats.bytes;
+        state.connection.exec("COMMIT");
+      } catch (error) {
+        if (state.connection.inTransaction) state.connection.exec("ROLLBACK");
+        throw error;
+      }
+    } else {
+      completed = false;
+    }
+
+    if (completed && shouldContinue()) {
+      try {
+        state.connection.pragma("wal_checkpoint(TRUNCATE)");
+        metrics = databasePageMetrics(state.connection);
+        if (
+          shouldContinue() &&
+          shouldVacuumStateAutomatically(
+            metrics,
+            options.vacuumMinBytes ?? AUTOMATIC_STATE_VACUUM_MIN_BYTES,
+            options.vacuumMinFreeRatio ?? AUTOMATIC_STATE_VACUUM_MIN_FREE_RATIO,
+          )
+        ) {
+          (options.vacuum ?? vacuumDatabase)(state.connection);
+          compacted = true;
+          state.connection.pragma("wal_checkpoint(TRUNCATE)");
+          metrics = databasePageMetrics(state.connection);
+        }
+      } catch (error) {
+        compactionError = errorMessage(error);
+        metrics = databasePageMetrics(state.connection);
+      }
+    }
+
+    return {
+      ...reportBase(cutoff, initial, sizeBefore),
+      deletedRows,
+      deletedBlobs,
+      deletedBlobBytes,
+      databaseBytesAfter: databaseBytes(databasePath),
+      applied: true,
+      completed,
+      compacted,
+      ...metrics,
+      ...(compactionError === undefined ? {} : { compactionError }),
+    };
+  } finally {
+    releaseMaintenanceLock(lockPath, lock);
+  }
+}
+
+export function shouldVacuumStateAutomatically(
+  metrics: DatabasePageMetrics,
+  minimumBytes: number = AUTOMATIC_STATE_VACUUM_MIN_BYTES,
+  minimumFreeRatio: number = AUTOMATIC_STATE_VACUUM_MIN_FREE_RATIO,
+): boolean {
+  return metrics.reclaimableBytes >= minimumBytes && metrics.freePageRatio >= minimumFreeRatio;
+}
+
+function reportBase(cutoff: number, selection: RunTreeSelection, databaseBytesBefore: number) {
+  return {
+    cutoff: new Date(cutoff).toISOString(),
+    candidateTrees: selection.candidateTrees,
+    blockedTrees: selection.blockedTrees,
+    selectedRuns: selection.runIds.length,
+    databaseBytesBefore,
+  };
+}
+
 function selectRunTrees(
   state: StateDatabase,
   cutoff: number,
-): { candidateTrees: number; blockedTrees: number; runIds: string[]; signature: string } {
+  observedAt: number = Date.now(),
+): RunTreeSelection {
   const { connection: database } = state;
   const rows = database
     .prepare(
-      `SELECT run_id AS runId, parent_run_id AS parentRunId,
+      `SELECT run_id AS runId, parent_run_id AS parentRunId, root_run_id AS rootRunId,
               launch_options_hash AS launchOptionsHash, status, finished_at AS finishedAt
        FROM runs ORDER BY created_at, run_id`,
     )
@@ -166,53 +317,119 @@ function selectRunTrees(
       )
       .map((row) => row.runId),
   );
-  const children = new Map<string, string[]>();
-  const parents = new Map<string, string[]>();
+  const rowIds = new Set(rows.map((row) => row.runId));
+  const links = new Map(rows.map((row) => [row.runId, new Set<string>()]));
   for (const row of rows) {
-    const runParents = new Set<string>();
-    if (row.parentRunId !== null) runParents.add(row.parentRunId);
-    const restartParentRunId = restartParentFromLaunchOptions(
-      state.readJson(row.launchOptionsHash),
+    linkRuns(links, rowIds, row.runId, row.parentRunId);
+    linkRuns(links, rowIds, row.runId, row.rootRunId);
+    linkRuns(
+      links,
+      rowIds,
+      row.runId,
+      restartParentFromLaunchOptions(state.readJson(row.launchOptionsHash)),
     );
-    if (restartParentRunId !== null) runParents.add(restartParentRunId);
-    parents.set(row.runId, [...runParents]);
-    for (const parentRunId of runParents) {
-      const values = children.get(parentRunId) ?? [];
-      values.push(row.runId);
-      children.set(parentRunId, values);
-    }
   }
-  const roots = rows.filter(
-    (row) =>
-      eligible.has(row.runId) &&
-      (parents.get(row.runId) ?? []).every((parentRunId) => !eligible.has(parentRunId)),
-  );
-  const selected = new Set<string>();
+
+  const components: string[][] = [];
+  const visited = new Set<string>();
+  for (const row of rows) {
+    if (visited.has(row.runId)) continue;
+    const component = descendants(row.runId, links);
+    for (const runId of component) visited.add(runId);
+    components.push(component.sort());
+  }
+
+  const trees: SelectedRunTree[] = [];
+  let candidateTrees = 0;
   let blockedTrees = 0;
-  for (const root of roots) {
-    const tree = descendants(root.runId, children);
-    if (tree.some((runId) => !eligible.has(runId)) || treeHasBlocker(database, tree)) {
+  for (const runIds of components) {
+    if (!runIds.some((runId) => eligible.has(runId))) continue;
+    candidateTrees += 1;
+    if (
+      runIds.some((runId) => !eligible.has(runId)) ||
+      treeHasBlocker(database, runIds, observedAt)
+    ) {
       blockedTrees += 1;
       continue;
     }
-    for (const runId of tree) selected.add(runId);
+    const rootRunId = chooseRootRunId(rows, runIds);
+    trees.push({
+      rootRunId,
+      runIds,
+      signature: selectionSignature(database, runIds),
+    });
   }
-  const runIds = [...selected].sort();
+  trees.sort((left, right) => left.rootRunId.localeCompare(right.rootRunId));
+  const runIds = trees.flatMap((tree) => tree.runIds).sort();
   return {
-    candidateTrees: roots.length,
+    candidateTrees,
     blockedTrees,
+    trees,
     runIds,
-    signature: selectionSignature(database, runIds),
+    signature: JSON.stringify(trees),
   };
 }
 
-function treeHasBlocker(database: Database.Database, runIds: string[]): boolean {
+function treeHasBlocker(
+  database: Database.Database,
+  runIds: string[],
+  observedAt: number,
+): boolean {
   const values = placeholders(runIds);
   if (
     hasRow(
       database,
       `SELECT 1 FROM run_queue WHERE run_id IN (${values}) AND status IN (${placeholders(LIVE_QUEUE_STATUSES)})`,
       [...runIds, ...LIVE_QUEUE_STATUSES],
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM run_workers
+       WHERE run_id IN (${values}) AND status IN (${placeholders(ACTIVE_RUNNER_STATUSES)})`,
+      [...runIds, ...ACTIVE_RUNNER_STATUSES],
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM node_attempts
+       WHERE run_id IN (${values}) AND status IN (${placeholders(ACTIVE_ATTEMPT_STATUSES)})`,
+      [...runIds, ...ACTIVE_ATTEMPT_STATUSES],
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM session_segments WHERE run_id IN (${values}) AND status = 'recording'`,
+      runIds,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM interactive_requests WHERE run_id IN (${values}) AND status = 'pending'`,
+      runIds,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM human_decisions d
+       LEFT JOIN human_decision_resolutions r ON r.decision_id = d.decision_id
+       WHERE d.run_id IN (${values}) AND r.decision_id IS NULL`,
+      runIds,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM workflow_messages WHERE run_id IN (${values}) AND status = 'pending'`,
+      runIds,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM workflow_turns WHERE run_id IN (${values}) AND state = 'started'`,
+      runIds,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM run_bindings b
+       WHERE b.run_id IN (${values}) AND b.execution_mode = 'interactive'
+         AND NOT EXISTS (
+           SELECT 1 FROM workflow_messages m
+           WHERE m.run_id = b.run_id AND m.kind = 'terminal' AND m.status = 'sent'
+         )`,
+      runIds,
     ) ||
     hasRow(
       database,
@@ -229,8 +446,9 @@ function treeHasBlocker(database: Database.Database, runIds: string[]): boolean 
     hasRow(
       database,
       `SELECT 1 FROM run_steps s JOIN node_attempts a ON a.attempt_id = s.attempt_id
-       WHERE a.run_id IN (${values}) AND s.run_id NOT IN (${values})`,
-      [...runIds, ...runIds],
+       WHERE (a.run_id IN (${values}) AND s.run_id NOT IN (${values}))
+          OR (s.run_id IN (${values}) AND a.run_id NOT IN (${values}))`,
+      [...runIds, ...runIds, ...runIds, ...runIds],
     ) ||
     hasRow(
       database,
@@ -251,12 +469,12 @@ function treeHasBlocker(database: Database.Database, runIds: string[]): boolean 
   }
   const resources = relatedResourceIds(database, runIds);
   const resourceValues = placeholders(resources);
-  if (
+  return (
     hasRow(
       database,
       `SELECT 1 FROM leases
        WHERE resource_id IN (${resourceValues}) AND owner_id IS NOT NULL AND expires_at > ?`,
-      [...resources, Date.now()],
+      [...resources, observedAt],
     ) ||
     hasRow(
       database,
@@ -271,10 +489,45 @@ function treeHasBlocker(database: Database.Database, runIds: string[]): boolean 
        WHERE d.run_id IN (${values})`,
       runIds,
     )
-  ) {
-    return true;
-  }
-  return false;
+  );
+}
+
+function deleteSelectedState(
+  database: Database.Database,
+  runIds: string[],
+  retainedBlobHashes: readonly Buffer[],
+): DeletedState {
+  const beforeChanges = totalChanges(database);
+  if (runIds.length !== 0) deleteRunAggregates(database, runIds);
+  deleteUnusedDefinitionsAndProjects(database);
+  const blobStats = unreferencedBlobStats(database, retainedBlobHashes);
+  deleteUnreferencedBlobs(database, retainedBlobHashes);
+  return {
+    deletedRows: totalChanges(database) - beforeChanges,
+    deletedBlobs: blobStats.count,
+    deletedBlobBytes: blobStats.bytes,
+  };
+}
+
+function deleteUnusedDefinitionsAndProjects(database: Database.Database): void {
+  database
+    .prepare(
+      `DELETE FROM workflow_definitions
+       WHERE NOT EXISTS (
+         SELECT 1 FROM runs WHERE runs.definition_digest = workflow_definitions.definition_digest
+       )`,
+    )
+    .run();
+  database
+    .prepare(
+      `DELETE FROM projects
+       WHERE NOT EXISTS (SELECT 1 FROM runs WHERE runs.project_id = projects.project_id)
+         AND NOT EXISTS (
+           SELECT 1 FROM controller_resources
+           WHERE controller_resources.project_id = projects.project_id
+         )`,
+    )
+    .run();
 }
 
 function deleteRunAggregates(database: Database.Database, runIds: string[]): void {
@@ -408,7 +661,60 @@ function blobReferencePredicate(database: Database.Database, retainedBlobCount: 
   return `${unreferenced} AND blob_hash NOT IN (${retainedPlaceholders})`;
 }
 
-function descendants(root: string, children: Map<string, string[]>): string[] {
+function vacuumDatabase(database: Database.Database): void {
+  database.exec("VACUUM");
+}
+
+function databasePageMetrics(database: Database.Database): DatabasePageMetrics {
+  const pageCount = pragmaNumber(database, "page_count");
+  const freePageCount = pragmaNumber(database, "freelist_count");
+  const pageSize = pragmaNumber(database, "page_size");
+  return {
+    pageCount,
+    freePageCount,
+    pageSize,
+    reclaimableBytes: freePageCount * pageSize,
+    freePageRatio: pageCount === 0 ? 0 : freePageCount / pageCount,
+  };
+}
+
+function pragmaNumber(database: Database.Database, name: string): number {
+  const value = database.pragma(name, { simple: true });
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`SQLite ${name} returned an invalid value`);
+  }
+  return value;
+}
+
+function sameSelection(left: RunTreeSelection, right: RunTreeSelection): boolean {
+  return left.runIds.join("\0") === right.runIds.join("\0") && left.signature === right.signature;
+}
+
+function sameTree(left: SelectedRunTree, right: SelectedRunTree): boolean {
+  return left.runIds.join("\0") === right.runIds.join("\0") && left.signature === right.signature;
+}
+
+function chooseRootRunId(rows: RunAgeRow[], runIds: string[]): string {
+  const runIdSet = new Set(runIds);
+  const candidates = rows
+    .filter((row) => runIdSet.has(row.runId) && row.rootRunId === row.runId)
+    .map((row) => row.runId)
+    .sort();
+  return candidates[0] ?? runIds[0] ?? "";
+}
+
+function linkRuns(
+  links: Map<string, Set<string>>,
+  rowIds: Set<string>,
+  left: string,
+  right: string | null,
+): void {
+  if (right === null || right === left || !rowIds.has(right)) return;
+  links.get(left)?.add(right);
+  links.get(right)?.add(left);
+}
+
+function descendants(root: string, links: Map<string, Set<string>>): string[] {
   const result: string[] = [];
   const seen = new Set<string>();
   const pending = [root];
@@ -417,7 +723,7 @@ function descendants(root: string, children: Map<string, string[]>): string[] {
     if (seen.has(runId)) continue;
     seen.add(runId);
     result.push(runId);
-    pending.push(...(children.get(runId) ?? []));
+    pending.push(...(links.get(runId) ?? []));
   }
   return result;
 }
@@ -442,6 +748,10 @@ function databaseBytes(databasePath: string): number {
   return [databasePath, `${databasePath}-wal`]
     .filter((filePath) => fs.existsSync(filePath))
     .reduce((total, filePath) => total + fs.statSync(filePath).size, 0);
+}
+
+function emptySelection(): RunTreeSelection {
+  return { candidateTrees: 0, blockedTrees: 0, trees: [], runIds: [], signature: "" };
 }
 
 function acquireMaintenanceLock(lockPath: string): number {
@@ -478,12 +788,28 @@ function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function yieldToEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isRunAgeRow(value: unknown): value is RunAgeRow {
-  return isRecord(value);
+  return (
+    isRecord(value) &&
+    typeof value.runId === "string" &&
+    (value.parentRunId === null || typeof value.parentRunId === "string") &&
+    typeof value.rootRunId === "string" &&
+    Buffer.isBuffer(value.launchOptionsHash) &&
+    typeof value.status === "string" &&
+    (value.finishedAt === null || typeof value.finishedAt === "number")
+  );
 }
 
 function isResourceRow(value: unknown): value is { resourceId: string } {

--- a/test/e2e/package-resources.e2e.test.ts
+++ b/test/e2e/package-resources.e2e.test.ts
@@ -9,7 +9,8 @@ import { clientSocketPath } from "../../src/client/protocol.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const piBin = path.join(repoRoot, "node_modules", ".bin", "pi");
-const SERVER_STOP_TIMEOUT_MS = 5_000;
+const PACKAGE_DISCOVERY_TIMEOUT_MS = 30_000;
+const SERVER_STOP_TIMEOUT_MS = PACKAGE_DISCOVERY_TIMEOUT_MS;
 const tempFixtures: Array<{ directory: string; serverExpected: boolean }> = [];
 
 type CommandInfo = {
@@ -59,7 +60,7 @@ async function getCommands(args: string[], tempDir: string): Promise<CommandInfo
     const timeout = setTimeout(() => {
       child.kill("SIGKILL");
       reject(new Error(`Pi package discovery timed out.\n${stderr}`));
-    }, 30_000);
+    }, PACKAGE_DISCOVERY_TIMEOUT_MS);
 
     child.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk.toString("utf8");

--- a/test/prune.test.ts
+++ b/test/prune.test.ts
@@ -5,7 +5,10 @@ import workflow from "../examples/workflows/echo.workflow.js";
 import { StateDatabase } from "../src/state/database.js";
 import { resourceIdFor } from "../src/state/mutation.js";
 import {
+  AUTOMATIC_STATE_RETENTION_MS,
   pruneState as pruneStateWithDatabase,
+  pruneStateAutomatically,
+  shouldVacuumStateAutomatically,
   type StatePruneOptions,
   type StatePruneReport,
   validateStatePruneOptions,
@@ -262,6 +265,354 @@ describe("state prune", () => {
       expect(report).toMatchObject({ deletedBlobs: 1, applied: true });
       expect(state.readBlob(retained)?.content.toString("utf8")).toBe("active runner content");
       expect(state.readBlob(unprotected)).toBeUndefined();
+    } finally {
+      state.close();
+    }
+  });
+
+  it("automatically deletes whole expired trees and unreferenced blobs without a backup", async () => {
+    const databasePath = await makeStateDatabasePath("state-prune-automatic");
+    const result = await new WorkflowEngine({
+      databasePath,
+      executor: new ScriptedExecutor().respond("reply", { output: { reply: "done" } }),
+    }).run(workflow, {});
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-write" });
+    const now = Date.now();
+    try {
+      state.connection
+        .prepare("UPDATE runs SET finished_at = ? WHERE run_id = ?")
+        .run(now - AUTOMATIC_STATE_RETENTION_MS - 1, result.runId);
+      const orphan = state.putBlob(Buffer.alloc(256 * 1024, 7), "application/json");
+      const report = await pruneStateAutomatically(state, databasePath, { now });
+
+      expect(report).toMatchObject({
+        applied: true,
+        completed: true,
+        candidateTrees: 1,
+        blockedTrees: 0,
+        selectedRuns: 1,
+      });
+      expect(report.deletedBlobs).toBeGreaterThan(0);
+      expect(
+        state.connection.prepare("SELECT 1 FROM runs WHERE run_id = ?").get(result.runId),
+      ).toBe(undefined);
+      expect(state.readBlob(orphan)).toBeUndefined();
+      expect(fs.readdirSync(path.dirname(databasePath))).not.toContain("backup.sqlite");
+
+      const repeated = await pruneStateAutomatically(state, databasePath, { now });
+      expect(repeated).toMatchObject({
+        completed: true,
+        candidateTrees: 0,
+        selectedRuns: 0,
+        deletedRows: 0,
+        deletedBlobs: 0,
+      });
+    } finally {
+      state.close();
+    }
+  });
+
+  it("rechecks each automatic tree and stops between complete tree transactions", async () => {
+    const databasePath = await makeStateDatabasePath("state-prune-automatic-recheck");
+    const first = await new WorkflowEngine({
+      databasePath,
+      executor: new ScriptedExecutor().respond("reply", { output: { reply: "first" } }),
+    }).run(workflow, {});
+    const second = await new WorkflowEngine({
+      databasePath,
+      executor: new ScriptedExecutor().respond("reply", { output: { reply: "second" } }),
+    }).run(workflow, {});
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-write" });
+    const now = Date.now();
+    try {
+      state.connection
+        .prepare("UPDATE runs SET finished_at = ? WHERE run_id IN (?, ?)")
+        .run(now - AUTOMATIC_STATE_RETENTION_MS - 1, first.runId, second.runId);
+      let yielded = false;
+      const report = await pruneStateAutomatically(state, databasePath, {
+        now,
+        yieldControl: async () => {
+          if (yielded) return;
+          yielded = true;
+          state.connection
+            .prepare("UPDATE runs SET finished_at = ? WHERE run_id IN (?, ?)")
+            .run(now, first.runId, second.runId);
+        },
+      });
+
+      expect(report.completed).toBe(false);
+      expect(report.selectedRuns).toBe(2);
+      expect(state.connection.prepare("SELECT count(*) AS count FROM runs").get()).toEqual({
+        count: 1,
+      });
+    } finally {
+      state.close();
+    }
+  });
+
+  it("protects every live or unsettled state owned by an expired run", async () => {
+    const databasePath = await makeStateDatabasePath("state-prune-protected");
+    const results = [];
+    for (let index = 0; index < 9; index += 1) {
+      results.push(
+        await new WorkflowEngine({
+          databasePath,
+          executor: new ScriptedExecutor().respond("reply", {
+            output: { reply: `run-${index}` },
+          }),
+        }).run(workflow, {}),
+      );
+    }
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-write" });
+    const now = Date.now();
+    try {
+      state.connection
+        .prepare("UPDATE runs SET finished_at = ?")
+        .run(now - AUTOMATIC_STATE_RETENTION_MS - 1);
+      const contentHash = state.putText("protected", now);
+      const contractHash = state.putJson({ contract: "protected" }, now);
+      const launchHash = state.putJson({ launch: "protected" }, now);
+      const attemptIds = results.map((result) => {
+        const row = state.connection
+          .prepare("SELECT attempt_id AS attemptId FROM node_attempts WHERE run_id = ? LIMIT 1")
+          .get(result.runId) as { attemptId: string };
+        return row.attemptId;
+      });
+
+      state.connection
+        .prepare(
+          `INSERT INTO workflow_messages(
+             workflow_message_id, run_id, target_session_id, kind, source_id, content_hash,
+             order_number, status, created_at, updated_at
+           ) VALUES ('pending-message', ?, 'protected-session', 'step', 'pending-source', ?, 1, 'pending', ?, ?)`,
+        )
+        .run(results[0]?.runId, contentHash, now, now);
+      state.connection
+        .prepare(
+          `INSERT INTO workflow_messages(
+             workflow_message_id, run_id, target_session_id, kind, source_id, content_hash,
+             order_number, status, pi_session_entry_id, created_at, updated_at
+           ) VALUES ('open-turn-message', ?, 'protected-session', 'step', 'turn-source', ?, 2, 'sent', 'pi-entry', ?, ?)`,
+        )
+        .run(results[1]?.runId, contentHash, now, now);
+      state.connection
+        .prepare(
+          `INSERT INTO workflow_turns(
+             workflow_turn_id, workflow_message_id, run_id, target_session_id, state, started_at
+           ) VALUES ('open-turn', 'open-turn-message', ?, 'protected-session', 'started', ?)`,
+        )
+        .run(results[1]?.runId, now);
+      state.connection
+        .prepare(
+          `INSERT INTO interactive_requests(
+             request_id, run_id, attempt_id, target_session_id, kind, contract_hash,
+             status, created_at, updated_at
+           ) VALUES ('pending-interaction', ?, ?, 'protected-session', 'agent', ?, 'pending', ?, ?)`,
+        )
+        .run(results[2]?.runId, attemptIds[2], contractHash, now, now);
+      state.connection
+        .prepare("UPDATE node_attempts SET status = 'waiting' WHERE attempt_id = ?")
+        .run(attemptIds[3]);
+      state.connection
+        .prepare(
+          `INSERT INTO run_workers(
+             worker_epoch, run_id, generation, host_epoch, launch_envelope_hash,
+             status, started_at, ready_at
+           ) VALUES ('active-worker', ?, 1, 1, ?, 'running', ?, ?)`,
+        )
+        .run(results[4]?.runId, launchHash, now, now);
+
+      const segmentResourceId = resourceIdFor("session", "recording-segment");
+      state.connection
+        .prepare(
+          `INSERT INTO resources(
+             resource_id, resource_type, aggregate_key, revision, created_at, updated_at
+           ) VALUES (?, 'session', 'recording-segment', 1, ?, ?)`,
+        )
+        .run(segmentResourceId, now, now);
+      state.connection
+        .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
+        .run(segmentResourceId);
+      state.connection
+        .prepare(
+          `INSERT INTO session_segments(
+             segment_id, run_id, session_id, resource_id, status, created_at
+           ) VALUES ('recording-segment', ?, 'protected-session', ?, 'recording', ?)`,
+        )
+        .run(results[5]?.runId, segmentResourceId, now);
+
+      const effectId = "pending-effect";
+      const effectResourceId = resourceIdFor("effect", effectId);
+      const source = state.connection
+        .prepare("SELECT resource_id AS resourceId FROM runs WHERE run_id = ?")
+        .get(results[6]?.runId) as { resourceId: string };
+      state.connection
+        .prepare(
+          `INSERT INTO resources(
+             resource_id, resource_type, aggregate_key, revision, created_at, updated_at
+           ) VALUES (?, 'effect', ?, 1, ?, ?)`,
+        )
+        .run(effectResourceId, effectId, now, now);
+      state.connection
+        .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
+        .run(effectResourceId);
+      state.connection
+        .prepare(
+          `INSERT INTO effects(
+             effect_id, resource_id, source_resource_id, source_revision, effect_type,
+             idempotency_key, payload_hash, owner_scope, status, created_at, updated_at
+           ) VALUES (?, ?, ?, 1, 'test', 'pending-effect', ?, 'run', 'pending', ?, ?)`,
+        )
+        .run(effectId, effectResourceId, source.resourceId, contentHash, now, now);
+
+      const decisionId = "pending-decision";
+      const decisionResourceId = resourceIdFor("decision", decisionId);
+      state.connection
+        .prepare(
+          `INSERT INTO resources(
+             resource_id, resource_type, aggregate_key, revision, created_at, updated_at
+           ) VALUES (?, 'decision', ?, 1, ?, ?)`,
+        )
+        .run(decisionResourceId, decisionId, now, now);
+      state.connection
+        .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
+        .run(decisionResourceId);
+      state.connection
+        .prepare(
+          `INSERT INTO human_decisions(
+             decision_id, resource_id, run_id, attempt_id, audience, title, subject_hash,
+             presentation_hash, choices_hash, request_digest, presentation_revision,
+             request_hash, created_at
+           ) VALUES (?, ?, ?, ?, 'operator', 'Pending', ?, ?, ?, ?, 1, ?, ?)`,
+        )
+        .run(
+          decisionId,
+          decisionResourceId,
+          results[7]?.runId,
+          attemptIds[7],
+          contractHash,
+          contractHash,
+          contractHash,
+          Buffer.alloc(32, 8),
+          contractHash,
+          now,
+        );
+
+      const controllerId = "retention-controller";
+      const controllerResourceId = resourceIdFor("controller", controllerId);
+      state.connection
+        .prepare(
+          `INSERT INTO resources(
+             resource_id, resource_type, aggregate_key, revision, created_at, updated_at
+           ) VALUES (?, 'controller', ?, 1, ?, ?)`,
+        )
+        .run(controllerResourceId, controllerId, now, now);
+      state.connection
+        .prepare("INSERT INTO leases(resource_id, generation) VALUES (?, 0)")
+        .run(controllerResourceId);
+      state.connection
+        .prepare(
+          `INSERT INTO controller_resources(
+             controller_resource_id, resource_id, controller_name, resource_key, uid,
+             generation, spec_hash, status_hash, created_at, updated_at
+           ) VALUES (?, ?, 'retention', 'protected', 'retention-protected', 1, ?, ?, ?, ?)`,
+        )
+        .run(controllerId, controllerResourceId, contractHash, contractHash, now, now);
+      state.connection
+        .prepare(
+          `INSERT INTO controller_workflows(
+             request_id, controller_resource_id, request_key, workflow_name,
+             input_fingerprint, run_id, status, created_at, updated_at
+           ) VALUES (
+             'retention-controller-request', ?, 'protected', 'retention', ?, ?, 'succeeded', ?, ?
+           )`,
+        )
+        .run(controllerId, Buffer.alloc(32, 9), results[8]?.runId, now, now);
+
+      const report = await pruneStateAutomatically(state, databasePath, { now });
+      expect(report).toMatchObject({
+        completed: true,
+        candidateTrees: 9,
+        blockedTrees: 9,
+        selectedRuns: 0,
+      });
+      expect(state.connection.prepare("SELECT count(*) AS count FROM runs").get()).toEqual({
+        count: 9,
+      });
+    } finally {
+      state.close();
+    }
+  });
+
+  it("reuses free pages and compacts only above both automatic thresholds", async () => {
+    expect(
+      shouldVacuumStateAutomatically({
+        pageCount: 100,
+        freePageCount: 20,
+        pageSize: 4096,
+        reclaimableBytes: 64 * 1024 * 1024,
+        freePageRatio: 0.2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldVacuumStateAutomatically({
+        pageCount: 100,
+        freePageCount: 19,
+        pageSize: 4096,
+        reclaimableBytes: 64 * 1024 * 1024,
+        freePageRatio: 0.19,
+      }),
+    ).toBe(false);
+
+    const databasePath = await makeStateDatabasePath("state-prune-pages");
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-write" });
+    try {
+      state.putBlob(Buffer.alloc(2 * 1024 * 1024, 11), "application/json");
+      state.connection.pragma("wal_checkpoint(TRUNCATE)");
+      const bytesBefore = fs.statSync(databasePath).size;
+      const logical = await pruneStateAutomatically(state, databasePath);
+      expect(logical.compacted).toBe(false);
+      expect(logical.reclaimableBytes).toBeGreaterThan(1024 * 1024);
+      const reusablePages = logical.pageCount;
+
+      state.putBlob(Buffer.alloc(2 * 1024 * 1024, 12), "application/json");
+      state.connection.pragma("wal_checkpoint(TRUNCATE)");
+      const pageCountAfterReuse = state.connection.pragma("page_count", { simple: true });
+      expect(pageCountAfterReuse).toBeLessThanOrEqual(reusablePages + 2);
+
+      const compacted = await pruneStateAutomatically(state, databasePath, {
+        vacuumMinBytes: 1,
+        vacuumMinFreeRatio: 0,
+      });
+      expect(compacted.compacted).toBe(true);
+      expect(fs.statSync(databasePath).size).toBeLessThan(bytesBefore);
+    } finally {
+      state.close();
+    }
+  });
+
+  it("keeps logical cleanup when automatic compaction fails", async () => {
+    const databasePath = await makeStateDatabasePath("state-prune-compaction-failure");
+    const state = new StateDatabase({ filePath: databasePath, mode: "read-write" });
+    try {
+      const orphan = state.putBlob(Buffer.alloc(2 * 1024 * 1024, 13), "application/json");
+      state.connection.pragma("wal_checkpoint(TRUNCATE)");
+      const report = await pruneStateAutomatically(state, databasePath, {
+        vacuumMinBytes: 1,
+        vacuumMinFreeRatio: 0,
+        vacuum: () => {
+          throw new Error("injected compaction failure");
+        },
+      });
+
+      expect(report).toMatchObject({
+        completed: true,
+        compacted: false,
+        compactionError: "injected compaction failure",
+      });
+      expect(report.reclaimableBytes).toBeGreaterThan(1024 * 1024);
+      expect(state.readBlob(orphan)).toBeUndefined();
+      state.integrityCheck();
     } finally {
       state.close();
     }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import echoWorkflow from "../examples/workflows/echo.workflow.js";
 import { WorkflowClient } from "../src/client/client.js";
 import {
   encodeProtocolLine,
@@ -25,8 +26,9 @@ import {
   AUTOMATIC_STATE_RETENTION_MS,
 } from "../src/state/prune.js";
 import type { WorkflowMessage } from "../src/state/workflow-messages.js";
+import { WorkflowEngine } from "../src/workflows/engine.js";
 import { SESSION_BINDING_SCHEMA, WorkflowRunStore } from "../src/workflows/store.js";
-import { makeTempDir, waitUntil } from "./helpers.js";
+import { ScriptedExecutor, makeTempDir, waitUntil } from "./helpers.js";
 
 async function writeComputeWorkflow(cwd: string): Promise<string> {
   const workflowPath = path.join(cwd, "compute.workflow.ts");
@@ -1300,70 +1302,19 @@ setInterval(() => {}, 1000);
     const cwd = await makeTempDir("host-automatic-prune-project");
     const databasePath = path.join(await makeTempDir("host-automatic-prune-state"), "state.sqlite");
     const workflowPath = await writeComputeWorkflow(cwd);
-    const setupHost = new WorkflowServer({ databasePath, claimPollMs: 10 });
-    const setupClient = new WorkflowClient({ databasePath });
-    await setupHost.start();
+    const seedStore = new WorkflowRunStore(databasePath);
     try {
-      await startRun({
-        client: setupClient,
-        cwd,
-        workflowPath,
-        runId: "automatic-prune-first",
+      const seedEngine = new WorkflowEngine({
+        store: seedStore,
+        executor: new ScriptedExecutor().respond("reply", { output: { reply: "first" } }),
       });
-      await waitUntil(() => {
-        const queue = new SqliteResourceManagerStore(databasePath, {
-          readOnly: true,
-          global: true,
-        });
-        try {
-          return queue.getWorkflowRun("automatic-prune-first")?.status === "done";
-        } finally {
-          queue.close();
-        }
-      }, 30_000);
-      await startRun({
-        client: setupClient,
-        cwd,
-        workflowPath,
-        runId: "automatic-prune-blocked",
-      });
-      await waitUntil(() => {
-        const queue = new SqliteResourceManagerStore(databasePath, {
-          readOnly: true,
-          global: true,
-        });
-        try {
-          return ["automatic-prune-first", "automatic-prune-blocked"].every(
-            (runId) => queue.getWorkflowRun(runId)?.status === "done",
-          );
-        } finally {
-          queue.close();
-        }
-      }, 30_000);
+      await seedEngine.run(echoWorkflow, {}, { runId: "automatic-prune-first" });
+      seedStore.state.connection
+        .prepare("UPDATE runs SET finished_at = ? WHERE run_id = ?")
+        .run(Date.now() - AUTOMATIC_STATE_RETENTION_MS - 1, "automatic-prune-first");
     } finally {
-      await setupClient.close();
-      await setupHost.stop();
+      seedStore.close();
     }
-
-    const now = Date.now();
-    const setup = new WorkflowRunStore(databasePath);
-    setup.state.connection
-      .prepare("UPDATE runs SET finished_at = ? WHERE run_id IN (?, ?)")
-      .run(
-        now - AUTOMATIC_STATE_RETENTION_MS - 1,
-        "automatic-prune-first",
-        "automatic-prune-blocked",
-      );
-    const blockedResource = setup.state.connection
-      .prepare("SELECT resource_id AS resourceId FROM runs WHERE run_id = ?")
-      .get("automatic-prune-blocked") as { resourceId: string };
-    setup.state.connection
-      .prepare(
-        `UPDATE leases SET owner_type = 'system', owner_id = 'retention-test', token_hash = ?,
-           acquired_at = ?, heartbeat_at = ?, expires_at = ? WHERE resource_id = ?`,
-      )
-      .run(Buffer.alloc(32, 4), now, now, now + 60_000, blockedResource.resourceId);
-    setup.close();
 
     const logs: string[] = [];
     const host = new WorkflowServer({
@@ -1383,20 +1334,20 @@ setInterval(() => {}, 1000);
         }
       }, 10_000);
       await expect(client.getRun("automatic-prune-first")).resolves.toBeNull();
-      await expect(client.getRun("automatic-prune-blocked")).resolves.not.toBeNull();
-      const retained = new WorkflowRunStore(databasePath, { readOnly: true });
-      expect(retained.readRun("automatic-prune-blocked")).not.toBeNull();
-      retained.close();
 
-      const writable = new WorkflowRunStore(databasePath);
-      writable.state.connection
-        .prepare(
-          `UPDATE leases SET owner_type = NULL, owner_id = NULL, token_hash = NULL,
-             acquired_at = NULL, heartbeat_at = NULL, expires_at = NULL
-           WHERE resource_id = ?`,
-        )
-        .run(blockedResource.resourceId);
-      writable.close();
+      const laterStore = new WorkflowRunStore(databasePath);
+      try {
+        const laterEngine = new WorkflowEngine({
+          store: laterStore,
+          executor: new ScriptedExecutor().respond("reply", { output: { reply: "later" } }),
+        });
+        await laterEngine.run(echoWorkflow, {}, { runId: "automatic-prune-later" });
+        laterStore.state.connection
+          .prepare("UPDATE runs SET finished_at = ? WHERE run_id = ?")
+          .run(Date.now() - AUTOMATIC_STATE_RETENTION_MS - 1, "automatic-prune-later");
+      } finally {
+        laterStore.close();
+      }
 
       const internal = host as unknown as {
         lastAutomaticStatePruneAt: number | null;
@@ -1406,7 +1357,7 @@ setInterval(() => {}, 1000);
       internal.requestAutomaticStatePrune();
       await new Promise((resolve) => setTimeout(resolve, 50));
       const throttled = new WorkflowRunStore(databasePath, { readOnly: true });
-      expect(throttled.readRun("automatic-prune-blocked")).not.toBeNull();
+      expect(throttled.readRun("automatic-prune-later")).not.toBeNull();
       throttled.close();
 
       internal.lastAutomaticStatePruneAt = Date.now() - AUTOMATIC_STATE_PRUNE_INTERVAL_MS - 1;
@@ -1419,7 +1370,7 @@ setInterval(() => {}, 1000);
       await waitUntil(() => {
         const store = new WorkflowRunStore(databasePath, { readOnly: true });
         try {
-          return store.readRun("automatic-prune-blocked") === null;
+          return store.readRun("automatic-prune-later") === null;
         } finally {
           store.close();
         }
@@ -1429,6 +1380,16 @@ setInterval(() => {}, 1000);
           logs.filter((message) => message.startsWith("automatic state prune completed")).length ===
           2,
       );
+      const settled = new WorkflowRunStore(databasePath, { readOnly: true });
+      const settlement = settled.state.connection
+        .prepare(
+          `SELECT e.status
+           FROM effects e JOIN runs r ON r.resource_id = e.source_resource_id
+           WHERE r.run_id = ? AND e.effect_type = 'run.settle_queue'`,
+        )
+        .get("automatic-prune-trigger") as { status: string } | undefined;
+      expect(settlement?.status).toBe("applied");
+      settled.close();
     } finally {
       await client.close();
       await host.stop();

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -14,7 +14,16 @@ import { SqliteResourceManagerStore } from "../src/resource-managers/sqlite.js";
 import { ServerProcessRegistry } from "../src/server/processes.js";
 import { WorkflowServer } from "../src/server/server.js";
 import { ServerStateStore, type InteractiveRequestRecord } from "../src/server/state.js";
+import {
+  encodeRunnerLine,
+  MAX_WORKFLOW_RUNNER_PROTOCOL_MESSAGE_BYTES,
+  type WorkflowRunnerResponse,
+} from "../src/server/workflow-runner-protocol.js";
 import { canonicalJson } from "../src/state/json.js";
+import {
+  AUTOMATIC_STATE_PRUNE_INTERVAL_MS,
+  AUTOMATIC_STATE_RETENTION_MS,
+} from "../src/state/prune.js";
 import type { WorkflowMessage } from "../src/state/workflow-messages.js";
 import { SESSION_BINDING_SCHEMA, WorkflowRunStore } from "../src/workflows/store.js";
 import { makeTempDir, waitUntil } from "./helpers.js";
@@ -1146,7 +1155,7 @@ setInterval(() => {}, 1000);
         await runStore.appendSessionEntry("large-resume-run", {
           id: `entry-${index}`,
           type: "message",
-          content: "x".repeat(128 * 1024),
+          content: `${index}:${"x".repeat(128 * 1024)}`,
         });
       }
       expect(
@@ -1192,6 +1201,13 @@ setInterval(() => {}, 1000);
       if (typeof secondContract.contract?.nodeId !== "string") {
         throw new Error("second interaction node is missing");
       }
+      const incrementalStore = new WorkflowRunStore(databasePath);
+      await incrementalStore.appendSessionEntry("large-resume-run", {
+        id: "entry-after-first-resume",
+        type: "message",
+        content: "small unique change after the first resume",
+      });
+      incrementalStore.close();
       const secondResponse = await client.request({
         operation: "interaction.submit",
         runId: pendingSecondInteraction.runId,
@@ -1218,19 +1234,246 @@ setInterval(() => {}, 1000);
         }
       }, 30_000);
       const completedStore = new WorkflowRunStore(databasePath);
-      expect(completedStore.readRun("large-resume-run")?.sessionEntries).toHaveLength(17);
+      expect(completedStore.readRun("large-resume-run")?.sessionEntries).toHaveLength(18);
       const crashed = completedStore.state.connection
         .prepare(
           "SELECT count(*) AS count FROM run_workers WHERE run_id = ? AND status = 'crashed'",
         )
         .get("large-resume-run") as { count: number };
       expect(crashed.count).toBe(0);
+
+      const history = completedStore.state.connection
+        .prepare(
+          `SELECT COALESCE(sum(b.byte_length), 0) AS bytes
+           FROM session_entries e JOIN blobs b ON b.blob_hash = e.entry_hash
+           WHERE e.run_id = ?`,
+        )
+        .get("large-resume-run") as { bytes: number };
+      const resultBlobs = completedStore.state.connection
+        .prepare(
+          `SELECT count(*) AS count, COALESCE(sum(b.byte_length), 0) AS bytes
+           FROM (
+             SELECT DISTINCT m.result_hash AS resultHash
+             FROM worker_messages m JOIN run_workers w ON w.worker_epoch = m.worker_epoch
+             WHERE w.run_id = ? AND m.result_hash IS NOT NULL
+           ) results JOIN blobs b ON b.blob_hash = results.resultHash`,
+        )
+        .get("large-resume-run") as { count: number; bytes: number };
+      const resultRows = completedStore.state.connection
+        .prepare(
+          `SELECT m.message_id AS messageId, m.outcome,
+                  m.accepted_revision AS revision, m.result_hash AS resultHash
+           FROM worker_messages m JOIN run_workers w ON w.worker_epoch = m.worker_epoch
+           WHERE w.run_id = ? AND m.result_hash IS NOT NULL`,
+        )
+        .all("large-resume-run") as Array<{
+        messageId: string;
+        outcome: WorkflowRunnerResponse["outcome"];
+        revision: number | null;
+        resultHash: Buffer;
+      }>;
+      const frameBytes = resultRows.map(
+        (row) =>
+          encodeRunnerLine({
+            schema: "pi-workflows.worker-response.v1",
+            messageId: row.messageId,
+            outcome: row.outcome,
+            ...(row.revision === null ? {} : { revision: row.revision }),
+            result: completedStore.state.readJson(row.resultHash),
+          }).byteLength,
+      );
+      const pageCount = completedStore.state.connection.pragma("page_count", { simple: true });
+      const pageSize = completedStore.state.connection.pragma("page_size", { simple: true });
+      expect(history.bytes).toBeGreaterThan(2 * 1024 * 1024);
+      expect(resultBlobs.count).toBeGreaterThan(1);
+      expect(resultBlobs.bytes).toBeLessThan(history.bytes);
+      expect(Math.max(...frameBytes)).toBeLessThan(MAX_WORKFLOW_RUNNER_PROTOCOL_MESSAGE_BYTES);
+      expect((pageCount as number) * (pageSize as number)).toBeLessThan(history.bytes * 4);
       completedStore.close();
     } finally {
       await client.close();
       await host.stop();
     }
   }, 60_000);
+
+  it("prunes expired state after recovery and after a later runner exit", async () => {
+    const cwd = await makeTempDir("host-automatic-prune-project");
+    const databasePath = path.join(await makeTempDir("host-automatic-prune-state"), "state.sqlite");
+    const workflowPath = await writeComputeWorkflow(cwd);
+    const setupHost = new WorkflowServer({ databasePath, claimPollMs: 10 });
+    const setupClient = new WorkflowClient({ databasePath });
+    await setupHost.start();
+    try {
+      await startRun({
+        client: setupClient,
+        cwd,
+        workflowPath,
+        runId: "automatic-prune-first",
+      });
+      await waitUntil(() => {
+        const queue = new SqliteResourceManagerStore(databasePath, {
+          readOnly: true,
+          global: true,
+        });
+        try {
+          return queue.getWorkflowRun("automatic-prune-first")?.status === "done";
+        } finally {
+          queue.close();
+        }
+      }, 30_000);
+      await startRun({
+        client: setupClient,
+        cwd,
+        workflowPath,
+        runId: "automatic-prune-blocked",
+      });
+      await waitUntil(() => {
+        const queue = new SqliteResourceManagerStore(databasePath, {
+          readOnly: true,
+          global: true,
+        });
+        try {
+          return ["automatic-prune-first", "automatic-prune-blocked"].every(
+            (runId) => queue.getWorkflowRun(runId)?.status === "done",
+          );
+        } finally {
+          queue.close();
+        }
+      }, 30_000);
+    } finally {
+      await setupClient.close();
+      await setupHost.stop();
+    }
+
+    const now = Date.now();
+    const setup = new WorkflowRunStore(databasePath);
+    setup.state.connection
+      .prepare("UPDATE runs SET finished_at = ? WHERE run_id IN (?, ?)")
+      .run(
+        now - AUTOMATIC_STATE_RETENTION_MS - 1,
+        "automatic-prune-first",
+        "automatic-prune-blocked",
+      );
+    const blockedResource = setup.state.connection
+      .prepare("SELECT resource_id AS resourceId FROM runs WHERE run_id = ?")
+      .get("automatic-prune-blocked") as { resourceId: string };
+    setup.state.connection
+      .prepare(
+        `UPDATE leases SET owner_type = 'system', owner_id = 'retention-test', token_hash = ?,
+           acquired_at = ?, heartbeat_at = ?, expires_at = ? WHERE resource_id = ?`,
+      )
+      .run(Buffer.alloc(32, 4), now, now, now + 60_000, blockedResource.resourceId);
+    setup.close();
+
+    const logs: string[] = [];
+    const host = new WorkflowServer({
+      databasePath,
+      claimPollMs: 10,
+      onLog: (message) => logs.push(message),
+    });
+    const client = new WorkflowClient({ databasePath });
+    await host.start();
+    try {
+      await waitUntil(() => {
+        const store = new WorkflowRunStore(databasePath, { readOnly: true });
+        try {
+          return store.readRun("automatic-prune-first") === null;
+        } finally {
+          store.close();
+        }
+      }, 10_000);
+      await expect(client.getRun("automatic-prune-first")).resolves.toBeNull();
+      await expect(client.getRun("automatic-prune-blocked")).resolves.not.toBeNull();
+      const retained = new WorkflowRunStore(databasePath, { readOnly: true });
+      expect(retained.readRun("automatic-prune-blocked")).not.toBeNull();
+      retained.close();
+
+      const writable = new WorkflowRunStore(databasePath);
+      writable.state.connection
+        .prepare(
+          `UPDATE leases SET owner_type = NULL, owner_id = NULL, token_hash = NULL,
+             acquired_at = NULL, heartbeat_at = NULL, expires_at = NULL
+           WHERE resource_id = ?`,
+        )
+        .run(blockedResource.resourceId);
+      writable.close();
+
+      const internal = host as unknown as {
+        lastAutomaticStatePruneAt: number | null;
+        requestAutomaticStatePrune(): void;
+      };
+      internal.requestAutomaticStatePrune();
+      internal.requestAutomaticStatePrune();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const throttled = new WorkflowRunStore(databasePath, { readOnly: true });
+      expect(throttled.readRun("automatic-prune-blocked")).not.toBeNull();
+      throttled.close();
+
+      internal.lastAutomaticStatePruneAt = Date.now() - AUTOMATIC_STATE_PRUNE_INTERVAL_MS - 1;
+      await startRun({
+        client,
+        cwd,
+        workflowPath,
+        runId: "automatic-prune-trigger",
+      });
+      await waitUntil(() => {
+        const store = new WorkflowRunStore(databasePath, { readOnly: true });
+        try {
+          return store.readRun("automatic-prune-blocked") === null;
+        } finally {
+          store.close();
+        }
+      }, 30_000);
+      await waitUntil(
+        () =>
+          logs.filter((message) => message.startsWith("automatic state prune completed")).length ===
+          2,
+      );
+    } finally {
+      await client.close();
+      await host.stop();
+    }
+  }, 60_000);
+
+  it("keeps cleanup failures nonfatal and does not retry them in a tight loop", async () => {
+    const databasePath = path.join(
+      await makeTempDir("host-automatic-prune-failure"),
+      "state.sqlite",
+    );
+    const logs: string[] = [];
+    const host = new WorkflowServer({
+      databasePath,
+      claimPollMs: 10,
+      onLog: (message) => logs.push(message),
+    });
+    const lockPath = `${databasePath}.maintenance.lock`;
+    await fs.writeFile(lockPath, "busy");
+    await host.start();
+    try {
+      await waitUntil(
+        () =>
+          logs.filter((message) => message.startsWith("automatic state prune failed")).length === 1,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(
+        logs.filter((message) => message.startsWith("automatic state prune failed")),
+      ).toHaveLength(1);
+
+      await fs.rm(lockPath);
+      const internal = host as unknown as {
+        nextAutomaticStatePruneAttemptAt: number;
+        requestAutomaticStatePrune(): void;
+      };
+      internal.nextAutomaticStatePruneAttemptAt = 0;
+      internal.requestAutomaticStatePrune();
+      await waitUntil(() =>
+        logs.some((message) => message.startsWith("automatic state prune completed")),
+      );
+    } finally {
+      await fs.rm(lockPath, { force: true });
+      await host.stop();
+    }
+  });
 
   it("resolves a protected decision timeout and starts its continuation", async () => {
     const cwd = await makeTempDir("host-decision-timeout-project");


### PR DESCRIPTION
## Summary

Completed workflow history could grow without limit, and an older runner bug once amplified a small workload into a multi-gigabyte state database.
This change keeps completed workflow trees for 30 days, then removes only safe expired trees and unused blobs while all active or unsettled work stays protected.
It also adds measured regression tests so repeated runner replies cannot copy growing session history again.

## What Changed

Automatic and manual cleanup now use one set of safety rules.
The Workflow Server runs cleanup only while idle and does not add another service or state writer.

- Added shared selection, exact-tree deletion, unreferenced-blob collection, and compaction logic.
- Added 30-day automatic retention after server recovery and runner exits, with overlap coalescing and one completed sweep per 24 hours.
- Protected active, pending, resumable, recording, leased, unsettled, cross-linked, undelivered, and active-content state.
- Kept manual prune backup-first and made automatic cleanup create no backups.
- Reused free SQLite pages and limited automatic `VACUUM` to idle periods with at least 64 MiB and 20 percent reclaimable space.
- Added cleanup, scheduling, concurrency, idempotency, viewer, resume, and large-state amplification tests.
- Updated the canonical state, server, workflow, and implementation-plan documentation.

## Testing

The full repository checks, real Pi E2E tests, storage regressions, and a separate authenticated low-cost model run passed.

- `npm run check` — 99 files and 1,168 tests passed with coverage.
- `npm run test:e2e` — 3 files and 11 tests passed.
- `npx slophammer-ts@latest dry .` — passed with no candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required` — passed with no findings.
- `git diff --check` — passed.
- Installed-package live E2E with `openai/gpt-5.6-luna` through `openai-responses` on Pi 0.85.0 — passed.

SimpleDoc still reports the repository's existing broad filename and frontmatter migration baseline.
This change does not run that unrelated migration.

## Risks

Cleanup can remove completed workflow history older than 30 days, but it fails closed when ownership or safety is uncertain.
Recent or protected work can still be large, and physical file shrink depends on a safe, successful SQLite compaction.

- Cleanup failures remain nonfatal and do not enter a tight retry loop.
- Logical deletion remains valid when automatic compaction is skipped or fails.
- Pi session history is not changed.
