### PR TITLE
fix: show active workflow work as running

### DIFF
--- a/docs/2026-09-07-workflow-handoff-plan.md
+++ b/docs/2026-09-07-workflow-handoff-plan.md
@@ -2,7 +2,7 @@
 title: Workflow handoff and fixed run definitions
 author: Onur Solmaz <2453968+osolmaz@users.noreply.github.com>
 date: 2026-09-07
-status: complete
+status: in-progress
 ---
 
 # Workflow handoff and fixed run definitions
@@ -54,7 +54,23 @@ Run SimpleDoc and relevant Rust viewer checks. Existing unrelated documentation
 issues must be identified, not silently repaired. Push before running
 `pi-reviewer --base main`; address P0/P1 findings before checking CI and merging.
 
-## Completion evidence
+## Remaining display correction
+
+The earlier completion claim was incomplete: active agent work still displayed `waiting`.
+Correct the shared display reducer without changing durable execution state. A nonterminal,
+unpaused run with an active workflow-owned Pi turn or supervised runner displays `running`.
+With no active work, a pending request displays `waiting`. Terminal, ambiguous, and paused states
+retain precedence. Ordinary chat is not workflow activity.
+
+Derive response controls from the exact pending request in both running and waiting displays.
+Keep agent submit/update, ordinary checkpoint answer, and protected human decisions separate.
+Changing a label must not hide valid response controls or expose them on paused or terminal runs.
+Update reducer, list, detail, widget, and real-Pi tests; retain assertions that durable agent state
+can remain waiting while the display says running. Run the required local checks, isolated
+low-cost live E2E, configured Pi Reviewer, and CI before merging. Release, installation, headless
+recovery, and detached-process control are not part of this correction.
+
+## Earlier completion evidence
 
 Implemented in PR #85. Local validation passed with 1,215 unit tests, 13 real-Pi
 mock-provider E2E tests, and 76 Rust tests. Slophammer, Clippy, and format checks

--- a/docs/2026-09-07-workflow-handoff-plan.md
+++ b/docs/2026-09-07-workflow-handoff-plan.md
@@ -65,6 +65,8 @@ retain precedence. Ordinary chat is not workflow activity.
 Derive response controls from the exact pending request in both running and waiting displays.
 Keep agent submit/update, ordinary checkpoint answer, and protected human decisions separate.
 Changing a label must not hide valid response controls or expose them on paused or terminal runs.
+Invalidate cached list/session views when supervised runner activity starts or ends, as well as
+when origin Pi activity changes. A cached running status must return to waiting after handoff.
 Update reducer, list, detail, widget, and real-Pi tests; retain assertions that durable agent state
 can remain waiting while the display says running. Run the required local checks, isolated
 low-cost live E2E, configured Pi Reviewer, and CI before merging. Release, installation, headless

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -187,6 +187,13 @@ cancel an expired running row. Resume refuses changed workflow source.
 
 Sends a prompt to the model. `expectedOutput` selects one of two output forms.
 
+While the workflow-owned Pi turn or supervised runner is active, the visible run status is
+`running`. The durable agent request can still be waiting for its result. With no active work,
+a pending request displays `waiting`. Pause, ambiguity, and terminal outcomes retain precedence.
+The exact pending request determines response controls in both running and waiting displays:
+agent steps retain `submit` and `update`, checkpoints retain `answer`, and protected decisions
+retain only their human response path. Ordinary chat is not workflow activity.
+
 `allowedTools` optionally restricts a step to exact tool names, for example `allowedTools: ["read", "grep", "find", "ls"]`. Omit it for the normal tool set; use `[]` to permit only matching workflow `submit` and `update` calls. Do not include `workflow` in the list. Restrictions remain in composed child graphs, definition snapshots, and the durable step contract. Changing them requires a new run under the fixed-definition rule.
 
 The origin Pi extension blocks other calls through public `tool_call` before execution, including while delivery acknowledgment is pending. It applies the restriction only to the workflow-owned running turn, not later ordinary chat. This is an exact tool allowlist, not a filesystem sandbox: authors must trust the implementations of the tools they allow. No shell is implicitly read-only.

--- a/docs/WORKFLOW_STEP_MESSAGES.md
+++ b/docs/WORKFLOW_STEP_MESSAGES.md
@@ -180,9 +180,13 @@ advances the request revision, and creates one resumed step message when needed.
 A protected decision keeps its answer revision and decision message. A missing
 submission stays pending: the host adds no reminder turn or hidden retry limit.
 
-Execution status and Pi activity remain separate. A completed run remains
-completed during reporting or follow-up work. A waiting run can have an active
-origin-session turn without changing its execution status to running. Host
+Durable execution status and the visible status remain separate. A completed run remains
+completed during reporting or follow-up work. An agent request can remain durably waiting
+while its workflow-owned Pi turn is active; the visible status is `running` during that work.
+An active supervised runner also displays `running`. Without active workflow work, a pending
+request displays `waiting`. Paused, ambiguous, and terminal states retain precedence. Ordinary
+chat does not count as workflow activity. Response controls follow the exact pending request
+in both running and waiting displays, not the visible label alone. Host
 recovery closes active-time intervals at their last durable samples, not the Pi
 turn itself. Only an idle-session branch report can prove an unended turn lost.
 

--- a/scripts/live-e2e.mjs
+++ b/scripts/live-e2e.mjs
@@ -887,6 +887,23 @@ async function runModelWorkflow(context, rpc, client, api) {
       return false;
     }
   };
+  const active = await waitFor(
+    "the live model's running workflow display",
+    async () => {
+      const view = await client.getRun(run.runId);
+      return view?.display?.activity === "origin_turn" ? view : false;
+    },
+    { rpc, timeoutMs: MODEL_TIMEOUT_MS },
+  );
+  if (
+    active.display.status !== "running" ||
+    !active.display.controls.includes("submit") ||
+    !active.display.controls.includes("update")
+  ) {
+    throw new Error(
+      `Active workflow display or response controls are incorrect: ${JSON.stringify(active.display)}`,
+    );
+  }
   const completed = await waitForRunDisplay(client, run.runId, "completed", MODEL_TIMEOUT_MS, rpc);
   const state = requireObject(completed.state, "model workflow state");
   const expected = {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -621,7 +621,7 @@ export class WorkflowServer {
       this.sessionCoordinators.delete(sessionId);
       changed = true;
     }
-    if (changed) this.views.noteOriginActivityChange();
+    if (changed) this.views.noteWorkflowActivityChange();
   }
 
   private async handleClientRequest(
@@ -693,7 +693,7 @@ export class WorkflowServer {
               needsTimerResume: true,
             } satisfies SessionCoordinator;
             this.sessionCoordinators.set(sessionId, coordinator);
-            this.views.noteOriginActivityChange();
+            this.views.noteWorkflowActivityChange();
             this.publishViews();
             return clientResponse(request.requestId, "accepted", {
               subscribed: true,
@@ -1017,7 +1017,7 @@ export class WorkflowServer {
       coordinator.needsTimerResume = false;
     });
     for (const runId of reconciledRunIds) this.tryEnsureTerminalWorkflowMessage(runId);
-    this.views.noteOriginActivityChange();
+    this.views.noteWorkflowActivityChange();
     this.publishViews();
     return clientResponse(request.requestId, "accepted", {
       recorded: true,
@@ -1108,7 +1108,7 @@ export class WorkflowServer {
       return workflowTurnReceipt("active", this.serverState.workflowMessages.startTurn(report));
     });
     coordinator.modelTurnActive = receipt.ownership === "active";
-    this.views.noteOriginActivityChange();
+    this.views.noteWorkflowActivityChange();
     this.publishViews();
     if (receipt.ownership === "settled") this.tryEnsureTerminalWorkflowMessage(report.runId);
     return clientResponse(request.requestId, outcome, receipt as unknown as JsonValue);
@@ -3773,6 +3773,7 @@ export class WorkflowServer {
       contentDigests: new Set(),
     };
     this.activeRuns.set(runId, active);
+    this.views.noteWorkflowActivityChange();
     this.clearPendingStart(runId, claimToken);
     try {
       this.runStore.synchronizeRevision(runId);
@@ -3825,6 +3826,7 @@ export class WorkflowServer {
     } finally {
       this.reapRunnerDescendants(envelope.runnerEpoch);
       this.activeRuns.delete(runId);
+      this.views.noteWorkflowActivityChange();
       this.requestAutomaticStatePrune();
     }
   }

--- a/src/server/view.ts
+++ b/src/server/view.ts
@@ -936,6 +936,11 @@ export function reduceWorkflowDisplay(facts: WorkflowDisplayFacts): WorkflowDisp
   } else if (facts.paused) {
     status = "paused";
     reason = "The workflow is durably paused.";
+  } else if (activity !== null) {
+    status = "running";
+    reason = facts.originTurnActive
+      ? "The agent is working on the workflow step."
+      : "The workflow runner is working.";
   } else if (facts.pendingRequestKind !== null || facts.durableStatus === "waiting") {
     status = "waiting";
     reason =
@@ -949,11 +954,8 @@ export function reduceWorkflowDisplay(facts: WorkflowDisplayFacts): WorkflowDisp
               ? "The workflow needs its assigned visible response."
               : "The workflow is waiting.";
     if (facts.pendingRequestKind === "agent" || facts.pendingRequestKind === "assistant") {
-      if (facts.originTurnActive) reason = "The agent is working on the workflow step.";
-      else if (!facts.requestDeliveryConfirmed) reason = "Workflow step delivery is not confirmed.";
+      if (!facts.requestDeliveryConfirmed) reason = "Workflow step delivery is not confirmed.";
     }
-  } else if (activity !== null) {
-    status = "running";
   } else if (facts.queueStatus === "parked" || facts.queueStatus === "queued") {
     status = "queued";
     reason =
@@ -976,7 +978,7 @@ export function reduceWorkflowDisplay(facts: WorkflowDisplayFacts): WorkflowDisp
     if (facts.queueStatus === "parked") controls.push("resume");
     controls.push("cancel");
   }
-  if (status === "waiting") {
+  if (status === "waiting" || status === "running") {
     if (facts.pendingRequestKind === "checkpoint") controls.push("answer");
     if (facts.pendingRequestKind === "decision") controls.push("human-answer");
     if (facts.pendingRequestKind === "agent") controls.push("update", "submit");

--- a/src/server/view.ts
+++ b/src/server/view.ts
@@ -69,7 +69,7 @@ export class ServerViewStore {
   private readonly runCache = new Map<string, { version: string; view: WorkflowRunView | null }>();
   private readonly sessionCache = new Map<string, { version: string; view: WorkflowSessionView }>();
   private contentBytes = 0;
-  private originActivityRevision = 0;
+  private activityRevision = 0;
   private readonly workflowMessages: WorkflowMessageStore;
 
   constructor(
@@ -83,8 +83,8 @@ export class ServerViewStore {
     this.workflowMessages = serverState.workflowMessages;
   }
 
-  noteOriginActivityChange(): void {
-    this.originActivityRevision += 1;
+  noteWorkflowActivityChange(): void {
+    this.activityRevision += 1;
   }
 
   list(cursor = 0, limit?: number): WorkflowRunListPage {
@@ -782,8 +782,8 @@ export class ServerViewStore {
     return isObjectRecord(row) &&
       typeof row.messageUpdatedAt === "number" &&
       typeof row.turnUpdatedAt === "number"
-      ? `${row.messageUpdatedAt}:${row.turnUpdatedAt}${this.originActivityRevision === 0 ? "" : `-${this.originActivityRevision}`}`
-      : `0:0${this.originActivityRevision === 0 ? "" : `-${this.originActivityRevision}`}`;
+      ? `${row.messageUpdatedAt}:${row.turnUpdatedAt}${this.activityRevision === 0 ? "" : `-${this.activityRevision}`}`
+      : `0:0${this.activityRevision === 0 ? "" : `-${this.activityRevision}`}`;
   }
 
   private display(

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -824,14 +824,18 @@ describe.sequential("out-of-process workflow server end to end", () => {
     await waitForCondition(
       async () => {
         runView = await client.getRun(runId);
-        return runView?.display.status === "waiting" && runView.display.activity === "origin_turn";
+        return runView?.display.status === "running" && runView.display.activity === "origin_turn";
       },
       () => rpcDiagnostic(pi),
       10_000,
     );
     await client.close();
     if (runView === null) throw new Error("Multi-step widget run view disappeared");
-    expect(runView.display).toMatchObject({ status: "waiting", activity: "origin_turn" });
+    expect(runView.display).toMatchObject({
+      status: "running",
+      activity: "origin_turn",
+      controls: ["pause", "cancel", "update", "submit"],
+    });
     expect(runView.state).toMatchObject({
       status: "waiting",
       waitingOn: "second",
@@ -847,7 +851,7 @@ describe.sequential("out-of-process workflow server end to end", () => {
       ["--import", "tsx", path.join(REPO_ROOT, "src", "viewer", "cli.ts"), "view", runId, "--once"],
       { cwd: REPO_ROOT, env: { ...process.env, ...piEnvironment() } },
     );
-    expect(piwOutput).toContain("waiting");
+    expect(piwOutput).toContain("running");
     expect(piwOutput).toContain("✓ first · ok");
     expect(piwOutput).not.toContain("● running");
 

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -880,8 +880,9 @@ describe.sequential("out-of-process workflow server end to end", () => {
         runView.display.status,
       ).lines;
       expect(lines.find((line) => line.includes("first"))).toContain("✓");
-      expect(lines.find((line) => line.includes("second"))).toContain("○");
-      expect(lines.join("\n")).toContain("second · waiting");
+      expect(lines.find((line) => line.includes("second"))).toContain("◐");
+      expect(lines.join("\n")).not.toContain("second · waiting");
+      expect(lines[0]).toContain("[running]");
     } finally {
       store.close();
     }

--- a/test/e2e/workflow.e2e.test.ts
+++ b/test/e2e/workflow.e2e.test.ts
@@ -851,9 +851,9 @@ describe.sequential("out-of-process workflow server end to end", () => {
       ["--import", "tsx", path.join(REPO_ROOT, "src", "viewer", "cli.ts"), "view", runId, "--once"],
       { cwd: REPO_ROOT, env: { ...process.env, ...piEnvironment() } },
     );
-    expect(piwOutput).toContain("running");
+    expect(piwOutput).toContain("● running");
     expect(piwOutput).toContain("✓ first · ok");
-    expect(piwOutput).not.toContain("● running");
+    expect(piwOutput).not.toMatch(/first[^\n]*● running/);
 
     const store = new WorkflowRunStore(databasePath, { readOnly: true });
     try {

--- a/test/fixtures/live-e2e/model.workflow.ts
+++ b/test/fixtures/live-e2e/model.workflow.ts
@@ -36,8 +36,11 @@ export default defineWorkflow({
         const source = `const fs = require('node:fs'); fs.writeFileSync(${JSON.stringify(path.join(directory, "live-timeout-partial.txt"))}, 'saved repair'); fs.writeFileSync(${JSON.stringify(path.join(directory, "live-timeout-command.pid"))}, String(process.pid)); setInterval(() => {}, 1000); setTimeout(() => process.exit(0), 180000);`;
         return [
           "This is an intentional timeout and cancellation test in an isolated temporary directory.",
-          "Call bash exactly once with the command below. It saves partial work and waits. Do not submit a workflow result or shorten the wait. The workflow will abort this command and deliver a recovery step.",
-          `${JSON.stringify(process.execPath)} -e ${JSON.stringify(source)}`,
+          "Call bash exactly once with the exact JSON arguments below, including timeout: 180 (seconds). Do not use a 10-second or other shorter tool timeout. The command saves partial work and waits. Do not submit a workflow result. The workflow will abort this command after its 60-second active-work deadline and deliver a recovery step.",
+          JSON.stringify({
+            command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(source)}`,
+            timeout: 180,
+          }),
         ].join("\n");
       },
     }),

--- a/test/server-view.test.ts
+++ b/test/server-view.test.ts
@@ -55,8 +55,8 @@ describe("host workflow display reducer", () => {
       "failed",
     );
     expect(display({ paused: true, runnerActive: true }).status).toBe("paused");
-    expect(display({ runnerActive: true }).status).toBe("waiting");
-    expect(display({ originTurnActive: true }).status).toBe("waiting");
+    expect(display({ runnerActive: true }).status).toBe("running");
+    expect(display({ originTurnActive: true }).status).toBe("running");
     expect(display({}).status).toBe("waiting");
     expect(
       display({ durableStatus: "running", pendingRequestKind: null, queueStatus: "parked" }).status,
@@ -64,6 +64,31 @@ describe("host workflow display reducer", () => {
     expect(
       display({ durableStatus: "running", pendingRequestKind: null, queueStatus: "queued" }).status,
     ).toBe("queued");
+  });
+
+  it.each([
+    { kind: "agent", responses: ["update", "submit"] },
+    { kind: "assistant", responses: [] },
+    { kind: "checkpoint", responses: ["answer"] },
+    { kind: "decision", responses: ["human-answer"] },
+    { kind: null, responses: [] },
+  ] as const)("keeps $kind controls correct across activity changes", ({ kind, responses }) => {
+    for (const active of [false, true]) {
+      for (const activity of ["runnerActive", "originTurnActive"] as const) {
+        expect(display({ pendingRequestKind: kind, [activity]: active })).toMatchObject({
+          status: active ? "running" : "waiting",
+          controls: ["pause", "cancel", ...responses],
+        });
+      }
+    }
+    for (const durableStatus of ["completed", "failed", "timed_out", "cancelled"] as const) {
+      expect(
+        display({ pendingRequestKind: kind, durableStatus, originTurnActive: true }).controls,
+      ).toEqual([]);
+    }
+    expect(
+      display({ pendingRequestKind: kind, paused: true, originTurnActive: true }).controls,
+    ).toEqual(["resume", "cancel"]);
   });
 
   it("distinguishes unconfirmed delivery, active work, required results, and pause", () => {
@@ -84,12 +109,12 @@ describe("host workflow display reducer", () => {
 
   it("reports exact activity and allowed controls", () => {
     expect(display({ runnerActive: true })).toMatchObject({
-      status: "waiting",
+      status: "running",
       activity: "supervised_runner",
       controls: ["pause", "cancel", "update", "submit"],
     });
     expect(display({ originTurnActive: true })).toMatchObject({
-      status: "waiting",
+      status: "running",
       activity: "origin_turn",
     });
     expect(display({ paused: true })).toMatchObject({
@@ -751,8 +776,9 @@ describe("host workflow display reducer", () => {
       now: Date.now() - 11_000,
     });
     expect(views.run("run-view")?.display).toMatchObject({
-      status: "waiting",
+      status: "running",
       activity: "origin_turn",
+      controls: ["pause", "cancel", "update", "submit"],
     });
     modelTurnActive = false;
     views.noteOriginActivityChange();
@@ -762,9 +788,9 @@ describe("host workflow display reducer", () => {
     const runningList = views.list();
     expect(runningList.revision).not.toBe(initialList.revision);
     expect(runningList.items).toMatchObject([
-      { display: { status: "waiting", activity: "origin_turn" } },
+      { display: { status: "running", activity: "origin_turn" } },
     ]);
-    expect(views.run("run-view")?.display.status).toBe("waiting");
+    expect(views.run("run-view")?.display.status).toBe("running");
 
     state.connection.prepare("UPDATE runs SET paused = 1 WHERE run_id = ?").run("run-view");
     expect(views.run("run-view")?.display.status).toBe("paused");

--- a/test/server-view.test.ts
+++ b/test/server-view.test.ts
@@ -738,12 +738,13 @@ describe("host workflow display reducer", () => {
       },
     });
     let modelTurnActive = true;
+    let runnerActive = false;
     const views = new ServerViewStore(
       state,
       queue,
       serverState,
       runs,
-      () => false,
+      () => runnerActive,
       () => modelTurnActive,
     );
     const readRun = vi.spyOn(runs, "readRun");
@@ -761,6 +762,23 @@ describe("host workflow display reducer", () => {
         workflowSource: { kind: "builtin", id: "echo", revision: "test" },
       },
     });
+    const waitingRevision = views.list().revision;
+    runnerActive = true;
+    views.noteWorkflowActivityChange();
+    const runnerList = views.list();
+    expect(runnerList.revision).not.toBe(waitingRevision);
+    expect(runnerList.items[0]?.display).toMatchObject({
+      status: "running",
+      activity: "supervised_runner",
+    });
+    expect(views.run("run-view")?.display.status).toBe("running");
+    runnerActive = false;
+    views.noteWorkflowActivityChange();
+    const parkedList = views.list();
+    expect(parkedList.revision).not.toBe(runnerList.revision);
+    expect(parkedList.items[0]?.display).toMatchObject({ status: "waiting", activity: null });
+    expect(views.run("run-view")?.display.status).toBe("waiting");
+
     const message = serverState.workflowMessages.listSession("session-view")[0];
     if (message === undefined) throw new Error("workflow message missing");
     serverState.workflowMessages.adoptBranch(
@@ -781,10 +799,10 @@ describe("host workflow display reducer", () => {
       controls: ["pause", "cancel", "update", "submit"],
     });
     modelTurnActive = false;
-    views.noteOriginActivityChange();
+    views.noteWorkflowActivityChange();
     expect(views.run("run-view")?.display.status).toBe("waiting");
     modelTurnActive = true;
-    views.noteOriginActivityChange();
+    views.noteWorkflowActivityChange();
     const runningList = views.list();
     expect(runningList.revision).not.toBe(initialList.revision);
     expect(runningList.items).toMatchObject([


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (@osolmaz).

## Summary

A workflow still displayed `waiting` while its agent was working.
The earlier handoff fix detected activity but did not restore the visible `running` status.
This completes that missing part without changing durable execution state or hiding submission controls.

## What Changed

One shared display reducer remains the source for the visible status and controls.

- Display `running` while a workflow-owned Pi turn or supervised runner is active. Keep terminal, ambiguous, and paused state precedence.
- Keep `waiting` for pending input or results without active work. Ordinary chat does not count as workflow activity.
- Derive response controls from the exact pending request in both running and waiting displays. Keep agent submissions, checkpoint answers, and protected decisions separate.
- Invalidate cached list/session views on runner start and exit, as well as origin Pi activity changes. A parked run must not keep a cached running label.
- Correct reducer and list/detail expectations; test running-to-waiting activity changes and control preservation. Real-Pi and live-model tests now assert visible running status and valid controls.
- Reopen the incomplete handoff plan and document the distinction between durable state and visible status.

This completes the status work left incomplete in #85 and identified after #86.

## Testing

All local checks pass. The final configured Pi Reviewer run has no findings. The final isolated live-model test passed with `openrouter/deepseek/deepseek-v4-flash` on Pi 0.85.0, including the visible running status, retained submit/update controls, intentional timeout, and recovery.

- `npm run check -- -- --maxWorkers=2`: 1,247 tests; 90.99% statement and 85.59% branch coverage.
- `npm run test:e2e -- --maxWorkers=2`: 14 tests, including the running header, active node indicator, and retained response controls through real Pi.
- `npx slophammer-ts@latest dry .`: zero candidates.
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`: passed.
- `npx -y @simpledoc/simpledoc check`: passed.
- `CARGO_BUILD_JOBS=2 cargo test --manifest-path tui/Cargo.toml`: 76 tests.
- `CARGO_BUILD_JOBS=2 cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`: passed.
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`: passed.

The exact live command was `npm run test:e2e:live -- --provider openrouter --model deepseek/deepseek-v4-flash --max-output-tokens 4096`. Run `20260907T155549292Z-live-model-e2e-8cbdcf21` passed on final head. Temporary files were removed, and no credentials appeared in output. An earlier probe used an incorrect model-selected 10-second tool timeout; the fixture now gives explicit 180-second tool arguments so the workflow's 60-second deadline controls the test. That incomplete probe is not counted as a pass.

All four [CI jobs](https://github.com/osolmaz/pi-workflows/actions/runs/34140233315) passed on final head `aa8c6b35668b1884169632239d93254d7b823585`.

## Risks

The change affects presentation, not durable run state or response authorization. Existing tests continue to require that a submitted agent request remains durably waiting until its result arrives.

No release, installation, live-run mutation, headless recovery change, or detached-process control is included.
