### PR TITLE
fix: stabilize composed built-in workflow sources

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -43,6 +43,12 @@ before execution. A revision mismatch refuses resume. Project and global
 workflow files also use their absolute path and SHA-256 hash as source
 identity.
 
+Package-internal workflows can be registered as non-discoverable built-ins.
+They do not appear in the workflow list or ordinary name lookup, but composed
+built-ins record them with a stable built-in ID and revision. This keeps source
+identity independent of the package installation path. It does not weaken file
+identity checks for project and global workflows.
+
 The workflow's command name is the file stem, so `.pi/workflows/triage.workflow.ts`
 runs as `/workflow triage`. A direct path also works: `/workflow ./somewhere/x.workflow.ts`.
 Files are loaded with [jiti](https://github.com/unjs/jiti), so plain TypeScript

--- a/docs/WORKFLOW_COMPOSITION.md
+++ b/docs/WORKFLOW_COMPOSITION.md
@@ -14,6 +14,13 @@ Change verification receives direct command descriptors and a prepared workspace
 
 These compositions use ordinary `agent`, `action`, `compute`, named exits, and `includeWorkflow()` mounts. They add no engine primitive or independent child run. Their large command outputs remain on action results, while findings carry stable output references.
 
+Workspace preparation, change verification, and plan change are
+non-discoverable built-ins. Parent workflows record their stable built-in IDs
+and revisions instead of package file paths. A resolver and runner can therefore
+load the same package version from different installation roots without a false
+source-change failure. Project and global child workflows still use an absolute
+path and SHA-256 hash.
+
 ## TypeScript API
 
 A TypeScript workflow definition is both executable code and a typed contract. Its input parser and exit parsers provide runtime validation and TypeScript inference from one declaration.

--- a/src/builtins/catalog.ts
+++ b/src/builtins/catalog.ts
@@ -2,21 +2,42 @@ import { BuiltinWorkflowCatalog } from "../workflows/catalog.js";
 import autodocWorkflow from "./autodoc.workflow.js";
 import autoimplementWorkflow from "./autoimplement.workflow.js";
 import autoplanWorkflow from "./autoplan.workflow.js";
+import changeVerificationWorkflow from "./change-verification.workflow.js";
 import monitorWorkflow from "./monitor.workflow.js";
 import plainSummaryWorkflow from "./plain-summary.workflow.js";
 import planApprovalWorkflow from "./plan-approval.workflow.js";
+import planChangeWorkflow from "./plan-change.workflow.js";
 import sanityCheckWorkflow from "./sanity-check.workflow.js";
+import workspacePreparationWorkflow from "./workspace-preparation.workflow.js";
 
 export const builtinWorkflowCatalog = new BuiltinWorkflowCatalog([
   { id: "plain-summary", revision: "3", definition: plainSummaryWorkflow },
   { id: "autoplan", revision: "6", definition: autoplanWorkflow },
-  { id: "autodoc", revision: "2", definition: autodocWorkflow },
-  { id: "autoimplement", revision: "11", definition: autoimplementWorkflow },
+  { id: "autodoc", revision: "3", definition: autodocWorkflow },
+  { id: "autoimplement", revision: "12", definition: autoimplementWorkflow },
   { id: "plan-approval", revision: "4", definition: planApprovalWorkflow },
   { id: "sanity-check", revision: "6", definition: sanityCheckWorkflow },
   {
+    id: "change-verification",
+    revision: "1",
+    definition: changeVerificationWorkflow,
+    discoverable: false,
+  },
+  {
+    id: "plan-change",
+    revision: "1",
+    definition: planChangeWorkflow,
+    discoverable: false,
+  },
+  {
+    id: "workspace-preparation",
+    revision: "1",
+    definition: workspacePreparationWorkflow,
+    discoverable: false,
+  },
+  {
     id: "monitor",
-    revision: "11",
+    revision: "12",
     definition: monitorWorkflow,
     legacySources: [
       {

--- a/src/builtins/metadata.ts
+++ b/src/builtins/metadata.ts
@@ -1,9 +1,9 @@
 export const BUILTIN_WORKFLOW_METADATA = [
   { id: "plain-summary", revision: "3" },
   { id: "autoplan", revision: "6" },
-  { id: "autodoc", revision: "2" },
-  { id: "autoimplement", revision: "11" },
+  { id: "autodoc", revision: "3" },
+  { id: "autoimplement", revision: "12" },
   { id: "plan-approval", revision: "4" },
   { id: "sanity-check", revision: "6" },
-  { id: "monitor", revision: "11" },
+  { id: "monitor", revision: "12" },
 ] as const;

--- a/src/workflows/catalog.ts
+++ b/src/workflows/catalog.ts
@@ -15,6 +15,7 @@ export type BuiltinWorkflowRegistration = {
   id: string;
   revision: string;
   definition: WorkflowDefinition;
+  discoverable?: boolean;
   legacySources?: LegacyBuiltinSource[];
 };
 
@@ -23,6 +24,7 @@ export type BuiltinWorkflowEntry = Readonly<{
   ref: string;
   revision: string;
   definition: WorkflowDefinition;
+  discoverable: boolean;
   legacySources: readonly LegacyBuiltinSource[];
 }>;
 
@@ -60,6 +62,7 @@ export class BuiltinWorkflowCatalog {
         ref: `builtin:${registration.id}`,
         revision: registration.revision,
         definition: registration.definition,
+        discoverable: registration.discoverable ?? true,
         legacySources: Object.freeze(
           (registration.legacySources ?? []).map((legacy) =>
             Object.freeze({ ...legacy, pathSuffixes: Object.freeze([...legacy.pathSuffixes]) }),
@@ -73,6 +76,10 @@ export class BuiltinWorkflowCatalog {
 
   list(): BuiltinWorkflowEntry[] {
     return [...this.byId.values()];
+  }
+
+  listDiscoverable(): BuiltinWorkflowEntry[] {
+    return this.list().filter((entry) => entry.discoverable);
   }
 
   get(id: string): BuiltinWorkflowEntry | undefined {

--- a/src/workflows/loader.ts
+++ b/src/workflows/loader.ts
@@ -113,7 +113,7 @@ export async function discoverWorkflows(
       discovered.push({ name, ref: filePath, source });
     }
   }
-  for (const builtin of catalog?.list() ?? []) {
+  for (const builtin of catalog?.listDiscoverable() ?? []) {
     if (seenNames.has(builtin.definition.name)) continue;
     seenNames.add(builtin.definition.name);
     discovered.push({ name: builtin.definition.name, ref: builtin.ref, source: "builtin" });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -17,9 +17,9 @@ describe("BuiltinWorkflowCatalog", () => {
   it("ships stable built-in revisions", () => {
     expect(builtinWorkflowCatalog.get("plain-summary")?.revision).toBe("3");
     expect(builtinWorkflowCatalog.get("autoplan")?.revision).toBe("6");
-    expect(builtinWorkflowCatalog.get("autodoc")?.revision).toBe("2");
-    expect(builtinWorkflowCatalog.get("autoimplement")?.revision).toBe("11");
-    expect(builtinWorkflowCatalog.get("monitor")?.revision).toBe("11");
+    expect(builtinWorkflowCatalog.get("autodoc")?.revision).toBe("3");
+    expect(builtinWorkflowCatalog.get("autoimplement")?.revision).toBe("12");
+    expect(builtinWorkflowCatalog.get("monitor")?.revision).toBe("12");
     expect(builtinWorkflowCatalog.get("plan-approval")?.revision).toBe("4");
     expect(builtinWorkflowCatalog.get("sanity-check")?.revision).toBe("6");
   });
@@ -39,6 +39,23 @@ describe("BuiltinWorkflowCatalog", () => {
 
     expect(catalog.resolve({ kind: "builtin", id: "fixture", revision: "r1" })).toBe(definition);
     expect(catalog.get("fixture")?.ref).toBe("builtin:fixture");
+  });
+
+  it("resolves hidden built-ins without listing them for discovery", () => {
+    const visible = fixture("visible");
+    const hidden = fixture("hidden");
+    const catalog = new BuiltinWorkflowCatalog([
+      { id: "visible", revision: "r1", definition: visible },
+      { id: "hidden", revision: "r1", definition: hidden, discoverable: false },
+    ]);
+
+    expect(catalog.list().map((entry) => entry.id)).toEqual(["visible", "hidden"]);
+    expect(catalog.listDiscoverable().map((entry) => entry.id)).toEqual(["visible"]);
+    expect(catalog.sourceForDefinition(hidden)).toEqual({
+      kind: "builtin",
+      id: "hidden",
+      revision: "r1",
+    });
   });
 
   it("rejects changed revisions with restart guidance and duplicate identities", () => {

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -142,8 +142,25 @@ describe("resolveWorkflowRef", () => {
     const resolved = await resolveWorkflowRef("monitor", { cwd, homeDir }, builtinWorkflowCatalog);
 
     expect(resolved.sourceKind).toBe("builtin");
-    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "11" });
+    expect(resolved.source).toEqual({ kind: "builtin", id: "monitor", revision: "12" });
     expect(resolved.definition.name).toBe("monitor");
+    expect(resolved.sources.every((item) => item.source.kind === "builtin")).toBe(true);
+    expect(resolved.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workflowName: "workspace-preparation",
+          source: { kind: "builtin", id: "workspace-preparation", revision: "1" },
+        }),
+        expect.objectContaining({
+          workflowName: "change-verification",
+          source: { kind: "builtin", id: "change-verification", revision: "1" },
+        }),
+        expect.objectContaining({
+          workflowName: "plan-change",
+          source: { kind: "builtin", id: "plan-change", revision: "1" },
+        }),
+      ]),
+    );
     expect(resolved.sources.map((item) => item.mountPath.join("/"))).toEqual([
       "implementation",
       "implementation/documentation",


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

Autoimplement could fail even when its source had not changed.
Its internal workflows were identified by installation paths, and the server and runner could load the same package from different paths.
This change gives those internal workflows stable built-in identities while keeping them out of user workflow discovery.

## What Changed

The source check now distinguishes package-owned internal workflows from project and global workflow files.
This removes false source-change failures without weakening checks for user files.

- Registered `workspace-preparation`, `change-verification`, and `plan-change` as non-discoverable built-ins.
- Added stable IDs and explicit revisions for those internal workflows.
- Kept hidden workflows out of normal discovery results.
- Updated parent built-in revisions because their recorded composed source sets changed.
- Documented the source identity rule for internal compositions.

## Testing

The focused regression tests and all required repository checks passed.
The installed-package check also passed with the exact low-cost model.

- `npx vitest run test/catalog.test.ts test/loader.test.ts`
- `npm run check`
- `npm run test:e2e`
- `npx slophammer-ts@latest dry .`
- `npx slophammer-ts@latest check . --only ts.dependency-boundaries-required`
- `cargo fmt --manifest-path tui/Cargo.toml -- --check`
- `cargo clippy --manifest-path tui/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path tui/Cargo.toml`
- `npm run test:e2e:live -- --provider openai --model gpt-5.6-luna --max-output-tokens 4096`
- `git diff main...HEAD --check`

The real-model run used `openai/gpt-5.6-luna` through `openai-responses` and cost $0.002926.

## Risks

The change keeps strict source checks in place.
Existing runs created with the old internal file identities cannot resume after the built-in revision change and must be restarted, which matches the repository's alpha compatibility policy.
