### PR TITLE
fix: preserve workflow handoffs and fixed run definitions

### DIFF
--- a/docs/2026-09-07-workflow-handoff-plan.md
+++ b/docs/2026-09-07-workflow-handoff-plan.md
@@ -56,5 +56,18 @@ issues must be identified, not silently repaired. Push before running
 
 ## Completion evidence
 
-Pending implementation and validation. Recovery of an installed live session is
-separate work and requires approval to update that installation.
+Implemented in PR #85. Local validation passed with 1,211 unit tests, 13 real-Pi
+mock-provider E2E tests, and 76 Rust tests. Slophammer, Clippy, and format checks
+passed. SimpleDoc reports the existing nine naming/frontmatter issues and 24
+reference updates.
+
+The final code commit passed the authenticated live test with
+`openrouter/deepseek/deepseek-v4-flash`, Pi 0.85.0, and a 4,096-token output
+allowance. It verified ordinary chat, a model tool start, exact submission,
+next-step completion, and saved conversation capture. The isolated Autoimplement
+test also verified actual temporary worktree creation before cancellation.
+
+The configured reviewer exited before review because its local provider
+configuration has an unknown field. Review, CI verification, and merge remain
+blocked; no alternate reviewer was substituted. Recovery of an installed live
+session is separate work and requires approval to update that installation.

--- a/docs/2026-09-07-workflow-handoff-plan.md
+++ b/docs/2026-09-07-workflow-handoff-plan.md
@@ -56,7 +56,7 @@ issues must be identified, not silently repaired. Push before running
 
 ## Completion evidence
 
-Implemented in PR #85. Local validation passed with 1,211 unit tests, 13 real-Pi
+Implemented in PR #85. Local validation passed with 1,215 unit tests, 13 real-Pi
 mock-provider E2E tests, and 76 Rust tests. Slophammer, Clippy, and format checks
 passed. SimpleDoc reports the existing nine naming/frontmatter issues and 24
 reference updates.
@@ -67,7 +67,11 @@ allowance. It verified ordinary chat, a model tool start, exact submission,
 next-step completion, and saved conversation capture. The isolated Autoimplement
 test also verified actual temporary worktree creation before cancellation.
 
-The configured reviewer exited before review because its local provider
-configuration has an unknown field. Review, CI verification, and merge remain
-blocked; no alternate reviewer was substituted. Recovery of an installed live
-session is separate work and requires approval to update that installation.
+The first reviewer attempt stopped on an unsupported local provider configuration.
+After that configuration was repaired, the configured reviewer found a P1 recovery
+case: a delivered step without an active workflow turn could claim an ordinary
+chat response. Recovery now requires the recorded active turn and its exact
+message as the latest user or custom input. Regression tests cover missing turn
+records and later ordinary input. Final review and CI verification remain pending.
+Recovery of an installed live session is separate work and requires approval to
+update that installation.

--- a/docs/2026-09-07-workflow-handoff-plan.md
+++ b/docs/2026-09-07-workflow-handoff-plan.md
@@ -1,0 +1,60 @@
+---
+title: Workflow handoff and fixed run definitions
+author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
+date: 2026-09-07
+status: in-progress
+---
+
+# Workflow handoff and fixed run definitions
+
+Keep the architecture small. Make ownership, delivery, and recovery rules explicit.
+This corrects regressions found after the [durable execution work](2026-09-06-durable-execution-plan.md).
+Normal chat currently leaves a turn record that blocks the first workflow message.
+Forced resume accepts changed source, then fails against the old saved graph.
+
+## Scope
+
+Change only pi-workflows. Implement, test, commit, push, review, and rebase-merge this
+change into main. Do not release, install packages into user profiles, alter live
+runs, reset databases, or modify Pi itself. No new workflow primitive, database,
+transport, persisted schema, compatibility path, or hidden model retry is needed.
+
+## Design
+
+- The extension tracks only workflow-owned turns. Its local states are absent,
+  delivering, running, and settled awaiting server acknowledgment. Normal chat
+  creates no owned turn. Pi automatic retries retain the same owned turn.
+- Save delivery identity before the public `sendMessage` call. Confirm delivery
+  from the public session branch. Retry reports with the same identity; never
+  resend a message merely because its acknowledgment was lost. Preserve an exact
+  settled response until submission and turn-end acknowledgment succeed.
+- Resume requires the original source and graph. Remove the `force` option.
+  Reject changes before any durable mutation. A changed definition requires an
+  explicit new run; accepted outputs and approvals are not silently transferred.
+- Derive delivery, active model work, required results, and pause labels from
+  existing message, turn, request, and run records. An unconfirmed message is not
+  proof that the agent received it. A start receipt proves only that a run exists.
+- Use Pi's public `agent_start`, `agent_end`, `agent_settled`, `sendMessage`, and
+  session branch APIs. Pi's normal message delivery appends the existing custom
+  message entry. There are no new Pi session fields or changes to Pi internals.
+
+## Acceptance and validation
+
+Tests must cover ordinary chat before and during start, full step delivery and
+submission, automatic retries, delayed branch and turn acknowledgments, reconnect,
+cancellation, pause/resume, and changed source or graph. Assert delivery counts,
+exact receipts, and durable state. Rejected resume must leave the run unchanged.
+Use real Pi with a mock provider for automated full-lifecycle tests, then a
+separate authenticated low-cost model for a tool-started live lifecycle.
+
+Run `npm run check`, `npm run test:e2e`,
+`npx slophammer-ts@latest dry .`, and
+`npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`.
+Run SimpleDoc and relevant Rust viewer checks. Existing unrelated documentation
+issues must be identified, not silently repaired. Push before running
+`pi-reviewer --base main`; address P0/P1 findings before checking CI and merging.
+
+## Completion evidence
+
+Pending implementation and validation. Recovery of an installed live session is
+separate work and requires approval to update that installation.

--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -122,8 +122,10 @@ The extension has one `WorkflowMessageCoordinator` for all message kinds. The se
 
 The coordinator retains only workflow-owned turns. Its local state is absent,
 delivering, running, or settled awaiting acknowledgment. An ordinary chat turn
-never creates an owned turn or blocks later workflow delivery. Recovery binds a
-running turn only to a server-owned message visible in the active Pi branch.
+never creates an owned turn or blocks later workflow delivery. Recovery requires
+an already recorded active workflow turn and its exact message as the latest
+user or custom input in the active Pi branch. A delivered step with no active
+workflow turn cannot claim a later ordinary chat response.
 A delayed acknowledgment retains the same message, turn ID, and exact response;
 it never creates another model attempt. Unconfirmed delivery stays visible as
 unconfirmed instead of being reported as a received step.
@@ -150,9 +152,10 @@ After Pi, the extension, or the server restarts, branch reporting runs before an
 ## Model-turn status
 
 `agent_start` has no message payload. A locally delivered prompt binds its start
-through the coordinator's saved message identity. Late binding and reconnect
-also require the exact message in the active branch. A session view alone does
-not prove that a message caused the current turn.
+through the coordinator's saved message identity. Reconnect requires the same
+recorded active turn, run, session, and message, with no later user or custom
+input in the active branch. Neither a session view nor an old branch entry alone
+proves that a message caused the current turn.
 
 Only pending, unpaused agent requests and explicit follow-ups can open model
 turns. Decisions, notifications, and terminal notices cannot. A stale start can

--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -120,6 +120,14 @@ Notifications keep the custom type `pi-workflows-notification` and use `triggerT
 
 The extension has one `WorkflowMessageCoordinator` for all message kinds. The server keeps one active coordinator connection and process-local epoch for each origin session. A replacement connection fences the old one, so two Pi processes cannot send for the same session.
 
+The coordinator retains only workflow-owned turns. Its local state is absent,
+delivering, running, or settled awaiting acknowledgment. An ordinary chat turn
+never creates an owned turn or blocks later workflow delivery. Recovery binds a
+running turn only to a server-owned message visible in the active Pi branch.
+A delayed acknowledgment retains the same message, turn ID, and exact response;
+it never creates another model attempt. Unconfirmed delivery stays visible as
+unconfirmed instead of being reported as a received step.
+
 The coordinator follows this sequence:
 
 1. After every server connection, wait for the complete origin-session view and report the active branch before any send or turn report.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -5,6 +5,23 @@ covers the file format, every node type, edge routing, the step contract the
 model sees, and how runs behave at runtime. For durable state, see
 [SQLITE_STATE.md](SQLITE_STATE.md).
 
+## Starting and resuming runs
+
+A successful start call confirms that a run was created. Wait for the delivered
+step contract before submitting an agent result. Report worktree creation or
+implementation progress only after the corresponding recorded steps succeed.
+The status view distinguishes unconfirmed step delivery, active agent work,
+required results, and a durable pause. Waiting uses a different glyph from pause.
+
+Resume uses the run's original source and graph, including ordinary workflows
+without included workflows. Source and graph checks run before any durable
+mutation. `WorkflowEngine.resumeRun` has no `force` option. Restore the original
+source to resume its accepted work, or explicitly start a new run for changed
+code. A new run does not inherit outputs, approvals, or effect receipts.
+File and built-in source identities verify code; callers of the direct engine
+API must supply source identity to detect callback-body changes that leave the
+structural graph unchanged.
+
 ## Workflow files
 
 A workflow is a TypeScript module whose default export is `defineWorkflow(...)`.

--- a/fixtures/layout/human-multigate.json
+++ b/fixtures/layout/human-multigate.json
@@ -204,7 +204,7 @@
         " ▶ ✓ first [checkpoint] 1 attempt · 1.0s",
         "                     │",
         "                     ▼",
-        "  ⏸ second [checkpoint] 1 attempt · 1.0s ■"
+        "  ○ second [checkpoint] 1 attempt · 1.0s ■"
       ]
     },
     {
@@ -223,7 +223,7 @@
         "  ┌─────────────────────────────┐",
         "  │           second            │ ■",
         "  ├─────────────────────────────┤",
-        "  │ ◆ checkpoint      ⏸ waiting │",
+        "  │ ◆ checkpoint      ○ waiting │",
         "  │ ↻ 1                  ◷ 1.0s │",
         "  │ … human decision · reviewer │",
         "  └─────────────────────────────┘"

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -854,7 +854,11 @@ async function runModelWorkflow(context, rpc, client, api) {
   stage(
     `running the real-model workflow through ${context.options.provider}/${context.options.model}`,
   );
-  await rpc.request("prompt", { message: `/workflow ${workflowName}` });
+  await rpc.request("prompt", { message: "Reply READY without using tools." });
+  await waitForPiIdle(rpc, MODEL_TIMEOUT_MS);
+  await rpc.request("prompt", {
+    message: `Use the workflow tool to start ${workflowName} exactly once with empty input. This is a workflow handoff test. After the start call, end your reply. Do not run commands or submit a step before its workflow message arrives.`,
+  });
   const run = await findRun(client, workflowName);
   const completed = await waitForRunDisplay(client, run.runId, "completed", MODEL_TIMEOUT_MS, rpc);
   const state = requireObject(completed.state, "model workflow state");
@@ -864,8 +868,8 @@ async function runModelWorkflow(context, rpc, client, api) {
       `Model workflow returned the wrong output: ${JSON.stringify(state.finalOutput)}`,
     );
   }
-  if (!Array.isArray(state.steps) || state.steps.length !== 1) {
-    throw new Error(`Model workflow recorded ${String(state.steps?.length)} steps instead of one`);
+  if (!Array.isArray(state.steps) || state.steps.length !== 2) {
+    throw new Error(`Model workflow recorded ${String(state.steps?.length)} steps instead of two`);
   }
   const step = requireObject(state.steps[0], "model workflow step");
   if (typeof step.attemptId !== "string" || step.outcome !== "ok") {
@@ -877,6 +881,19 @@ async function runModelWorkflow(context, rpc, client, api) {
 
   const entriesData = requireObject(await rpc.request("get_entries"), "Pi entries response");
   if (!Array.isArray(entriesData.entries)) throw new Error("Pi returned no session entries");
+  const starts = entriesData.entries.flatMap((entry) =>
+    entry.message?.role === "assistant" && Array.isArray(entry.message.content)
+      ? entry.message.content.filter(
+          (item) =>
+            item.type === "toolCall" &&
+            item.name === "workflow" &&
+            item.arguments?.action === "start" &&
+            item.arguments?.workflow === workflowName,
+        )
+      : [],
+  );
+  if (starts.length !== 1)
+    throw new Error(`Expected one model workflow start call, observed ${starts.length}`);
   const deliveries = entriesData.entries.filter(
     (entry) =>
       entry.type === "custom_message" &&

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -850,7 +850,7 @@ async function executeCommand(
         },
       });
       return {
-        message: `Started hosted workflow ${resolved.workflowName} as ${runId}.`,
+        message: `Created hosted workflow ${resolved.workflowName} as ${runId}. This confirms the run, not worktree creation or implementation. Complete the next delivered step using its exact contract.`,
         details: { action: "start", runId, response: response.receipt ?? null },
       };
     }

--- a/src/extension/widget.ts
+++ b/src/extension/widget.ts
@@ -54,7 +54,7 @@ export function nodeGlyph(
     return "◐";
   }
   if (state.waitingOn === nodeId) {
-    return "⏸";
+    return displayStatus === "paused" || state.paused === true ? "⏸" : "○";
   }
   const result = state.results[nodeId];
   if (!result) {

--- a/src/extension/workflow-message-coordinator.ts
+++ b/src/extension/workflow-message-coordinator.ts
@@ -23,14 +23,11 @@ type DeliveryCallbacks = {
   terminalDelivered?: (message: WorkflowMessage) => Promise<void>;
 };
 
-type PendingTurn = {
+type OwnedTurn = {
   workflowTurnId: string;
-  workflowMessageId: string | null;
-  runId: string | null;
-  message: WorkflowMessage | null;
+  message: WorkflowMessage;
   startedReported: boolean;
-  end: SettledTurn | null;
-};
+} & ({ phase: "delivering" | "running" } | { phase: "settled"; end: SettledTurn });
 
 /** Adds every server-owned workflow message to one Pi session through one public API path. */
 export class WorkflowMessageCoordinator {
@@ -40,8 +37,7 @@ export class WorkflowMessageCoordinator {
   private synchronizing = false;
   private lastBranchEpoch: string | null = null;
   private view: WorkflowSessionView | null = null;
-  private awaitingTurnMessage: WorkflowMessage | null = null;
-  private turn: PendingTurn | null = null;
+  private turn: OwnedTurn | null = null;
 
   updateView(view: WorkflowSessionView): void {
     this.view = view;
@@ -64,24 +60,15 @@ export class WorkflowMessageCoordinator {
   }
 
   startTurn(): void {
-    // Automatic Pi retries belong to the same unsettled workflow turn.
-    if (this.turn !== null) return;
-    const awaited = this.awaitingTurnMessage;
-    this.awaitingTurnMessage = null;
-    this.turn = {
-      workflowTurnId: `workflow-turn-${randomUUID()}`,
-      workflowMessageId: null,
-      runId: null,
-      message: null,
-      startedReported: false,
-      end: null,
-    };
-    if (awaited !== null) this.bindTurn(awaited);
+    // Ordinary chat owns no workflow turn. Automatic Pi retries retain the
+    // existing turn, including a settled result whose acknowledgment is pending.
+    if (this.turn?.phase === "delivering") this.turn = { ...this.turn, phase: "running" };
   }
 
   endTurn(stopReason: WorkflowTurnStopReason, responseSessionEntryId: string | null): void {
-    if (this.turn !== null && this.turn.end === null)
-      this.turn.end = { stopReason, responseSessionEntryId };
+    if (this.turn?.phase === "running") {
+      this.turn = { ...this.turn, phase: "settled", end: { stopReason, responseSessionEntryId } };
+    }
   }
 
   activeTurnMessage(): WorkflowMessage | undefined {
@@ -101,26 +88,18 @@ export class WorkflowMessageCoordinator {
       const view = this.view;
       if (!view.coordinatorActive || view.coordinatorEpoch === null) return;
       const branchEntries = branchWorkflowEntries(ctx.sessionManager.getBranch());
-      if (this.turn?.workflowMessageId === null) {
+      if (this.turn === null && !ctx.isIdle()) {
         const candidate = this.turnCandidate();
         if (candidate !== undefined && branchEntries.has(candidate.workflowMessageId)) {
-          this.bindTurn(candidate);
+          const open = view.openWorkflowTurn;
+          const recovered = open?.workflowMessageId === candidate.workflowMessageId ? open : null;
+          this.turn = {
+            workflowTurnId: recovered?.workflowTurnId ?? `workflow-turn-${randomUUID()}`,
+            message: candidate,
+            startedReported: recovered !== null,
+            phase: "running",
+          };
         }
-      }
-      if (
-        this.turn === null &&
-        !ctx.isIdle() &&
-        view.openWorkflowTurn !== null &&
-        branchEntries.has(view.openWorkflowTurn.workflowMessageId)
-      ) {
-        this.turn = {
-          workflowTurnId: view.openWorkflowTurn.workflowTurnId,
-          workflowMessageId: view.openWorkflowTurn.workflowMessageId,
-          runId: view.openWorkflowTurn.runId,
-          message: messageById(view, view.openWorkflowTurn.workflowMessageId) ?? null,
-          startedReported: true,
-          end: null,
-        };
       }
       if (
         view.branchReportRequired ||
@@ -170,7 +149,12 @@ export class WorkflowMessageCoordinator {
         return;
       }
       if (messageStartsTurn(message)) {
-        this.awaitingTurnMessage = message;
+        this.turn = {
+          workflowTurnId: `workflow-turn-${randomUUID()}`,
+          message,
+          startedReported: false,
+          phase: "delivering",
+        };
       }
       try {
         pi.sendMessage(
@@ -184,8 +168,11 @@ export class WorkflowMessageCoordinator {
         );
       } catch (error) {
         this.queued.delete(messageId);
-        if (this.awaitingTurnMessage?.workflowMessageId === messageId) {
-          this.awaitingTurnMessage = null;
+        if (
+          this.turn?.phase === "delivering" &&
+          this.turn.message.workflowMessageId === messageId
+        ) {
+          this.turn = null;
         }
         throw error;
       }
@@ -201,7 +188,6 @@ export class WorkflowMessageCoordinator {
     this.closedTurnMessages.clear();
     this.finalizedTerminals.clear();
     this.view = null;
-    this.awaitingTurnMessage = null;
     this.turn = null;
     this.lastBranchEpoch = null;
     this.synchronizing = false;
@@ -227,23 +213,15 @@ export class WorkflowMessageCoordinator {
     return undefined;
   }
 
-  private bindTurn(message: WorkflowMessage): void {
-    if (this.turn === null) return;
-    this.turn.workflowMessageId = message.workflowMessageId;
-    this.turn.runId = message.runId;
-    this.turn.message = message;
-  }
-
   private async flushTurn(
     client: WorkflowClient,
     view: WorkflowSessionView,
     beforeTurnEnd?: BeforeTurnEnd,
   ): Promise<void> {
-    const pending = this.turn;
+    let pending = this.turn;
     if (
       pending === null ||
-      pending.workflowMessageId === null ||
-      pending.runId === null ||
+      pending.phase === "delivering" ||
       view.coordinatorEpoch === null ||
       this.lastBranchEpoch !== view.coordinatorEpoch
     ) {
@@ -251,19 +229,24 @@ export class WorkflowMessageCoordinator {
     }
     let message = pending.message;
     if (!pending.startedReported) {
-      message = messageById(view, pending.workflowMessageId) ?? null;
-      if (message?.status !== "sent") return;
+      const confirmed = messageById(view, message.workflowMessageId);
+      if (confirmed?.status !== "sent") return;
+      message = confirmed;
       const receipt = await reportTurn(client, {
         state: "started",
-        workflowMessageId: pending.workflowMessageId,
+        workflowMessageId: message.workflowMessageId,
         workflowTurnId: pending.workflowTurnId,
-        runId: pending.runId,
+        runId: message.runId,
         targetSessionId: view.sessionId,
         coordinatorEpoch: view.coordinatorEpoch,
       });
+      // Pi can settle while the start report is in flight. Keep that exact
+      // response and do not restore a turn cleared by session shutdown.
+      if (this.turn?.workflowTurnId !== pending.workflowTurnId) return;
+      pending = this.turn;
       if (
         receipt.ownership !== "active" &&
-        !(receipt.ownership === "settled" && pending.end !== null)
+        !(receipt.ownership === "settled" && pending.phase === "settled")
       ) {
         this.turn = null;
         return;
@@ -271,28 +254,28 @@ export class WorkflowMessageCoordinator {
       pending.message = message;
       pending.startedReported = true;
     }
-    if (pending.end === null) return;
-    if (message !== null) await beforeTurnEnd?.(message, pending.end);
+    if (pending.phase !== "settled") return;
+    await beforeTurnEnd?.(message, pending.end);
     await reportTurn(client, {
       state: "ended",
-      workflowMessageId: pending.workflowMessageId,
+      workflowMessageId: message.workflowMessageId,
       workflowTurnId: pending.workflowTurnId,
-      runId: pending.runId,
+      runId: message.runId,
       targetSessionId: view.sessionId,
       coordinatorEpoch: view.coordinatorEpoch,
       stopReason: pending.end.stopReason,
       responseSessionEntryId: pending.end.responseSessionEntryId,
     });
-    if (message?.kind === "followUp") {
-      this.closedTurnMessages.add(pending.workflowMessageId);
+    if (message.kind === "followUp") {
+      this.closedTurnMessages.add(message.workflowMessageId);
     }
     for (const current of new Set([view, this.view])) {
       if (current?.openWorkflowTurn?.workflowTurnId === pending.workflowTurnId) {
         current.openWorkflowTurn = null;
       }
       if (
-        current?.openWorkflowMessageId === pending.workflowMessageId &&
-        message?.kind === "followUp"
+        current?.openWorkflowMessageId === message.workflowMessageId &&
+        message.kind === "followUp"
       ) {
         current.openWorkflowMessageId = null;
       }

--- a/src/extension/workflow-message-coordinator.ts
+++ b/src/extension/workflow-message-coordinator.ts
@@ -90,13 +90,19 @@ export class WorkflowMessageCoordinator {
       const branchEntries = branchWorkflowEntries(ctx.sessionManager.getBranch());
       if (this.turn === null && !ctx.isIdle()) {
         const candidate = this.turnCandidate();
-        if (candidate !== undefined && branchEntries.has(candidate.workflowMessageId)) {
-          const open = view.openWorkflowTurn;
-          const recovered = open?.workflowMessageId === candidate.workflowMessageId ? open : null;
+        const open = view.openWorkflowTurn;
+        if (
+          candidate !== undefined &&
+          open?.state === "started" &&
+          open.workflowMessageId === candidate.workflowMessageId &&
+          open.runId === candidate.runId &&
+          open.targetSessionId === view.sessionId &&
+          latestTurnInputIsWorkflow(ctx.sessionManager.getBranch(), candidate.workflowMessageId)
+        ) {
           this.turn = {
-            workflowTurnId: recovered?.workflowTurnId ?? `workflow-turn-${randomUUID()}`,
+            workflowTurnId: open.workflowTurnId,
             message: candidate,
-            startedReported: recovered !== null,
+            startedReported: true,
             phase: "running",
           };
         }
@@ -341,6 +347,27 @@ export function branchWorkflowEntries(entries: readonly unknown[]): Map<string, 
     if (typeof workflowMessageId === "string") found.set(workflowMessageId, value.id);
   }
   return found;
+}
+
+function latestTurnInputIsWorkflow(
+  entries: readonly unknown[],
+  workflowMessageId: string,
+): boolean {
+  for (const value of [...entries].reverse()) {
+    if (!isRecord(value)) continue;
+    if (
+      value.role === "user" ||
+      (value.type === "message" && isRecord(value.message) && value.message.role === "user")
+    ) {
+      return false;
+    }
+    if (value.type === "custom_message" || value.role === "custom") {
+      return (
+        isRecord(value.details) && value.details[WORKFLOW_MESSAGE_ID_FIELD] === workflowMessageId
+      );
+    }
+  }
+  return false;
 }
 
 export function responseEntryId(entries: readonly unknown[]): string | null {

--- a/src/render/graph-render.ts
+++ b/src/render/graph-render.ts
@@ -48,7 +48,7 @@ const STATUS_GLYPHS: Record<NodeStatus, string> = {
   timed_out: "×",
   active: "◐",
   replay_focus: "◆",
-  waiting: "⏸",
+  waiting: "○",
   cancelled: "~",
   queued: "·",
 };

--- a/src/server/view.ts
+++ b/src/server/view.ts
@@ -774,6 +774,7 @@ export class ServerViewStore {
       runnerActive: this.hasLiveRunner(queue.runId),
       originTurnActive: this.hasActivity(queue.runId),
       pendingRequestKind: this.pendingRequestKind(queue.runId),
+      requestDeliveryConfirmed: this.requestDeliveryConfirmed(queue.runId),
       errorMessage: state?.error ?? queue.errorMessage,
     });
   }
@@ -801,6 +802,18 @@ export class ServerViewStore {
       | { kind: Exclude<WorkflowDisplayFacts["pendingRequestKind"], null> }
       | undefined;
     return row?.kind ?? null;
+  }
+
+  private requestDeliveryConfirmed(runId: string): boolean {
+    const row = this.state.connection
+      .prepare(
+        `SELECT m.status FROM interactive_requests i
+       JOIN workflow_messages m ON m.source_id = i.request_id AND m.kind = 'step'
+       WHERE i.run_id = ? AND i.status = 'pending'
+       ORDER BY m.order_number DESC LIMIT 1`,
+      )
+      .get(runId) as { status: string } | undefined;
+    return row?.status === "sent";
   }
 
   private hasAmbiguousEffect(runId: string): boolean {
@@ -836,6 +849,7 @@ export class ServerViewStore {
       this.hasLiveRunner(runId),
       this.hasActivity(runId),
       this.pendingRequestKind(runId),
+      this.requestDeliveryConfirmed(runId),
       this.hasAmbiguousEffect(runId),
     ].join(":");
   }
@@ -869,6 +883,7 @@ export type WorkflowDisplayFacts = {
   runnerActive: boolean;
   originTurnActive: boolean;
   pendingRequestKind: "agent" | "assistant" | "checkpoint" | "decision" | null;
+  requestDeliveryConfirmed: boolean;
   errorMessage: string | null;
 };
 
@@ -909,6 +924,10 @@ export function reduceWorkflowDisplay(facts: WorkflowDisplayFacts): WorkflowDisp
             : facts.pendingRequestKind === "assistant"
               ? "The workflow needs its assigned visible response."
               : "The workflow is waiting.";
+    if (facts.pendingRequestKind === "agent" || facts.pendingRequestKind === "assistant") {
+      if (facts.originTurnActive) reason = "The agent is working on the workflow step.";
+      else if (!facts.requestDeliveryConfirmed) reason = "Workflow step delivery is not confirmed.";
+    }
   } else if (activity !== null) {
     status = "running";
   } else if (facts.queueStatus === "parked" || facts.queueStatus === "queued") {

--- a/src/workflows/engine.ts
+++ b/src/workflows/engine.ts
@@ -329,7 +329,6 @@ export class WorkflowEngine {
     runId: string,
     options: {
       workflowSource?: WorkflowSource;
-      force?: boolean;
       resumeInteractionAttemptId?: string;
     } = {},
   ): Promise<WorkflowRunResult> {
@@ -343,7 +342,7 @@ export class WorkflowEngine {
     const stored = await this.store.readRunState(runId);
     if (stored === null) throw new Error(`Cannot resume unreadable workflow run: ${runId}`);
     const sourceMismatch = workflowIdentityMismatch(stored, workflow, options.workflowSource);
-    if (sourceMismatch && options.force !== true) {
+    if (sourceMismatch) {
       throw new WorkflowSourceChangedError(runId);
     }
     const state = await this.store.prepareRunResume(runId);
@@ -395,7 +394,6 @@ export class WorkflowEngine {
         ...(point.nodeId !== null ? { resumeAt: point.nodeId } : {}),
         ...(resumedAttempt !== undefined ? { resumedAttemptId: resumedAttempt.attemptId } : {}),
         replayedSteps: state.steps.length,
-        ...(sourceMismatch ? { workflowSourceMismatch: true, forced: true } : {}),
       },
     });
     await this.onRunStarted?.(runId, state);
@@ -533,9 +531,7 @@ export class WorkflowEngine {
       ...(await this.resolveTitleBounded(workflow, input)),
       ...(workflowSource !== undefined ? { workflowSource } : {}),
       ...(composition?.sources.length ? { workflowSources: composition.sources } : {}),
-      ...(composition?.snapshot.mounts.length
-        ? { definitionDigest: definitionDigest(workflow) }
-        : {}),
+      definitionDigest: definitionDigest(workflow),
       startedAt: now,
       updatedAt: now,
       status: "running",
@@ -1778,8 +1774,7 @@ export function workflowIdentityMismatch(
   const metadata = compositionMetadata(workflow);
   const currentSources = metadata?.sources ?? [];
   if (!isDeepStrictEqual(state.workflowSources ?? [], currentSources)) return true;
-  const currentDigest = metadata?.snapshot.mounts.length ? definitionDigest(workflow) : undefined;
-  return state.definitionDigest !== currentDigest;
+  return state.definitionDigest !== definitionDigest(workflow);
 }
 
 function definitionDigest(workflow: WorkflowDefinition): string {

--- a/src/workflows/errors.ts
+++ b/src/workflows/errors.ts
@@ -54,12 +54,14 @@ export function isRunParkedError(error: unknown): error is RunParkedError {
   return error instanceof RunParkedError;
 }
 
-/** The workflow source changed after the run started; resume needs force. */
+/** A run can resume only with its original workflow source and definition. */
 export class WorkflowSourceChangedError extends Error {
   readonly runId: string;
 
   constructor(runId: string) {
-    super(`Workflow source changed since run ${runId} started; pass force to resume anyway`);
+    super(
+      `Workflow source or definition changed since run ${runId} started; restore the original definition to resume, or explicitly start a new run`,
+    );
     this.name = "WorkflowSourceChangedError";
     this.runId = runId;
   }

--- a/src/workflows/store.ts
+++ b/src/workflows/store.ts
@@ -19,7 +19,7 @@ import {
   type ViewerDeltaDraft,
 } from "../state/viewer.js";
 import { WorkflowMessageStore, workflowMessageIdFor } from "../state/workflow-messages.js";
-import { compositionMetadata } from "./composition.js";
+import { compileWorkflowDefinition, compositionMetadata } from "./composition.js";
 import { ClaimLostError } from "./errors.js";
 import { HumanDecisionStore } from "./human-decision.js";
 import { applyJsonPatch, validateJsonPatch } from "./json-patch.js";
@@ -844,7 +844,7 @@ export class WorkflowRunStore {
     options: InitializeWorkflowRunOptions = {},
   ): Promise<string> {
     return await this.initializeRunFromSnapshot(
-      createDefinitionSnapshot(workflow),
+      createDefinitionSnapshot(compileWorkflowDefinition(workflow)),
       workflow.name,
       state,
       options,
@@ -3608,9 +3608,7 @@ export class WorkflowRunStore {
       ...(row.title === null ? {} : { runTitle: row.title }),
       ...(sources.root === undefined ? {} : { workflowSource: sources.root }),
       ...(sources.mounted.length === 0 ? {} : { workflowSources: sources.mounted }),
-      ...(sources.mounted.length !== 0 || snapshot.composition?.mounts.length
-        ? { definitionDigest: `sha256:${row.definitionDigest.toString("hex")}` }
-        : {}),
+      definitionDigest: `sha256:${row.definitionDigest.toString("hex")}`,
       startedAt: new Date(row.createdAt).toISOString(),
       ...(row.finishedAt === null ? {} : { finishedAt: new Date(row.finishedAt).toISOString() }),
       updatedAt: new Date(row.updatedAt).toISOString(),

--- a/test/checkpoint-recovery.test.ts
+++ b/test/checkpoint-recovery.test.ts
@@ -55,8 +55,7 @@ describe("checkpoint recovery", () => {
       ).rejects.toThrow(WorkflowSourceChangedError);
       expect(store.readRun(waiting.runId, { includeTrace: true })).toEqual(before);
       const done = await engine.resumeRun(workflow, waiting.runId, {
-        workflowSource: { kind: "file", path: "/demo.ts", hash: "new" },
-        force: true,
+        workflowSource: { kind: "file", path: "/demo.ts", hash: "old" },
       });
       expect(done.state.status).toBe("completed");
     } finally {

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -9,7 +9,7 @@ import { buildWidgetView } from "../../src/extension/widget.js";
 import { branchWorkflowEntries } from "../../src/extension/workflow-message-coordinator.js";
 import { SqliteResourceManagerStore } from "../../src/resource-managers/sqlite.js";
 import { ServerStateStore } from "../../src/server/state.js";
-import { workflowStatePath } from "../../src/state/database.js";
+import { StateDatabase, workflowStatePath } from "../../src/state/database.js";
 import { parseJson, type JsonValue } from "../../src/state/json.js";
 import { WorkflowRunQueueStore } from "../../src/workflows/queue.js";
 import type { InteractiveRequestRecord } from "../../src/workflows/requests.js";
@@ -449,8 +449,44 @@ describe.sequential("out-of-process workflow server end to end", () => {
     mock = await startMockOpenAiServer(
       ({ messages, lastRole }) => {
         if (lastRole === "tool") return { kind: "text", text: "Workflow tool result accepted." };
+        if (JSON.stringify(messages.at(-1)?.content).includes("START_AUTOIMPLEMENT_HANDOFF_TEST")) {
+          const repository = path.join(projectDir, "autoimplement-repo");
+          return {
+            kind: "tool",
+            toolName: "workflow",
+            args: {
+              action: "start",
+              workflow: "autoimplement",
+              input: {
+                task: "Verify workspace preparation in this temporary test repository.",
+                plan: { summary: "Prepare a temporary worktree, then stop for test cancellation." },
+                repository,
+                baseBranch: "main",
+                workspaceMode: "worktree",
+                merge: false,
+                scope: `Only inspect and create a local task worktree in ${repository}. Do not implement, push, open a pull request, merge, release, deploy, or touch another repository.`,
+              },
+            },
+          };
+        }
         const contract = latestStepContract(messages);
         if (contract === null) return { kind: "text", text: "No workflow step is pending." };
+        if (contract.workflow === "autoimplement") {
+          if (contract.step === "workspace/propose")
+            return {
+              kind: "tool",
+              toolName: "workflow",
+              args: {
+                action: "submit",
+                requestId: contract.requestId,
+                output: { branchName: "test/handoff", reason: "Temporary workflow handoff test." },
+              },
+            };
+          return {
+            kind: "text",
+            text: "The workspace test is complete. Await cancellation without further work.",
+          };
+        }
         if (contract.workflow === "assistant-e2e" && contract.step === "prepare") {
           return {
             kind: "tool",
@@ -584,6 +620,89 @@ describe.sequential("out-of-process workflow server end to end", () => {
     await mock?.close();
   });
 
+  it("starts Autoimplement from normal chat and submits its first delivered step", async () => {
+    const repository = path.join(projectDir, "autoimplement-repo");
+    await fs.mkdir(repository);
+    await execFileAsync("git", ["init", "-b", "main", repository]);
+    await execFileAsync(
+      "git",
+      [
+        "-c",
+        "user.name=Workflow Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "test: initialize workspace",
+      ],
+      { cwd: repository },
+    );
+    pi.send({ id: "ordinary-chat", type: "prompt", message: "Respond with a short greeting." });
+    await waitForPiIdle(pi);
+    pi.send({
+      id: "tool-autoimplement-start",
+      type: "prompt",
+      message: "START_AUTOIMPLEMENT_HANDOFF_TEST",
+    });
+    const run = await waitForRun(
+      databasePath,
+      "autoimplement",
+      (state) => state.results["workspace/ready"]?.outcome === "ok",
+      () => rpcDiagnostic(pi),
+    );
+    await waitForPiIdle(pi);
+    const store = new WorkflowRunStore(databasePath, { readOnly: true });
+    let worktreePath: string;
+    try {
+      const saved = store.readRun(run.runId);
+      const workspace = saved?.state.outputs["workspace/ready"];
+      if (!isRecord(workspace) || typeof workspace.worktreePath !== "string")
+        throw new Error("Autoimplement did not save its worktree");
+      worktreePath = workspace.worktreePath;
+      await fs.stat(worktreePath);
+      expect(saved?.state.steps.filter((step) => step.nodeId === "workspace/propose")).toHaveLength(
+        1,
+      );
+      const state = new StateDatabase({ filePath: databasePath, mode: "read-only" });
+      try {
+        const rows = state.connection
+          .prepare(`SELECT i.status, i.consumed_at AS consumedAt, m.status AS deliveryStatus,
+          (SELECT COUNT(*) FROM interactive_submissions s WHERE s.request_id = i.request_id AND s.outcome = 'accepted') AS accepted
+          FROM interactive_requests i JOIN node_attempts a ON a.attempt_id = i.attempt_id
+          JOIN workflow_messages m ON m.source_id = i.request_id
+          WHERE i.run_id = ? AND a.node_id = 'workspace/propose'`)
+          .all(run.runId);
+        expect(rows).toEqual([
+          {
+            status: "settled",
+            consumedAt: expect.any(Number),
+            deliveryStatus: "sent",
+            accepted: 1,
+          },
+        ]);
+      } finally {
+        state.close();
+      }
+    } finally {
+      store.close();
+    }
+    pi.send({
+      id: "cancel-autoimplement-test",
+      type: "prompt",
+      message: `/workflow cancel ${run.runId}`,
+    });
+    await waitForRun(
+      databasePath,
+      "autoimplement",
+      (state) => state.status === "cancelled",
+      () => rpcDiagnostic(pi),
+    );
+    await waitForPiIdle(pi);
+    await execFileAsync("git", ["worktree", "remove", worktreePath], { cwd: repository });
+    await execFileAsync("git", ["branch", "-D", "test/handoff"], { cwd: repository });
+  });
+
   it("marks a completed agent node done while the next agent turn runs", async () => {
     const requestStart = mock.requests.length;
     pi.send({
@@ -665,7 +784,7 @@ describe.sequential("out-of-process workflow server end to end", () => {
         runView.display.status,
       ).lines;
       expect(lines.find((line) => line.includes("first"))).toContain("✓");
-      expect(lines.find((line) => line.includes("second"))).toContain("⏸");
+      expect(lines.find((line) => line.includes("second"))).toContain("○");
       expect(lines.join("\n")).toContain("second · waiting");
     } finally {
       store.close();

--- a/test/fixtures/live-e2e/model.workflow.ts
+++ b/test/fixtures/live-e2e/model.workflow.ts
@@ -1,4 +1,4 @@
-import { agent, defineWorkflow } from "@osolmaz/pi-workflows";
+import { agent, compute, defineWorkflow } from "@osolmaz/pi-workflows";
 
 export default defineWorkflow({
   name: "live-model-e2e",
@@ -6,9 +6,10 @@ export default defineWorkflow({
   nodes: {
     submit: agent({
       prompt: () =>
-        'Call the workflow tool exactly once. Before the call, compare the step and attempt arguments character-for-character with the appended workflow step contract. Submit this object: { "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }.',
+        'Call the workflow tool exactly once. Use the exact requestId from the appended workflow step contract. Submit this object: { "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }.',
       expectedOutput: '{ "smoke": "model-passed", "nonce": "pi-workflows-live-e2e" }',
     }),
+    finish: compute({ run: ({ outputs }) => outputs.submit }),
   },
-  edges: [],
+  edges: [{ from: "submit", to: "finish" }],
 });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -264,7 +264,7 @@ describe("resolveWorkflowRef", () => {
     await fs.appendFile(file, "\n// changed\n");
     await expect(
       resolveWorkflowSource(resolved.source, builtinWorkflowCatalog, "stored-run"),
-    ).rejects.toThrow(/source changed/i);
+    ).rejects.toThrow(/source or definition changed/i);
     await expect(
       resolveWorkflowSource({ kind: "builtin", id: "plain-summary", revision: "3" }),
     ).rejects.toThrow("No built-in workflow catalog");

--- a/test/run-resume.test.ts
+++ b/test/run-resume.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { agent, compute, defineWorkflow } from "../src/workflows/definition.js";
 import { WorkflowEngine } from "../src/workflows/engine.js";
 import { WorkflowSourceChangedError } from "../src/workflows/errors.js";
+import { WorkflowRunStore } from "../src/workflows/store.js";
 import { ScriptedExecutor, makeStateDatabasePath, waitUntil } from "./helpers.js";
 
 function workflow(counter: { count: number }) {
@@ -43,7 +44,7 @@ describe("WorkflowEngine.resumeRun SQLite", () => {
     expect(counter.count).toBe(1);
   });
 
-  it("rejects changed source unless force is explicit", async () => {
+  it("rejects changed source without changing the run, even with an obsolete force field", async () => {
     const databasePath = await makeStateDatabasePath("resume-source");
     const definition = workflow({ count: 0 });
     const executor = new ScriptedExecutor().respond("finish", { hang: true });
@@ -69,11 +70,51 @@ describe("WorkflowEngine.resumeRun SQLite", () => {
         workflowSource: { kind: "file", path: "/workflow.ts", hash: "new" },
       }),
     ).rejects.toThrow(WorkflowSourceChangedError);
-    const forced = await second.resumeRun(definition, "resume-source", {
-      workflowSource: { kind: "file", path: "/workflow.ts", hash: "new" },
-      force: true,
+    const store = new WorkflowRunStore(databasePath);
+    const before = store.readRun("resume-source", { includeTrace: true });
+    await expect(
+      second.resumeRun(definition, "resume-source", {
+        workflowSource: { kind: "file", path: "/workflow.ts", hash: "new" },
+        // @ts-expect-error force is no longer a supported resume option
+        force: true,
+      }),
+    ).rejects.toThrow(WorkflowSourceChangedError);
+    expect(store.readRun("resume-source", { includeTrace: true })).toEqual(before);
+    const resumed = await second.resumeRun(definition, "resume-source", {
+      workflowSource: { kind: "file", path: "/workflow.ts", hash: "old" },
     });
-    expect(forced.state.status).toBe("completed");
+    expect(resumed.state.status).toBe("completed");
+    store.close();
+  });
+
+  it("rejects a changed graph before dispatching or changing saved state", async () => {
+    const databasePath = await makeStateDatabasePath("resume-graph");
+    const definition = workflow({ count: 0 });
+    const executor = new ScriptedExecutor().respond("finish", { hang: true });
+    const first = new WorkflowEngine({ databasePath, executor });
+    const running = first.run(definition, {}, { runId: "resume-graph" });
+    await waitUntil(() => executor.requests.length === 1);
+    first.park();
+    await running;
+    const store = new WorkflowRunStore(databasePath);
+    const before = store.readRun("resume-graph", { includeTrace: true });
+    const nextExecutor = new ScriptedExecutor().respond("finish", { output: true });
+    const second = new WorkflowEngine({ store, executor: nextExecutor });
+    const changed = defineWorkflow({
+      ...definition,
+      nodes: { ...definition.nodes, added: compute({ run: () => "new work" }) },
+      edges: [
+        { from: "prepare", to: "finish" },
+        { from: "finish", to: "added" },
+      ],
+    });
+    await expect(second.resumeRun(changed, "resume-graph")).rejects.toThrow(
+      /explicitly start a new run/,
+    );
+    expect(store.readRun("resume-graph", { includeTrace: true })).toEqual(before);
+    expect(nextExecutor.requests).toHaveLength(0);
+    expect((await second.resumeRun(definition, "resume-graph")).state.status).toBe("completed");
+    store.close();
   });
 
   it("rejects a terminal run", async () => {

--- a/test/server-view.test.ts
+++ b/test/server-view.test.ts
@@ -33,6 +33,7 @@ const base: WorkflowDisplayFacts = {
   runnerActive: false,
   originTurnActive: false,
   pendingRequestKind: "agent",
+  requestDeliveryConfirmed: true,
   errorMessage: null,
 };
 
@@ -63,6 +64,22 @@ describe("host workflow display reducer", () => {
     expect(
       display({ durableStatus: "running", pendingRequestKind: null, queueStatus: "queued" }).status,
     ).toBe("queued");
+  });
+
+  it("distinguishes unconfirmed delivery, active work, required results, and pause", () => {
+    expect(display({ requestDeliveryConfirmed: false }).reason).toBe(
+      "Workflow step delivery is not confirmed.",
+    );
+    expect(display({ originTurnActive: true }).reason).toBe(
+      "The agent is working on the workflow step.",
+    );
+    expect(display({}).reason).toBe("The workflow needs its assigned agent result.");
+    expect(display({ pendingRequestKind: "assistant" }).reason).toBe(
+      "The workflow needs its assigned visible response.",
+    );
+    expect(display({ paused: true, requestDeliveryConfirmed: false }).reason).toBe(
+      "The workflow is durably paused.",
+    );
   });
 
   it("reports exact activity and allowed controls", () => {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -144,8 +144,9 @@ describe("nodeGlyph", () => {
     state.results.third = makeResult("third", "ok");
     expect(nodeGlyph(state, "first")).toBe("✓");
     expect(nodeGlyph(state, "second")).toBe("✗");
-    expect(nodeGlyph(state, "third")).toBe("⏸");
-    expect(nodeGlyph(makeState({ waitingOn: "third" }), "third")).toBe("⏸");
+    expect(nodeGlyph(state, "third")).toBe("○");
+    expect(nodeGlyph(makeState({ waitingOn: "third" }), "third")).toBe("○");
+    expect(nodeGlyph(makeState({ waitingOn: "third" }), "third", "paused")).toBe("⏸");
     expect(nodeGlyph(makeState({ waitingOn: "third" }), "third", "running")).toBe("◐");
     expect(nodeGlyph(makeState(), "first")).toBe("·");
   });
@@ -587,7 +588,7 @@ describe("buildWidgetLines", () => {
       TEST_THEME,
     ).lines;
     const waiting = waitingLines.find((line) => stripAnsi(line).includes("third")) ?? "";
-    expect(waiting).toContain("\u001b[33m⏸ ƒ ");
+    expect(waiting).toContain("\u001b[33m○ ƒ ");
     expect(waiting).toContain("\u001b[1mthird\u001b[22m");
   });
 
@@ -850,7 +851,7 @@ describe("buildWidgetLines", () => {
     ).lines;
     const waitingText = stripAnsi(waiting.join("\n"));
     expect(stripAnsi(waiting[0] ?? "")).toContain("○ workflow demo [waiting]");
-    expect(waitingText).toContain("⏸ ƒ third · waiting");
+    expect(waitingText).toContain("○ ƒ third · waiting");
 
     const paused = buildWidgetView(
       waitingState,
@@ -896,7 +897,7 @@ describe("buildWidgetLines", () => {
     expect(waitingText).not.toContain("\u001b[2J");
     expect(waitingText).not.toContain("\n");
     expect(waiting[0]).toContain("evil title");
-    expect(stripAnsi(waitingText)).toContain("⏸ ƒ third · waiting");
+    expect(stripAnsi(waitingText)).toContain("○ ƒ third · waiting");
     expect(stripAnsi(waiting.at(-1) ?? "")).toContain("waiting on step: third");
 
     const failed = buildWidgetLines(

--- a/test/workflow-message-coordinator.test.ts
+++ b/test/workflow-message-coordinator.test.ts
@@ -400,6 +400,72 @@ describe("WorkflowMessageCoordinator", () => {
     ).toHaveLength(2);
   });
 
+  it.each([
+    { recordedTurn: false, laterInput: null },
+    { recordedTurn: true, laterInput: { type: "message", message: { role: "user" } } },
+    { recordedTurn: true, laterInput: { role: "user" } },
+    { recordedTurn: true, laterInput: { type: "custom_message", details: {} } },
+  ])(
+    "does not recover ordinary chat as an outstanding step: %j",
+    async ({ recordedTurn, laterInput }) => {
+      const message = followUpMessage("sent");
+      message.kind = "step";
+      const current = view(message);
+      current.openWorkflowMessageId = message.workflowMessageId;
+      if (recordedTurn) {
+        current.openWorkflowTurn = {
+          schema: WORKFLOW_TURN_SCHEMA,
+          workflowTurnId: "old-workflow-turn",
+          workflowMessageId: message.workflowMessageId,
+          runId: message.runId,
+          targetSessionId: message.targetSessionId,
+          state: "started",
+          stopReason: null,
+          responseSessionEntryId: null,
+          startedAt: "2026-09-02T00:00:00.000Z",
+          endedAt: null,
+        };
+      }
+      const branch: unknown[] = [
+        { type: "custom_message", id: "entry-1", details: message.content.details },
+        { type: "message", id: "old-response", message: { role: "assistant" } },
+      ];
+      if (laterInput !== null) branch.push(laterInput);
+      const coordinator = new WorkflowMessageCoordinator();
+      coordinator.updateView(current);
+      const sendMessage = vi.fn();
+      const beforeTurnEnd = vi.fn(async () => undefined);
+      const request = vi.fn(async (options: Record<string, unknown>) =>
+        acceptedServerRequest(options),
+      );
+      let idle = false;
+      const ctx = {
+        isIdle: () => idle,
+        hasPendingMessages: () => false,
+        sessionManager: { getBranch: () => branch },
+      } as never;
+      const sync = () =>
+        coordinator.synchronize({ sendMessage } as never, { request } as never, ctx, {
+          beforeTurnEnd,
+        });
+      coordinator.startTurn();
+      await sync();
+      expect(coordinator.activeTurnMessage()).toBeUndefined();
+      coordinator.endTurn("completed", "ordinary-reply");
+      idle = true;
+      await sync();
+      expect(beforeTurnEnd).not.toHaveBeenCalled();
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(
+        request.mock.calls.filter(([call]) => call.operation === "workflowTurn.report"),
+      ).toEqual([]);
+      expect(current.openWorkflowMessageId).toBe(message.workflowMessageId);
+      expect(current.openWorkflowTurn?.workflowTurnId ?? null).toBe(
+        recordedTurn ? "old-workflow-turn" : null,
+      );
+    },
+  );
+
   it("keeps the accepted workflow turn through an automatic Pi retry", async () => {
     const message = followUpMessage("sent");
     const current = view(message);

--- a/test/workflow-message-coordinator.test.ts
+++ b/test/workflow-message-coordinator.test.ts
@@ -82,6 +82,175 @@ function view(message: WorkflowMessage): WorkflowSessionView {
 }
 
 describe("WorkflowMessageCoordinator", () => {
+  it.each(["before start", "during start"])(
+    "does not let normal chat block delivery %s",
+    async (timing) => {
+      const coordinator = new WorkflowMessageCoordinator();
+      const message = followUpMessage();
+      message.kind = "step";
+      const branch: Record<string, unknown>[] = [];
+      let idle = false;
+      const ctx = {
+        isIdle: () => idle,
+        hasPendingMessages: () => false,
+        sessionManager: { getBranch: () => branch },
+      } as never;
+      const sendMessage = vi.fn((entry: { details: unknown }) => {
+        branch.push({ type: "custom_message", id: "step-entry", details: entry.details });
+        idle = false;
+        coordinator.startTurn();
+      });
+      const request = vi.fn(async (options: Record<string, unknown>) =>
+        acceptedServerRequest(options),
+      );
+      const sync = () =>
+        coordinator.synchronize({ sendMessage } as never, { request } as never, ctx);
+      coordinator.startTurn();
+      if (timing === "during start") {
+        coordinator.updateView(view(message));
+        await sync();
+        expect(sendMessage).not.toHaveBeenCalled();
+      }
+      idle = true;
+      coordinator.endTurn("completed", "ordinary-reply");
+      coordinator.updateView(view(message));
+      await sync();
+      await sync();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(coordinator.activeTurnMessage()?.workflowMessageId).toBe(message.workflowMessageId);
+      const beforeTurnEnd = vi.fn(async () => undefined);
+      idle = true;
+      coordinator.endTurn("completed", "workflow-reply");
+      await coordinator.synchronize({ sendMessage } as never, { request } as never, ctx, {
+        beforeTurnEnd,
+      });
+      expect(beforeTurnEnd).toHaveBeenCalledWith(message, {
+        stopReason: "completed",
+        responseSessionEntryId: "workflow-reply",
+      });
+      expect(
+        request.mock.calls.filter(([call]) => call.operation === "workflowTurn.report"),
+      ).toHaveLength(2);
+    },
+  );
+
+  it("does not resend an unconfirmed delivery while ordinary events arrive", async () => {
+    const coordinator = new WorkflowMessageCoordinator();
+    coordinator.updateView(view(followUpMessage()));
+    const sendMessage = vi.fn();
+    const request = vi.fn(async (options: Record<string, unknown>) =>
+      acceptedServerRequest(options),
+    );
+    const ctx = {
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      sessionManager: { getBranch: () => [] },
+    } as never;
+    for (let count = 0; count < 3; count++) {
+      await coordinator.synchronize({ sendMessage } as never, { request } as never, ctx);
+      coordinator.endTurn("completed", "unrelated-reply");
+    }
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeTurnMessage()).toBeUndefined();
+    expect(request.mock.calls.every(([call]) => call.operation !== "workflowTurn.report")).toBe(
+      true,
+    );
+  });
+
+  it("retries a lost turn-end acknowledgment without replacing or redelivering the result", async () => {
+    const coordinator = new WorkflowMessageCoordinator();
+    const message = followUpMessage();
+    coordinator.updateView(view(message));
+    const branch: Record<string, unknown>[] = [];
+    const sendMessage = vi.fn((entry: { details: unknown }) => {
+      branch.push({ type: "custom_message", id: "step-entry", details: entry.details });
+      coordinator.startTurn();
+    });
+    let loseEnd = true;
+    const request = vi.fn(async (options: Record<string, unknown>) => {
+      if (
+        options.operation === "workflowTurn.report" &&
+        (options.payload as { state: string }).state === "ended" &&
+        loseEnd
+      ) {
+        loseEnd = false;
+        throw new Error("Lost end acknowledgment");
+      }
+      return acceptedServerRequest(options);
+    });
+    const ctx = {
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      sessionManager: { getBranch: () => branch },
+    } as never;
+    const beforeTurnEnd = vi.fn(
+      async (_message: WorkflowMessage, _end: { responseSessionEntryId: string | null }) =>
+        undefined,
+    );
+    const sync = () =>
+      coordinator.synchronize({ sendMessage } as never, { request } as never, ctx, {
+        beforeTurnEnd,
+      });
+    await sync();
+    coordinator.endTurn("completed", "exact-reply");
+    await expect(sync()).rejects.toThrow("Lost end acknowledgment");
+    coordinator.startTurn();
+    coordinator.endTurn("error", "other-reply");
+    await sync();
+    const ends = request.mock.calls
+      .map(([call]) => call)
+      .filter(
+        (call) =>
+          call.operation === "workflowTurn.report" &&
+          (call.payload as { state: string }).state === "ended",
+      );
+    expect(ends).toHaveLength(2);
+    expect(ends[0]).toEqual(ends[1]);
+    expect(
+      beforeTurnEnd.mock.calls.every(([, end]) => end.responseSessionEntryId === "exact-reply"),
+    ).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeTurnMessage()).toBeUndefined();
+  });
+
+  it("keeps a response that settles while the start acknowledgment is in flight", async () => {
+    const coordinator = new WorkflowMessageCoordinator();
+    const message = followUpMessage();
+    coordinator.updateView(view(message));
+    const branch: Record<string, unknown>[] = [];
+    const sendMessage = vi.fn((entry: { details: unknown }) => {
+      branch.push({ type: "custom_message", id: "prompt", details: entry.details });
+      coordinator.startTurn();
+    });
+    const request = vi.fn(async (options: Record<string, unknown>) => {
+      if (
+        options.operation === "workflowTurn.report" &&
+        (options.payload as { state: string }).state === "started"
+      ) {
+        await Promise.resolve();
+        coordinator.endTurn("completed", "response-during-ack");
+      }
+      return acceptedServerRequest(options);
+    });
+    const beforeTurnEnd = vi.fn(async () => undefined);
+    const ctx = {
+      isIdle: () => true,
+      hasPendingMessages: () => false,
+      sessionManager: { getBranch: () => branch },
+    } as never;
+    await coordinator.synchronize({ sendMessage } as never, { request } as never, ctx, {
+      beforeTurnEnd,
+    });
+    expect(beforeTurnEnd).toHaveBeenCalledWith(message, {
+      stopReason: "completed",
+      responseSessionEntryId: "response-during-ack",
+    });
+    expect(
+      request.mock.calls.filter(([call]) => call.operation === "workflowTurn.report"),
+    ).toHaveLength(2);
+    expect(coordinator.activeTurnMessage()).toBeUndefined();
+  });
+
   it("finalizes a delivered terminal notice once, without starting a turn", async () => {
     const message = followUpMessage("sent");
     message.kind = "terminal";

--- a/tui/src/render.rs
+++ b/tui/src/render.rs
@@ -43,7 +43,7 @@ impl NodeStatus {
             NodeStatus::TimedOut => '×',
             NodeStatus::Active => '◐',
             NodeStatus::ReplayFocus => '◆',
-            NodeStatus::Waiting => '⏸',
+            NodeStatus::Waiting => '○',
             NodeStatus::Cancelled => '~',
             NodeStatus::Queued => '·',
         }

--- a/tui/src/ui/mod.rs
+++ b/tui/src/ui/mod.rs
@@ -1614,8 +1614,8 @@ fn status_glyph(status: RunStatus) -> &'static str {
     match status {
         RunStatus::Queued => "·",
         RunStatus::Running => "◐",
-        RunStatus::Waiting => "⏸",
-        RunStatus::Paused => "Ⅱ",
+        RunStatus::Waiting => "○",
+        RunStatus::Paused => "⏸",
         RunStatus::Completed => "✓",
         RunStatus::Failed => "✗",
         RunStatus::TimedOut => "×",

--- a/tui/src/ui/timeline.rs
+++ b/tui/src/ui/timeline.rs
@@ -327,8 +327,8 @@ fn status_glyph(status: RunStatus) -> &'static str {
     match status {
         RunStatus::Queued => "·",
         RunStatus::Running => "◐",
-        RunStatus::Waiting => "⏸",
-        RunStatus::Paused => "Ⅱ",
+        RunStatus::Waiting => "○",
+        RunStatus::Paused => "⏸",
         RunStatus::Completed => "✓",
         RunStatus::Failed => "✗",
         RunStatus::TimedOut => "×",
@@ -353,6 +353,14 @@ fn status_color(status: RunStatus, palette: &Palette) -> ratatui::style::Color {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn waiting_and_paused_have_distinct_glyphs() {
+        assert_eq!(status_glyph(RunStatus::Waiting), "○");
+        assert_eq!(status_glyph(RunStatus::Paused), "⏸");
+        assert_eq!(super::super::status_glyph(RunStatus::Waiting), "○");
+        assert_eq!(super::super::status_glyph(RunStatus::Paused), "⏸");
+    }
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

A normal chat reply could leave Pi Workflows waiting for a step that it never delivered.
The coordinator now retains only workflow-owned turns, including exact results awaiting acknowledgment.
Resume rejects changed source or graph before changing saved work, and waiting no longer uses the pause symbol.
This corrects regressions found after #84.

## What Changed

Normal chat no longer creates an owned workflow turn.
Delivery and turn reports retain their identities through lost acknowledgments and Pi retries.
Recovery requires a recorded active turn and its exact message as the latest user or custom input; an old delivered step cannot claim an ordinary chat reply.

- Use local delivering, running, and settled states, with no new database or Pi API.
- Remove the forced-resume option and verify every graph, including workflows without includes.
- Distinguish unconfirmed delivery, active agent work, required results, and pause using existing records.
- Keep Pi and Rust waiting symbols consistent. A start receipt confirms only run creation.
- Add a real-Pi Autoimplement test that starts from chat, submits `workspace/propose`, creates a temporary worktree, and cancels before implementation.
- Change the low-cost live test to use a model tool start after ordinary chat, then verify submission, next-step completion, and saved conversation capture.

The implementation follows [the handoff plan](docs/2026-09-07-workflow-handoff-plan.md).

## Testing

Local validation is complete: 1,215 unit tests, 13 Pi E2E tests, and 76 Rust tests passed.
The configured Pi Reviewer completed with no findings after its P1 recovery finding was fixed.
All CI jobs passed: check, E2E, installed-package E2E, and Rust checks. The check job passed on an unchanged retry after one lease-renewal test timed out; that test also passed in the full local suite and a focused run.
The automated Pi tests include Autoimplement, pause/resume, and a real Pi restart.
The live test passed with `openrouter/deepseek/deepseek-v4-flash` on Pi 0.85.0, with a 4,096-token output allowance.

Required commands include `npm run check`, `npm run test:e2e`, the Slophammer DRY and dependency checks, and Rust test, Clippy, and format checks.
SimpleDoc reports the same existing nine naming/frontmatter issues and 24 reference updates; this change does not migrate those documents.

## Risks

Callers must restore the original workflow source to resume saved work, or explicitly start a new run for a changed definition.
Direct engine callers must provide source identity to detect callback-body changes that leave the structural graph unchanged.
An unconfirmed delivery remains visible as uncertain; it does not trigger another model attempt.
No live database, installed package, release, or existing user workflow was changed.
